### PR TITLE
Mise à jour des tables de suivi utilisateurs pour le calcul du taux de rétention

### DIFF
--- a/dbt/models/marts/suivi_tb_prive_semaine.sql
+++ b/dbt/models/marts/suivi_tb_prive_semaine.sql
@@ -1,17 +1,34 @@
+with follow_users as (
+    select
+        nom_tb,
+        semaine,
+        num_semaine,
+        -- liste des utilisateurs venus cette semaine
+        array_agg(id_utilisateur) as liste_utilisateurs,
+        -- liste des utilisateurs venus la semaine dernière
+        -- TODO (laurine) : a adapter pour récupérer les utilisateurs de toutes les semaines précédentes et non pas uniquement la precedente
+        lag(array_agg(id_utilisateur)) over (partition by nom_tb order by num_semaine) as liste_utilisateurs_semaine_prec,
+        -- nb total d'utilisateurs cette semaine
+        count(id_utilisateur)     as nb_utilisateurs,
+        -- nb d'utilisateurs revenus au moins une fois cette semaine
+        count(
+            case
+                when nb_visites > 1 then 1
+            end
+        )                         as nb_utilisateurs_plusieurs_visites
+    from {{ ref('suivi_utilisateurs_tb_prive_semaine') }}
+    group by
+        num_semaine,
+        nom_tb,
+        semaine
+)
+
 select
-    nom_tb,
-    semaine,
-    num_semaine,
-    -- nb total d'utilisateurs cette semaine
-    count(id_utilisateur) as nb_utilisateurs,
-    -- nb d'utilisateurs revenus au moins une fois cette semaine
-    count(
-        case
-            when nb_visites > 1 then 1
-        end
-    )                     as nb_utilisateurs_plusieurs_visites
-from {{ ref('suivi_utilisateurs_tb_prive_semaine') }}
-group by
-    nom_tb,
-    semaine,
-    num_semaine
+    *,
+    -- visiteurs cumules
+    array(select distinct u from unnest(array_cat(liste_utilisateurs, liste_utilisateurs_semaine_prec)) as u) as visiteurs_cumules,
+    -- nouveaux visiteurs ie ne se sont jamais connectés avant cette semaine
+    array(select distinct u from unnest(liste_utilisateurs) as u where u not in (select * from unnest(liste_utilisateurs_semaine_prec))) as nouveaux_visiteurs,
+    -- anciens visiteurs ie se sont déjà connecté une fois avant cette semaine
+    array(select distinct u from unnest(liste_utilisateurs) as u where u in (select * from unnest(liste_utilisateurs_semaine_prec))) as anciens_visiteurs
+from follow_users

--- a/dbt/models/marts/suivi_utilisateurs_tb_prive_semaine.sql
+++ b/dbt/models/marts/suivi_utilisateurs_tb_prive_semaine.sql
@@ -28,7 +28,7 @@ left join {{ source('emplois', 'institutions') }} as institutions
 left join {{ source('emplois', 'utilisateurs') }} as c1_users
     on c1_users.id = cast(visits.user_id as INTEGER)
 -- ignore intern staff and 119 dashboard (c1 intern stats)
-where c1_users.email not in (select email from pilotage_c1_users) and visits.dashboard_id != '119'
+where c1_users.email not in (select email from {{ ref('pilotage_c1_users') }}) and visits.dashboard_id != '119'
 group by
     id_utilisateur,
     email_utilisateur,

--- a/dbt/models/marts/suivi_utilisateurs_tb_prive_semaine.sql
+++ b/dbt/models/marts/suivi_utilisateurs_tb_prive_semaine.sql
@@ -27,7 +27,8 @@ left join {{ source('emplois', 'institutions') }} as institutions
     on institutions.id = cast(visits.current_institution_id as INTEGER) and visits.user_kind = 'labor_inspector'
 left join {{ source('emplois', 'utilisateurs') }} as c1_users
     on c1_users.id = cast(visits.user_id as INTEGER)
-where c1_users.email not in (select email from pilotage_c1_users)
+-- ignore intern staff and 119 dashboard (c1 intern stats)
+where c1_users.email not in (select email from pilotage_c1_users) and visits.dashboard_id != '119'
 group by
     id_utilisateur,
     email_utilisateur,

--- a/dbt/seeds/pilotage_interne/pilotage_c1_users.csv
+++ b/dbt/seeds/pilotage_interne/pilotage_c1_users.csv
@@ -2,4 +2,3 @@ email,utilisateur
 pilotage.institution@inclusion.beta.gouv.fr,pilotage
 pilotage.prescripteur@inclusion.beta.gouv.fr,pilotage
 pilotage.employeur@inclusion.beta.gouv.fr,pilotage
-victor@iso3103.net,victor


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/R-aliser-table-s-permettant-de-calculer-des-indicateurs-d-impact-suivre-sur-le-produit-4894e065aba34b04b8b1d9295e5d5a53?pvs=4

### Pourquoi ?

Suivre les utilisateurs réguliers de nos TBs et calculer le taux de rétention.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

