### PR TITLE
DBT : Correction de la clause de détection de CI

### DIFF
--- a/dbt/models/marts/suivi_auto_prescription.sql
+++ b/dbt/models/marts/suivi_auto_prescription.sql
@@ -1,5 +1,5 @@
 select
-    {% if env_var('CI', ',') %}
+    {% if env_var('CI', '') %}
         autopr_all.*,
     {% else %}
         {{ dbt_utils.star(ref('stg_candidatures_autoprescription')) }},

--- a/dbt/models/marts/suivi_candidatures_prescripteurs_habilites.sql
+++ b/dbt/models/marts/suivi_candidatures_prescripteurs_habilites.sql
@@ -7,7 +7,7 @@ with candidatures_ph as (
         we have to workaround it. I would have like to monkeypatch it in CI (some override of
         the macro somewhere) but could not find a way to do it. Essentialy, we would want the
         following code being applied automatically. */
-        {% if env_var('CI', ',') %}
+        {% if env_var('CI', '') %}
             *,
         {% else %}
             {{ dbt_utils.star(ref('candidatures_echelle_locale')) }},


### PR DESCRIPTION
**Fil slack : https://itou-inclusion.slack.com/archives/C04SAGUGJFJ/p1684162201788149?thread_ts=1684153562.319589&cid=C04SAGUGJFJ**

### Pourquoi ?

La clause initiale renvoyait tout le temps `True` en fait. ¯\_(ツ)_/¯