### PR TITLE
Renommer la valeur `Candidatures déclinées` en `Candidatures refusées` + refacto

### DIFF
--- a/dbt/models/legacy/candidatures_echelle_locale.sql
+++ b/dbt/models/legacy/candidatures_echelle_locale.sql
@@ -94,7 +94,11 @@ select
     bassin_emploi.code_commune,
     bassin_emploi.nom_arrondissement,
     bassin_emploi.bassin_d_emploi,
-    {{ dbt_utils.star(ref('stg_candidatures'), except=["origine_détaillée", "cdd_id_org_prescripteur", "cdd_id_structure"]) }},
+    {% if env_var('CI', ',') %}
+        candidatures.*,
+    {% else %}
+        {{ dbt_utils.star(ref('stg_candidatures'), except=["origine_détaillée", "cdd_id_org_prescripteur", "cdd_id_structure"]) }},
+    {% endif %}
     -- laurine : needed to rename to solve dbt issue, needs to rename again to be sure to not broke metabase tables
     -- next step : discuss good practice and rename columns that have same name in different tables to avoid dbt grumbling
     candidatures.cdd_id_org_prescripteur as id_org_prescripteur,

--- a/dbt/models/legacy/candidatures_echelle_locale.sql
+++ b/dbt/models/legacy/candidatures_echelle_locale.sql
@@ -1,37 +1,7 @@
 /*
 L'objectif est de créer une table qui contient des informations à l'échelle locale (bassin d'emploi, epci, etc)
 */
