### PR TITLE
Ajout d'une colonne id structure pour le TB SIAE CAP

### DIFF
--- a/dbt/models/legacy/suivi_cap_criteres.sql
+++ b/dbt/models/legacy/suivi_cap_criteres.sql
@@ -4,7 +4,7 @@ select
     criteres."niveau"         as "niveau_critère",
     -- REFUSED et REFUSED_2 correspondent au même état (?) - à confirmer par Zo
     camp."nom"                as "nom_campagne",
-    structs."id"              as "id_structure"
+    structs."id"              as "id_structure",
     structs."nom"             as "nom_structure",
     structs."nom_complet"     as "nom_structure_complet",
     structs."département"     as "département",

--- a/dbt/models/legacy/suivi_cap_criteres.sql
+++ b/dbt/models/legacy/suivi_cap_criteres.sql
@@ -4,6 +4,7 @@ select
     criteres."niveau"         as "niveau_critère",
     -- REFUSED et REFUSED_2 correspondent au même état (?) - à confirmer par Zo
     camp."nom"                as "nom_campagne",
+    structs."id"              as "id_structure"
     structs."nom"             as "nom_structure",
     structs."nom_complet"     as "nom_structure_complet",
     structs."département"     as "département",


### PR DESCRIPTION
### Pourquoi ?

Ajout d'une colonne id structure pour le TB SIAE CAP et permettre a Vermeer de créer une vue privée sur le C1

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

