### PR TITLE
Création d'une table PASS agréments contenant une information sur la validité du pass

### DIFF
--- a/dbt/models/marts/pass_agrements_valides.sql
+++ b/dbt/models/marts/pass_agrements_valides.sql
@@ -1,0 +1,9 @@
+select
+    {{ pilo_star(source('emplois', 'pass_agréments'), relation_alias="pa") }},
+    case
+        when
+            pa.date_fin >= current_date then 'pass valide'
+        else 'pass non valide'
+    end as validite_pass
+from
+    {{ source('emplois', 'pass_agréments') }} as pa

--- a/dbt/models/marts/properties.yml
+++ b/dbt/models/marts/properties.yml
@@ -50,3 +50,9 @@ models:
   - name: suivi_consommation_etp_V2
     description: >
       Table créée pour suivre la consommation réelle d'ETPs par structure ainsi que leur conventionnement.
+  - name: pass_agrements_valides
+    description: >
+      A la demande du C1, cette table a été créée pour suivre le nombre de pass IAE valides. Ici un pass est considéré valide quand sa date de fin n'a pas expiré.
+      Afin d'informer si le pass est valide ou pas une colonne validite_pass remplie, avec les strings 'pass valide/pass non valide', a été créée.
+      L'information contenue dans cette colonne n'est pas sous forme 1/0 afin d'anticiper une potentielle demande métier où cette colonne servirait de filtre.
+      Cette colonne aurait pu être rajoutée dans {{source, pass_agréments}} mais un marts a été préféré à un ajout de colonne pour des raisons d'autonomie du côté des data analyst.


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

A la demande du C1, création d'une table PASS agréments contenant une information sur la validité du pass. Cet indicateur sera utilisé dans leur future page stats.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

