### PR TITLE
DAG generate_docs : Ajout de `dbt deps` pour résoudre un crash

### DIFF
--- a/dags/generate_docs.py
+++ b/dags/generate_docs.py
@@ -15,6 +15,13 @@ with airflow.DAG(
 
     env_vars = db.connection_envvars()
 
+    dbt_deps = bash.BashOperator(
+        task_id="dbt_deps",
+        bash_command="dbt deps",
+        env=env_vars,
+        append_env=True,
+    )
+
     dbt_generate_docs = bash.BashOperator(
         task_id="dbt_generate_docs",
         bash_command="rm -rf /tmp/dbt-docs && DBT_TARGET_PATH=/tmp/dbt-docs dbt docs generate",


### PR DESCRIPTION
**Fil slack : https://itou-inclusion.slack.com/archives/C04SAGUGJFJ/p1684139602326119**

### Pourquoi ?

Le DAG a crashé trois fois sur cette erreur :

```
[2023-05-15, 00:00:08 UTC] {subprocess.py:93} INFO - Compilation Error
[2023-05-15, 00:00:08 UTC] {subprocess.py:93} INFO -   dbt found 1 package(s) specified in packages.yml, but only 0 package(s) installed in dbt/packages. Run "dbt deps" to install package dependencies.
[2023-05-15, 00:00:08 UTC] {subprocess.py:97} INFO - Command exited with return code 2
```

### Test en local

Malheureusement pas possible de tester le DAG en local (segfault python sur DAG Airflow). Mais avec un peu de chance ça passera du premier coup.

