### PR TITLE
make sqlfluff work for db with no password

### DIFF
--- a/profiles.yml
+++ b/profiles.yml
@@ -7,7 +7,7 @@ dbt_pilotage:
       type: postgres
       dbname: "{{ env_var('PGDATABASE') }}"
       host: "{{ env_var('PGHOST') }}"
-      password: "{{ env_var('PGPASSWORD') }}"
+      password: "{{ env_var('PGPASSWORD', '') }}"
       port: "{{ env_var('PGPORT') | int }}"
       user: "{{ env_var('PGUSER') }}"
 


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Résoudre un bug de sqlfluff qui attend un mdp pour tourner avec DBT. Laurine n'ayant pas de mdp sur sa db locale -> modification mineure sur profiles.yml.

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

