### PR TITLE
Ajout d'une colonne oui/non pour l'injection AI

### DIFF
--- a/dbt/models/marts/candidatures_echelle_locale.sql
+++ b/dbt/models/marts/candidatures_echelle_locale.sql
@@ -8,6 +8,10 @@ select
         except=["nom_departement", "nom_region", "type_epci", "id_structure"], relation_alias='bassin_emploi') }},
         {{ dbt_utils.star(ref('stg_reseaux'), except=["SIRET","id_structure"], relation_alias='rsx') }},
     {% endif %}
+    case
+        when candidatures.injection_ai = 0 then 'Non'
+        else 'Oui'
+    end as reprise_de_stock_ai,
     nom_org.type_auteur_diagnostic_detaille
 from
     {{ ref('stg_candidatures') }} as candidatures


### PR DESCRIPTION
### Pourquoi ?

A la demande d'Annie, ajout d'une colonne oui/non pour indiquer si une candidature provient de la reprise de stock ai

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

