### PR TITLE
Ajout de tables spécifiques aux prescripteurs de la dihal

### DIFF
--- a/dbt/models/legacy/candidatures_echelle_locale.sql
+++ b/dbt/models/legacy/candidatures_echelle_locale.sql
@@ -36,7 +36,8 @@ org_prescripteur as ( /* On récupère l'id et le dept des organismes prescripte
         org.id                as id_org,
         org.siret             as siret_org_prescripteur,
         org."nom_département" as dept_org,  /*bien mettre nom département et pas département */
-        org."région"          as "région_org"
+        org."région"          as "région_org",
+        org."type"            as type_org_prescripteur
     from
         {{ source('emplois', 'organisations') }} as org
 ),
@@ -140,6 +141,7 @@ select
     "nom_prénom_conseiller",
     org_prescripteur.dept_org,
     org_prescripteur."région_org",
+    org_prescripteur.type_org_prescripteur,
     candidatures_p.injection_ai,
     bassin_emploi.ville,
     bassin_emploi.nom_epci,

--- a/dbt/models/marts/candidatures_dihal.sql
+++ b/dbt/models/marts/candidatures_dihal.sql
@@ -1,0 +1,3 @@
+select *
+from candidatures_echelle_locale
+where candidatures_echelle_locale.type_org_prescripteur in ('CHRS', 'CHU', 'RS_FJT', 'OIL')

--- a/dbt/models/marts/organisations_dihal.sql
+++ b/dbt/models/marts/organisations_dihal.sql
@@ -1,0 +1,3 @@
+select *
+from organisations
+where organisations.type in ('CHRS', 'CHU', 'RS_FJT', 'OIL')


### PR DESCRIPTION
**Fil slack : ** https://itou-inclusion.slack.com/archives/C053YHWGK41/p1683716714700559

### Pourquoi ?

Pour restreindre sur metabase les filtres prescripteurs sur le tb dihal

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

