### PR TITLE
materialize marts as table

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -30,7 +30,8 @@ models:
       +materialized: table
     staging:
       +materialized: view
-
+    marts:
+      +materialized: table
 seeds:
   dbt_pilotage:
     sa_ept:


### PR DESCRIPTION
**Carte Notion : **


Pourquoi ?

Vermeer a identifié que la màj c1->metabase casse car la table suivi_prescripteurs est matérialisée en vue.
C'est car le dossier marts n'est pas spécifié dans le dbt_project.yml et donc est matérialisé en vue par défaut, alors qu'on veut le matérialiser en table.

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

