### PR TITLE
[Metabase] : Ajout du noms des structures pour le TB cap SIAE

### DIFF
--- a/dbt/models/legacy/suivi_cap_criteres.sql
+++ b/dbt/models/legacy/suivi_cap_criteres.sql
@@ -4,6 +4,8 @@ select
     criteres."niveau"         as "niveau_critère",
     -- REFUSED et REFUSED_2 correspondent au même état (?) - à confirmer par Zo
     camp."nom"                as "nom_campagne",
+    structs."nom"             as "nom_structure",
+    structs."nom_complet"     as "nom_structure_complet",
     structs."département"     as "département",
     structs."nom_département" as "nom_département",
     structs."région"          as "nom_région",


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Ajout du noms des structures suite aux demandes des SIAE dans le cadre du suivi de l'auto prescription. 