-
-with candidatures_p as (
-    select
-        id,
-        "id_anonymisé",
-        id_candidat,
-        "id_candidat_anonymisé",
-        date_candidature,
-        date_embauche,
-        "délai_de_réponse",
-        "délai_prise_en_compte",
-        "département_structure",
-        safir_org_prescripteur,
-        id_structure,
-        id_org_prescripteur,
-        motif_de_refus,
-        "nom_département_structure",
-        "région_structure",
-        nom_structure,
-        type_structure,
-        "origine_détaillée",
-        nom_org_prescripteur,
-        "nom_prénom_conseiller",
-        origine,
-        injection_ai,
-        "état"
-    from
-        {{ source('emplois', 'candidatures') }}
-),
-
-org_prescripteur as ( /* On récupère l'id et le dept des organismes prescripteurs afin de filtrer selon le département de l'agence PE associée */
+with org_prescripteur as ( /* On récupère l'id et le dept des organismes prescripteurs afin de filtrer selon le département de l'agence PE associée */
     select
         org.id                as id_org,
         org.siret             as siret_org_prescripteur,
@@ -115,30 +85,6 @@ adherents_cocagne as (
 )
 
 select
-    candidatures_p.date_candidature,
-    candidatures_p.date_embauche,
-    candidatures_p."délai_de_réponse",
-    candidatures_p."délai_prise_en_compte",
-    candidatures_p."département_structure",
-    candidatures_p."état",
-    candidatures_p.id,
-    candidatures_p."id_anonymisé",
-    candidatures_p.id_candidat,
-    /* TODO dejafait drop as soon as analistos have migrated to the new deanonymized column */
-    candidatures_p."id_candidat_anonymisé",
-    candidatures_p.id_structure,
-    /* TODO dejafait drop as soon as analistos have migrated to the new deanonymized column */
-    candidatures_p.motif_de_refus,
-    candidatures_p."nom_département_structure",
-    candidatures_p.nom_structure,
-    candidatures_p.type_structure,
-    candidatures_p."origine_détaillée",
-    candidatures_p."région_structure",
-    candidatures_p.safir_org_prescripteur,
-    candidatures_p.id_org_prescripteur,
-    candidatures_p.nom_org_prescripteur,
-    candidatures_p."nom_prénom_conseiller",
-    candidatures_p.injection_ai,
     org_prescripteur.siret_org_prescripteur,
     org_prescripteur.dept_org,
     org_prescripteur."région_org",
@@ -148,78 +94,77 @@ select
     bassin_emploi.code_commune,
     bassin_emploi.nom_arrondissement,
     bassin_emploi.bassin_d_emploi,
-    extract(day from candidatures_p."délai_de_réponse")      as temps_de_reponse,
-    extract(day from candidatures_p."délai_prise_en_compte") as temps_de_prise_en_compte,
-    case
-        when candidatures_p.origine = 'Candidat' then 'Candidature en ligne'
-        else candidatures_p.origine
-    end                                                      as origine,
+    {{ dbt_utils.star(ref('stg_candidatures'), except=["origine_détaillée", "cdd_id_org_prescripteur", "cdd_id_structure"]) }},
+    -- laurine : needed to rename to solve dbt issue, needs to rename again to be sure to not broke metabase tables
+    -- next step : discuss good practice and rename columns that have same name in different tables to avoid dbt grumbling
+    candidatures.cdd_id_org_prescripteur as id_org_prescripteur,
+    candidatures.cdd_id_structure        as id_structure,
     case /* Ajout colonne avec des noms de prescripteurs correspondant à ceux de la table taux_transformation_prescripteurs */
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité AFPA' then 'AFPA - Agence nationale pour la formation professionnelle des adultes'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité ASE' then 'ASE - Aide sociale à l''enfance'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité Autre' then 'Autre'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité CAARUD' then 'CAARUD - Centre d''accueil et d''accompagnement à la réduction de risques pour usagers de drogues'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité CADA' then 'CADA - Centre d''accueil de demandeurs d''asile'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité CAF' then 'CAF - Caisse d''allocations familiales'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité CAP_EMPLOI' then 'CAP emploi'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité CAVA' then 'ACAVA - Centre d''adaptation à la vie active'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité CCAS' then 'CCAS - Centre communal d''action sociale ou centre intercommunal d''action sociale'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité CHRS' then 'CHRS - Centre d''hébergement et de réinsertion sociale'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité CHU' then 'CHU - Centre d''hébergement d''urgence'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité CIDFF' then 'CIDFF - Centre d''information sur les droits des femmes et des familles'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité CPH' then 'CPH - Centre provisoire d''hébergement'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité CSAPA' then 'CSAPA - Centre de soins, d''accompagnement et de prévention en addictologie'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité DEPT' then 'Service social du conseil départemental'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité E2C' then 'E2C - École de la deuxième chance'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité EPIDE' then 'EPIDE - Établissement pour l''insertion dans l''emploi'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité HUDA' then 'HUDA - Hébergement d''urgence pour demandeurs d''asile'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité ML' then 'Mission Locale'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité MSA' then 'MSA - Mutualité Sociale Agricole'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité OACAS' then 'OACAS - Structure porteuse d''un agrément national organisme d''accueil communautaire et d''activité solidaire'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité ODC' then 'Organisation délégataire d''un CD'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité OIL' then 'Opérateur d''intermédiation locative'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité PE' then 'Pôle emploi'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité PENSION' then 'Pension de famille / résidence accueil'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité PIJ_BIJ' then 'PIJ-BIJ - Point/Bureau information jeunesse'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité PJJ' then 'PJJ - Protection judiciaire de la jeunesse'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité PLIE' then 'PLIE - Plan local pour l''insertion et l''emploi'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité PREVENTION' then 'Service ou club de prévention'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité RS_FJT' then 'Résidence sociale / FJT - Foyer de Jeunes Travailleurs'
-        when candidatures_p."origine_détaillée" = 'Prescripteur habilité SPIP' then 'SPIP - Service pénitentiaire d''insertion et de probation'
-    end                                                      as type_auteur_diagnostic_detaille,
+        when candidatures."origine_détaillée" = 'Prescripteur habilité AFPA' then 'AFPA - Agence nationale pour la formation professionnelle des adultes'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité ASE' then 'ASE - Aide sociale à l''enfance'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité Autre' then 'Autre'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité CAARUD' then 'CAARUD - Centre d''accueil et d''accompagnement à la réduction de risques pour usagers de drogues'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité CADA' then 'CADA - Centre d''accueil de demandeurs d''asile'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité CAF' then 'CAF - Caisse d''allocations familiales'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité CAP_EMPLOI' then 'CAP emploi'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité CAVA' then 'ACAVA - Centre d''adaptation à la vie active'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité CCAS' then 'CCAS - Centre communal d''action sociale ou centre intercommunal d''action sociale'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité CHRS' then 'CHRS - Centre d''hébergement et de réinsertion sociale'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité CHU' then 'CHU - Centre d''hébergement d''urgence'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité CIDFF' then 'CIDFF - Centre d''information sur les droits des femmes et des familles'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité CPH' then 'CPH - Centre provisoire d''hébergement'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité CSAPA' then 'CSAPA - Centre de soins, d''accompagnement et de prévention en addictologie'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité DEPT' then 'Service social du conseil départemental'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité E2C' then 'E2C - École de la deuxième chance'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité EPIDE' then 'EPIDE - Établissement pour l''insertion dans l''emploi'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité HUDA' then 'HUDA - Hébergement d''urgence pour demandeurs d''asile'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité ML' then 'Mission Locale'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité MSA' then 'MSA - Mutualité Sociale Agricole'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité OACAS' then 'OACAS - Structure porteuse d''un agrément national organisme d''accueil communautaire et d''activité solidaire'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité ODC' then 'Organisation délégataire d''un CD'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité OIL' then 'Opérateur d''intermédiation locative'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité PE' then 'Pôle emploi'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité PENSION' then 'Pension de famille / résidence accueil'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité PIJ_BIJ' then 'PIJ-BIJ - Point/Bureau information jeunesse'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité PJJ' then 'PJJ - Protection judiciaire de la jeunesse'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité PLIE' then 'PLIE - Plan local pour l''insertion et l''emploi'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité PREVENTION' then 'Service ou club de prévention'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité RS_FJT' then 'Résidence sociale / FJT - Foyer de Jeunes Travailleurs'
+        when candidatures."origine_détaillée" = 'Prescripteur habilité SPIP' then 'SPIP - Service pénitentiaire d''insertion et de probation'
+    end                                  as type_auteur_diagnostic_detaille,
     case
         when adherents_emmaus.reseau_emmaus = 'Emmaus' then 'Oui'
         else 'Non'
-    end                                                      as reseau_emmaus,
+    end                                  as reseau_emmaus,
     case
         when adherents_coorace.reseau_coorace = 'Coorace' then 'Oui'
         else 'Non'
-    end                                                      as reseau_coorace,
+    end                                  as reseau_coorace,
     case
         when adherents_fei.reseau_fei = 'FEI' then 'Oui'
         else 'Non'
-    end                                                      as reseau_fei,
+    end                                  as reseau_fei,
     case
         when adherents_unai.reseau_unai = 'Unai' then 'Oui'
         else 'Non'
-    end                                                      as reseau_unai,
+    end                                  as reseau_unai,
     case
         when adherents_cocagne.reseau_cocagne = 'Cocagne' then 'Oui'
         else 'Non'
-    end                                                      as reseau_cocagne
+    end                                  as reseau_cocagne
 from
-    candidatures_p
+    {{ ref('stg_candidatures') }} as candidatures
 left join bassin_emploi
-    on bassin_emploi.id_structure = candidatures_p.id_structure
+    on bassin_emploi.id_structure = candidatures.cdd_id_structure
 left join adherents_emmaus
-    on adherents_emmaus.id_structure = candidatures_p.id_structure
+    on adherents_emmaus.id_structure = candidatures.cdd_id_structure
 left join adherents_coorace
-    on adherents_coorace.id_structure = candidatures_p.id_structure
+    on adherents_coorace.id_structure = candidatures.cdd_id_structure
 left join adherents_fei
-    on adherents_fei.id_structure = candidatures_p.id_structure
+    on adherents_fei.id_structure = candidatures.cdd_id_structure
 left join adherents_unai
-    on adherents_unai.id_structure = candidatures_p.id_structure
+    on adherents_unai.id_structure = candidatures.cdd_id_structure
 left join adherents_cocagne
-    on adherents_cocagne.id_structure = candidatures_p.id_structure
+    on adherents_cocagne.id_structure = candidatures.cdd_id_structure
 left join org_prescripteur
-    on org_prescripteur.id_org = candidatures_p.id_org_prescripteur
+    on org_prescripteur.id_org = candidatures.cdd_id_org_prescripteur

--- a/dbt/models/legacy/candidatures_echelle_locale.sql
+++ b/dbt/models/legacy/candidatures_echelle_locale.sql
@@ -137,23 +137,23 @@ select
     candidatures_p.safir_org_prescripteur,
     candidatures_p.id_org_prescripteur,
     candidatures_p.nom_org_prescripteur,
+    candidatures_p."nom_prénom_conseiller",
+    candidatures_p.injection_ai,
     org_prescripteur.siret_org_prescripteur,
-    "nom_prénom_conseiller",
     org_prescripteur.dept_org,
     org_prescripteur."région_org",
     org_prescripteur.type_org_prescripteur,
-    candidatures_p.injection_ai,
     bassin_emploi.ville,
     bassin_emploi.nom_epci,
     bassin_emploi.code_commune,
     bassin_emploi.nom_arrondissement,
     bassin_emploi.bassin_d_emploi,
-    extract(day from "délai_de_réponse")      as temps_de_reponse,
-    extract(day from "délai_prise_en_compte") as temps_de_prise_en_compte,
+    extract(day from candidatures_p."délai_de_réponse")      as temps_de_reponse,
+    extract(day from candidatures_p."délai_prise_en_compte") as temps_de_prise_en_compte,
     case
         when candidatures_p.origine = 'Candidat' then 'Candidature en ligne'
         else candidatures_p.origine
-    end                                       as origine,
+    end                                                      as origine,
     case /* Ajout colonne avec des noms de prescripteurs correspondant à ceux de la table taux_transformation_prescripteurs */
         when candidatures_p."origine_détaillée" = 'Prescripteur habilité AFPA' then 'AFPA - Agence nationale pour la formation professionnelle des adultes'
         when candidatures_p."origine_détaillée" = 'Prescripteur habilité ASE' then 'ASE - Aide sociale à l''enfance'
@@ -186,27 +186,27 @@ select
         when candidatures_p."origine_détaillée" = 'Prescripteur habilité PREVENTION' then 'Service ou club de prévention'
         when candidatures_p."origine_détaillée" = 'Prescripteur habilité RS_FJT' then 'Résidence sociale / FJT - Foyer de Jeunes Travailleurs'
         when candidatures_p."origine_détaillée" = 'Prescripteur habilité SPIP' then 'SPIP - Service pénitentiaire d''insertion et de probation'
-    end                                       as type_auteur_diagnostic_detaille,
+    end                                                      as type_auteur_diagnostic_detaille,
     case
         when adherents_emmaus.reseau_emmaus = 'Emmaus' then 'Oui'
         else 'Non'
-    end                                       as reseau_emmaus,
+    end                                                      as reseau_emmaus,
     case
         when adherents_coorace.reseau_coorace = 'Coorace' then 'Oui'
         else 'Non'
-    end                                       as reseau_coorace,
+    end                                                      as reseau_coorace,
     case
         when adherents_fei.reseau_fei = 'FEI' then 'Oui'
         else 'Non'
-    end                                       as reseau_fei,
+    end                                                      as reseau_fei,
     case
         when adherents_unai.reseau_unai = 'Unai' then 'Oui'
         else 'Non'
-    end                                       as reseau_unai,
+    end                                                      as reseau_unai,
     case
         when adherents_cocagne.reseau_cocagne = 'Cocagne' then 'Oui'
         else 'Non'
-    end                                       as reseau_cocagne
+    end                                                      as reseau_cocagne
 from
     candidatures_p
 left join bassin_emploi

--- a/dbt/models/staging/properties.yml
+++ b/dbt/models/staging/properties.yml
@@ -24,3 +24,6 @@ models:
     description: >
       Ce modèle permet de sélectionner les candidats provenant d'une auto prescription.
       Nous parlons d'auto prescription lorsque l'auteur du diagnostic et l'origine de la candidature proviennent du même employeur.
+  - name: stg_candidatures
+    description: >
+      Ce modèle récupère les données de la table candidatures et y applique quelques modifications de renommage ou d'extraction de données.

--- a/dbt/models/staging/properties.yml
+++ b/dbt/models/staging/properties.yml
@@ -27,3 +27,4 @@ models:
   - name: stg_candidatures
     description: >
       Ce modèle récupère les données de la table candidatures et y applique quelques modifications de renommage ou d'extraction de données.
+

--- a/dbt/models/staging/stg_candidatures.sql
+++ b/dbt/models/staging/stg_candidatures.sql
@@ -1,34 +1,21 @@
 select
-    id,
-    "id_anonymisé",
-    id_candidat,
-    "id_candidat_anonymisé",
-    date_candidature,
-    date_embauche,
-    "délai_de_réponse",
-    "délai_prise_en_compte",
-    "département_structure",
-    safir_org_prescripteur,
-    id_structure                              as cdd_id_structure,
-    id_org_prescripteur                       as cdd_id_org_prescripteur,
-    motif_de_refus,
-    "nom_département_structure",
-    "région_structure",
-    nom_structure,
-    type_structure,
-    "origine_détaillée",
-    nom_org_prescripteur,
-    "nom_prénom_conseiller",
-    injection_ai,
-    case
-        when "état" = 'Candidature déclinée' then 'Candidature refusée'
-        else "état"
-    end                                       as "état",
-    case
-        when origine = 'Candidat' then 'Candidature en ligne'
-        else origine
-    end                                       as origine,
-    extract(day from "délai_de_réponse")      as temps_de_reponse,
-    extract(day from "délai_prise_en_compte") as temps_de_prise_en_compte
+    {% if env_var('CI', ',') %}
+        *
+    {% else %}
+        {{ dbt_utils.star(source('emplois', 'candidatures'), except=["état", "origine", "délai_de_réponse", "délai_prise_en_compte", "cdd_id_org_prescripteur", "cdd_id_structure"]) }},
+        -- laurine: je mets tout ici car sinon dbt râle car je lui demande de créer des colonnes qui existent déjà
+        id_structure                              as cdd_id_structure,
+        id_org_prescripteur                       as cdd_id_org_prescripteur,
+        case
+            when "état" = 'Candidature déclinée' then 'Candidature refusée'
+            else "état"
+        end                                       as "état",
+        case
+            when origine = 'Candidat' then 'Candidature en ligne'
+            else origine
+        end                                       as origine,
+        extract(day from "délai_de_réponse")      as temps_de_reponse,
+        extract(day from "délai_prise_en_compte") as temps_de_prise_en_compte
+    {% endif %}
 from
     {{ source('emplois', 'candidatures') }}

--- a/dbt/models/staging/stg_candidatures.sql
+++ b/dbt/models/staging/stg_candidatures.sql
@@ -1,5 +1,5 @@
 select
-    {% if env_var('CI', ',') %}
+    {% if env_var('CI', '') %}
         *
     {% else %}
         {{ dbt_utils.star(source('emplois', 'candidatures'), except=["état", "origine", "délai_de_réponse", "délai_prise_en_compte", "cdd_id_org_prescripteur", "cdd_id_structure"]) }},

--- a/dbt/models/staging/stg_candidatures.sql
+++ b/dbt/models/staging/stg_candidatures.sql
@@ -1,0 +1,34 @@
+select
+    id,
+    "id_anonymisé",
+    id_candidat,
+    "id_candidat_anonymisé",
+    date_candidature,
+    date_embauche,
+    "délai_de_réponse",
+    "délai_prise_en_compte",
+    "département_structure",
+    safir_org_prescripteur,
+    id_structure                              as cdd_id_structure,
+    id_org_prescripteur                       as cdd_id_org_prescripteur,
+    motif_de_refus,
+    "nom_département_structure",
+    "région_structure",
+    nom_structure,
+    type_structure,
+    "origine_détaillée",
+    nom_org_prescripteur,
+    "nom_prénom_conseiller",
+    injection_ai,
+    case
+        when "état" = 'Candidature déclinée' then 'Candidature refusée'
+        else "état"
+    end                                       as "état",
+    case
+        when origine = 'Candidat' then 'Candidature en ligne'
+        else origine
+    end                                       as origine,
+    extract(day from "délai_de_réponse")      as temps_de_reponse,
+    extract(day from "délai_prise_en_compte") as temps_de_prise_en_compte
+from
+    {{ source('emplois', 'candidatures') }}


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Uniformiser-dans-nos-TB-le-vocabulaire-de-l-tat-des-candidatures-refus-es-et-d-clin-es-318ebc733db64d60a77465480e5cb597?pvs=4

### Pourquoi ?

Unifier le vocabulaire entre les légendes des indicateurs et le texte des TBs

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

