### PR TITLE
deleting the view associated to the dag

### DIFF
--- a/dags/reseau_iae_adherents.py
+++ b/dags/reseau_iae_adherents.py
@@ -7,6 +7,7 @@ from dags.common import db, default_dag_args, slack
 
 
 RESEAU_IAE_TABLE_CREATE_SQL = """
+DROP VIEW IF EXISTS stg_reseaux;
 DROP TABLE IF EXISTS {table_name};
 CREATE TABLE {table_name}(
     "SIRET" VARCHAR(16),


### PR DESCRIPTION
### Pourquoi ?

Ajout d'un `drop view `de la vue associée à ce DAG. Si la vue existe toujours, le code ne peut pas tourner.

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

