### PR TITLE
Renommer prescripteurs habilité

### DIFF
--- a/dbt/models/staging/stg_candidatures.sql
+++ b/dbt/models/staging/stg_candidatures.sql
@@ -1,6 +1,6 @@
 select
     {{ pilo_star(source('emplois', 'candidatures'),
-        except=["état", "motif_de_refus", "origine", "délai_de_réponse", "délai_prise_en_compte"]) }},
+        except=["état", "motif_de_refus", "origine", "délai_de_réponse", "délai_prise_en_compte", "origine_détaillée"]) }},
     case
         when "état" = 'Candidature déclinée' then 'Candidature refusée'
         else "état"
@@ -13,6 +13,10 @@ select
         when origine = 'Candidat' then 'Candidature en ligne'
         else origine
     end                                       as origine,
+    case
+        when "origine_détaillée" = 'Prescripteur habilité Autre' then 'Prescripteur habilité par habilitation préfectorale'
+        else "origine_détaillée"
+    end                                       as "origine_détaillée",
     extract(day from "délai_de_réponse")      as temps_de_reponse,
     extract(day from "délai_prise_en_compte") as temps_de_prise_en_compte
 from


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/En-tant-qu-utilisateur-je-ne-comprends-pas-la-diff-rence-entre-autres-orienteurs-et-autres-presc-a467413982284456a2ed6a0212f4b37a?pvs=4

### Pourquoi ?

clarifier le type "prescripteur habilité autres"

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

