### PR TITLE
Premiers tests Python (outils communs des DAGs) et DBT (nombre de lignes)

### DIFF
--- a/dbt/models/marts/properties.yml
+++ b/dbt/models/marts/properties.yml
@@ -50,6 +50,9 @@ models:
   - name: suivi_consommation_etp_V2
     description: >
       Table créée pour suivre la consommation réelle d'ETPs par structure ainsi que leur conventionnement.
+    tests:
+      - dbt_utils.equal_rowcount:
+          compare_model: ref('suivi_etp_conventionnes_v2')
   - name: pass_agrements_valides
     description: >
       A la demande du C1, cette table a été créée pour suivre le nombre de pass IAE valides. Ici un pass est considéré valide quand sa date de fin n'a pas expiré.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -61,6 +61,7 @@ Flask-Login==0.6.2
 Flask-Session==0.5.0
 Flask-SQLAlchemy==2.5.1
 Flask-WTF==1.1.1
+freezegun==1.2.2
 frozenlist==1.3.3
 future==0.18.3
 graphviz==0.20.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 
 black
 flake8
+freezegun
 isort
 pytest
 pytest-subtests

--- a/tests/test_common_dates.py
+++ b/tests/test_common_dates.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+import pandas  # init pandas to avoid a crash with freezegun  # noqa: F401
+from freezegun import freeze_time
+
+from dags.common import dates
+
+
+@freeze_time("2022-06-08")
+def test_date_functions():
+    assert dates.start_of_week() == datetime(2022, 6, 6)
+    assert dates.start_of_previous_week() == datetime(2022, 5, 30)
+    assert dates.end_of_previous_week() == datetime(2022, 6, 5)
+    # FIXME(vperron) : this function is VERY weird, it relies internally on a fixed
+    # date, 2022-06-06. WHY ?
+    assert dates.week_list() == [datetime(2022, 6, 6)]


### PR DESCRIPTION
Des exemples pour mes pilotos !

Outre les tests classiques (unique, not null, etc) fournis par DBT, `dbt_utils` en a un PAQUET et ils sont super cools !

Donc désormais, essayons de nous forcer à en mettre au moins un par exemple ?

Je pars en weekend donc je n'ai pas encore écrit le DAG qui lancera les tests sur la prod, mais je le fais des que possible. En attendant ça marche (`pytest` pour les tests python, `dbt test` pour les tests data)


![Screenshot from 2023-06-21 17-51-17](https://github.com/gip-inclusion/pilotage-airflow/assets/88618/f38fbd58-0859-4cc5-abbd-23bb0c15915f)
