### PR TITLE
Materialize marts as table

### DIFF
--- a/dbt/models/legacy/candidatures_prescripteurs_habilites.sql
+++ b/dbt/models/legacy/candidatures_prescripteurs_habilites.sql
@@ -1,0 +1,13 @@
+with candidatures_ph as (
+    select
+        *,
+        replace(cel.origine_détaillée, 'Prescripteur habilité ', '') as origine_simplifiee
+    from {{ ref('candidatures_echelle_locale') }} as cel
+    where starts_with(cel.origine_détaillée, 'Prescripteur habilité')
+)
+select
+    candidatures_ph.*,
+    org_libelles.libelle as libelle_complet
+from candidatures_ph
+left join {{ ref('organisation_libelles')}} as org_libelles
+on org_libelles.type = candidatures_ph.origine_simplifiee

--- a/dbt/models/staging/stg_suivi_prescripteurs.sql
+++ b/dbt/models/staging/stg_suivi_prescripteurs.sql
@@ -1,0 +1,24 @@
+with nb_siae_partenaires as ( 
+    select 
+        organisations.id, 
+        count(distinct cel.id_structure) as nb_siae
+    from 
+        {{ source('emplois', 'organisations') }} as organisations
+    left join candidatures_echelle_locale as cel 
+    on organisations.id = cel.id_org_prescripteur
+    group by organisations.id
+)
+select 
+    organisations.*,
+    -- appartenance geographique de l'organisation
+    appartenance_geo_communes.libelle_commune,
+    appartenance_geo_communes.code_insee,
+    appartenance_geo_communes.nom_zone_emploi,
+    -- nombre de siae partenaires de l'organisation = 
+    -- nombre de siae qui ont reçu une candidature de ce prescripteur
+    nb_siae_partenaires.nb_siae
+from {{ source('emplois', 'organisations') }} as organisations
+left join {{ ref('stg_insee_appartenance_geo_communes') }} as appartenance_geo_communes
+on ltrim(organisations.code_commune, '0') = appartenance_geo_communes.code_insee
+left join nb_siae_partenaires on organisations.id = nb_siae_partenaires.id
+where organisations.nom != 'Regroupement des prescripteurs sans organisation'

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -30,6 +30,8 @@ models:
       +materialized: table
     staging:
       +materialized: view
+    marts:
+      +materialized: table
 
 seeds:
   dbt_pilotage:


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Vermeer a identifié que la màj c1->metabase casse car la table suivi_prescripteurs est matérialisée en vue.
C'est car le dossier `marts` n'est pas spécifié dans le dbt_project.yml et donc est matérialisé en vue par défaut, alors qu'on veut le matérialiser en table. 

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

