### PR TITLE
TB réseaux : Retrait des structures qui ne sont pas des SIAE

### DIFF
--- a/dbt/models/marts/candidatures_reseaux.sql
+++ b/dbt/models/marts/candidatures_reseaux.sql
@@ -19,3 +19,4 @@ left join {{ ref('nom_prescripteur') }} as nom_org
     on nom_org.origine_detaille = candidatures."origine_détaillée"
 left join {{ ref('stg_reseaux') }} as rsx
     on candidatures.id_structure = rsx.id_structure
+where candidatures.type_structure in ('AI', 'ACI', 'EITI', 'ETTI', 'EI')

--- a/dbt/models/staging/properties.yml
+++ b/dbt/models/staging/properties.yml
@@ -54,7 +54,6 @@ models:
       Cette table suit les metrics des TBs prives avant l'automatisation des requêtes API Matomo introduite par Victor.
   - name: stg_suivi_visiteurs_prives_v1
     description: >
-      Permet de suivre les metrics matomo associees aux TB prives.
       Cette table suit les metrics des TBs prives après l'automatisation des requêtes API Matomo introduite par Victor.
   - name: stg_duree_annexe
     description: >

--- a/dbt/models/staging/stg_reseaux.sql
+++ b/dbt/models/staging/stg_reseaux.sql
@@ -5,5 +5,5 @@ select
 from {{ source('oneshot', 'reseau_iae_adherents') }} as ria
 left join {{ ref('reseau_iae_ids') }} as rid
     on ria."Réseau IAE" = rid.nom
-inner join {{ source('emplois', 'structures') }} as s
+left join {{ source('emplois', 'structures') }} as s
     on s.siret = ria."SIRET"


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

TB réseaux : Retrait des structures qui ne sont pas des SIAE + remplacement d'un inner join par un left join qui nous permettait pas d'avoir des doublons dans les duos structures x réseaux

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

