### PR TITLE
dags: Run data_consistency only after a successful final_tables

### DIFF
--- a/dags/data_consistency.py
+++ b/dags/data_consistency.py
@@ -8,7 +8,6 @@ dag_args = default_dag_args() | {"default_args": dbt.get_default_args()}
 
 with airflow.DAG(
     dag_id="data_consistency",
-    schedule_interval="@hourly",
     **dag_args,
 ) as dag:
     start = empty.EmptyOperator(task_id="start")

--- a/dags/final_tables.py
+++ b/dags/final_tables.py
@@ -1,5 +1,5 @@
 import airflow
-from airflow.operators import bash, empty
+from airflow.operators import bash, empty, trigger_dagrun
 
 from dags.common import db, dbt, default_dag_args, slack
 
@@ -52,4 +52,8 @@ with airflow.DAG(
         append_env=True,
     )
 
-    (start >> dbt_debug >> dbt_deps >> dbt_seed >> dbt_run >> dbt_clean >> end)
+    dag_data_consistency = trigger_dagrun.TriggerDagRunOperator(
+        trigger_dag_id="data_consistency", task_id="trigger_data_consistency"
+    )
+
+    (start >> dbt_debug >> dbt_deps >> dbt_seed >> dbt_run >> dbt_clean >> dag_data_consistency >> end)


### PR DESCRIPTION
Stop having those errors upon recreation, also only run when it means something ^^

### Pourquoi ?

Il y en a assez de voir toutes ces erreurs la nuit parce que on est logiquement en train de recréer les tables.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

