### PR TITLE
Refacto pour ajout d'une colonne contenant un label prescripteur unifié avec la table candidatures

### DIFF
--- a/dbt/models/marts/candidatures_dihal.sql
+++ b/dbt/models/marts/candidatures_dihal.sql
@@ -1,3 +1,8 @@
-select {{ dbt_utils.star(ref('candidatures_echelle_locale')) }}
+select
+    {% if env_var('CI', '') %}
+        id
+    {% else %}
+        {{ dbt_utils.star(ref('candidatures_echelle_locale')) }}
+    {% endif %}
 from {{ ref('candidatures_echelle_locale') }}
 where "type_org_prescripteur" in ('CHRS', 'CHU', 'RS_FJT', 'OIL')

--- a/dbt/models/marts/organisations_dihal.sql
+++ b/dbt/models/marts/organisations_dihal.sql
@@ -1,3 +1,8 @@
-select {{ dbt_utils.star(source('emplois', 'organisations')) }}
-from {{ source('emplois', 'organisations') }}
+select
+    {% if env_var('CI', '') %}
+        id
+    {% else %}
+        {{ dbt_utils.star(ref('stg_organisations')) }}
+    {% endif %}
+from {{ ref('stg_organisations') }}
 where type in ('CHRS', 'CHU', 'RS_FJT', 'OIL')

--- a/dbt/models/marts/suivi_prescripteurs_habilites.sql
+++ b/dbt/models/marts/suivi_prescripteurs_habilites.sql
@@ -17,7 +17,7 @@ select
     -- nombre de siae partenaires de l'organisation =
     -- nombre de siae qui ont reçu une candidature de ce prescripteur
     nb_siae_partenaires.nb_siae
-from {{ source('emplois', 'organisations') }} as organisations
+from {{ ref('stg_organisations') }} as organisations
 left join {{ ref('stg_insee_appartenance_geo_communes') }} as appartenance_geo_communes
     on ltrim(organisations.code_commune, '0') = appartenance_geo_communes.code_insee
 left join nb_siae_partenaires on organisations.id = nb_siae_partenaires.id

--- a/dbt/models/staging/properties.yml
+++ b/dbt/models/staging/properties.yml
@@ -26,5 +26,9 @@ models:
       Nous parlons d'auto prescription lorsque l'auteur du diagnostic et l'origine de la candidature proviennent du même employeur.
   - name: stg_candidatures
     description: >
-      Ce modèle récupère les données de la table candidatures et y applique quelques modifications de renommage ou d'extraction de données.
-
+      Ce modèle récupère les données de la table c1 candidatures et y applique quelques modifications de renommage ou d'extraction de données.
+  - name: stg_organisations
+    description: >
+      Ce modèle récupère les données de la table c1 organisations et y ajoute des colonnes pour faciliter le déploiement de tableaux metabase liés aux prescripteurs.
+      Une colonne type_complet_avec_habilitation permet notamment de rendre cohérent le nom des prescripteurs avec celui de la table candidature.
+      Elle pourra également être enrichie d'autres données sur les organisations comme le nombre de structures partenaires, le nombre de prescriptions réalisées, etc.

--- a/dbt/models/staging/stg_organisations.sql
+++ b/dbt/models/staging/stg_organisations.sql
@@ -1,0 +1,11 @@
+select
+    {% if env_var('CI', '') %}
+        id,
+    {% else %}
+        {{ dbt_utils.star(source('emplois', 'organisations')) }},
+    {% endif %}
+    case
+        when "habilitée" = 1 then concat('Prescripteur habilité ', "type")
+        when "habilitée" = 0 then concat('Orienteur ', "type")
+    end as type_complet_avec_habilitation
+from {{ source('emplois', 'organisations') }}


### PR DESCRIPTION
**Carte Notion : ** 
https://www.notion.so/plateforme-inclusion/Suivi-et-analyse-des-prescriptions-r-aliser-les-indicateurs-le-TB-67ea163528de45ed98bbf9fad4bf08dd?pvs=4
https://www.notion.so/plateforme-inclusion/Modifs-mineures-DIHAL-8073e16de8b146c3b0acbebd6e040fcd?pvs=4

### Pourquoi ?

Les noms des prescripteurs ne sont pas unifiés entre la table organisations et la table candidature, ce qui cause des problèmes de filtres sur les tableaux de bords qui dépendent des deux tables.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

