### PR TITLE
Suivi des prescriptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
+      CI: 1
       PYTHONPATH: .
       PGPASSWORD: password
       PGHOST: localhost

--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,12 @@ clean: dbt_clean
 	find . -type d -empty -delete
 
 # if `sqlfluff fix` does not work, use `sqlfluff parse` to investigate.
-fix: clean
+fix:
 	black $(MONITORED_DIRS)
 	isort $(MONITORED_DIRS)
 	sqlfluff fix --force $(SQLFLUFF_OPTIONS) $(MONITORED_DIRS)
 
-quality: clean
+quality:
 	black --check $(MONITORED_DIRS)
 	isort --check $(MONITORED_DIRS)
 	flake8 --count --show-source --statistics $(MONITORED_DIRS)

--- a/dbt/models/marts/properties.yml
+++ b/dbt/models/marts/properties.yml
@@ -1,0 +1,14 @@
+version: 2
+
+models:
+  - name: suivi_candidatures_prescripteurs_habilites
+    description: >
+      Table introduite pour réaliser le tableau de bord prescripteurs.
+      Elle a comme base la table [candidatures_echelle_locale](#!/source/source.dbt_pilotage.emplois.candidatures_echelle_locale) et ajoute une colonne `libelle_complet`
+      à partir de la seed [organisation_libelles](#!/seeds/organisation_libelles) pour pouvoir afficher le libelle sur metabase tel
+      qu'affiché sur les emplois.
+  - name: suivi_prescripteurs_habilites
+    description: >
+      Table introduite pour réaliser le tableau de bord prescripteurs.
+      Elle a comme base la table [organisations](#!/source/source.dbt_pilotage.emplois.organisations) + d'autres informations :
+        - le nombre de siae partenaires de ces organisations

--- a/dbt/models/marts/suivi_candidatures_prescripteurs_habilites.sql
+++ b/dbt/models/marts/suivi_candidatures_prescripteurs_habilites.sql
@@ -1,6 +1,17 @@
 with candidatures_ph as (
     select
-        {{ dbt_utils.star(ref('candidatures_echelle_locale')) }},
+        /* FIXME(vperron): Normally, sqlfluff rendering star() should render a `*`.
+        But for some reason it does not, yet, or not anymore.
+        https://github.com/dbt-labs/dbt-utils/pull/732
+        In the meantime, and since we don't want to fully maintain an intialized DB in CI,
+        we have to workaround it. I would have like to monkeypatch it in CI (some override of
+        the macro somewhere) but could not find a way to do it. Essentialy, we would want the
+        following code being applied automatically. */
+        {% if env_var('CI', ',') %}
+            *,
+        {% else %}
+            {{ dbt_utils.star(ref('candidatures_echelle_locale')) }},
+        {% endif %}
         replace("origine_détaillée", 'Prescripteur habilité ', '') as origine_simplifiee
     from {{ ref('candidatures_echelle_locale') }}
     where starts_with("origine_détaillée", 'Prescripteur habilité')

--- a/dbt/models/marts/suivi_candidatures_prescripteurs_habilites.sql
+++ b/dbt/models/marts/suivi_candidatures_prescripteurs_habilites.sql
@@ -1,0 +1,13 @@
+with candidatures_ph as (
+    select
+        {{ dbt_utils.star(ref('candidatures_echelle_locale')) }},
+        replace("origine_détaillée", 'Prescripteur habilité ', '') as origine_simplifiee
+    from {{ ref('candidatures_echelle_locale') }}
+    where starts_with("origine_détaillée", 'Prescripteur habilité')
+)
+select
+    candidatures_ph.*,
+    org_libelles.libelle as libelle_complet
+from candidatures_ph
+left join {{ ref('organisation_libelles') }} as org_libelles
+    on org_libelles.type = candidatures_ph.origine_simplifiee

--- a/dbt/models/marts/suivi_prescripteurs_habilites.sql
+++ b/dbt/models/marts/suivi_prescripteurs_habilites.sql
@@ -1,0 +1,24 @@
+with nb_siae_partenaires as (
+    select
+        organisations.id,
+        count(distinct cel.id_structure) as nb_siae
+    from
+        {{ source('emplois', 'organisations') }} as organisations
+    left join {{ ref('candidatures_echelle_locale') }} as cel
+        on organisations.id = cel.id_org_prescripteur
+    group by organisations.id
+)
+select
+    organisations.*,
+    -- appartenance geographique de l'organisation
+    appartenance_geo_communes.libelle_commune,
+    appartenance_geo_communes.code_insee,
+    appartenance_geo_communes.nom_zone_emploi,
+    -- nombre de siae partenaires de l'organisation =
+    -- nombre de siae qui ont reçu une candidature de ce prescripteur
+    nb_siae_partenaires.nb_siae
+from {{ source('emplois', 'organisations') }} as organisations
+left join {{ ref('stg_insee_appartenance_geo_communes') }} as appartenance_geo_communes
+    on ltrim(organisations.code_commune, '0') = appartenance_geo_communes.code_insee
+left join nb_siae_partenaires on organisations.id = nb_siae_partenaires.id
+where organisations.nom != 'Regroupement des prescripteurs sans organisation'

--- a/dbt/seeds/prescripteurs_habilites/organisation_libelles.csv
+++ b/dbt/seeds/prescripteurs_habilites/organisation_libelles.csv
@@ -1,0 +1,33 @@
+type,libelle
+AFPA,AFPA - Agence nationale pour la formation professionnelle des adultes
+ASE,ASE - Aide sociale à l'enfance
+Autre,Autre
+CAARUD,CAARUD - Centre d'accueil et d'accompagnement à la réduction de risques pour usagers de drogues
+CADA,CADA - Centre d'accueil de demandeurs d'asile
+CAF,CAF - Caisse d'allocations familiales
+CAP_EMPLOI,CAP_EMPLOI - Cap emploi
+CAVA,CAVA - Centre d'adaptation à la vie active
+CCAS,CCAS - Centre communal d'action sociale ou centre intercommunal d'action sociale
+CHRS,CHRS - Centre d'hébergement et de réinsertion sociale
+CHU,CHU - Centre d'hébergement d'urgence
+CIDFF,CIDFF - Centre d'information sur les droits des femmes et des familles
+CPH,CPH - Centre provisoire d'hébergement
+CSAPA,"CSAPA - Centre de soins, d'accompagnement et de prévention en addictologie"
+DEPT,DEPT - Service social du conseil départemental
+E2C,E2C - École de la deuxième chance
+EPIDE,EPIDE - Établissement pour l'insertion dans l'emploi
+HUDA,HUDA - Hébergement d'urgence pour demandeurs d'asile
+ML,ML - Mission locale
+MSA,MSA - Mutualité Sociale Agricole
+OACAS,OACAS - Structure porteuse d'un agrément national organisme d'accueil communautaire et d'activité solidaire
+ODC,ODC - Organisation délégataire d'un CD
+OIL,OIL - Opérateur d'intermédiation locative
+PE,PE - Pôle emploi
+PENSION,PENSION - Pension de famille / résidence accueil
+PIJ_BIJ,PIJ-BIJ - Point/Bureau information jeunesse
+PJJ,PJJ - Protection judiciaire de la jeunesse
+PLIE,PLIE - Plan local pour l'insertion et l'emploi
+PREVENTION,PREVENTION - Service ou club de prévention
+RS_FJT,RS - Résidence sociale / FJT - Foyer de Jeunes Travailleurs
+SANS-ORGANISATION,Regroupement des prescripteurs non rattaché à une organisation
+SPIP,SPIP - Service pénitentiaire d'insertion et de probation

--- a/dbt/seeds/properties.yml
+++ b/dbt/seeds/properties.yml
@@ -50,3 +50,13 @@ seeds:
     description: >
       dispositifs de l'IAE, identifiants et libellés
       (source (à vérifier avec Yannick): ?asp?)
+  - name: organisation_libelles
+    # (laurine) je suis pas sûre d'être très claire sur la description que je fais ci dessous,
+    # à clarifier après discussion bonne practoche car j'ai qqs questions, mais je tente un truc
+    description: >
+      correspondance entre codes organisation des emplois et labels affichés dans les tb pilotage
+      source de la correspondance : [emplois : organizations model](https://github.com/betagouv/itou/blob/2edc1adb394174d08752887c0c2512c37b16e19b/itou/prescribers/enums.py#L4-L44)
+      à ce stade la correspondance semble redondante mais
+      cette seed pourra être enrichie en fonction du label que l'on souhaite afficher sur metabase
+      notamment le label actuel de la colonne libelle est trop long et pourra être simplifié pour le rendu sur metabase.
+


### PR DESCRIPTION
**Carte Notion : ** 
https://www.notion.so/plateforme-inclusion/Suivi-et-analyse-des-prescriptions-r-aliser-les-indicateurs-67ea163528de45ed98bbf9fad4bf08dd?pvs=4
+ https://www.notion.so/plateforme-inclusion/V-rifier-les-labels-prescripteurs-et-tablir-une-liste-efedd3d00a984a1c83c81cb79a6ae01d?pvs=4

### Pourquoi ?

Création d'un modèle contenant les candidatures des prescrpiteurs habilités uniquement. 
Dans le but d'économiser de nombreux filtres sur metabase en pouvant travailler directement sur cette table.
J'en profite pour créer une seed qui permet d'unifier les noms de prescripteurs entre la table candidatures et la table organisations.
Je n'ai pas créé de doc à ce stade car j'aimerais d'abord valider la PR qui traite de la doc afin d'éviter du bazaaar.
J'ai un premier cas d'usage de test pour cette table, j'aimerais bien en parler avec toi @vperron voir si tu trouves pertinent + savoir comment l'intégrer si ça l'est.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

