### PR TITLE
Suivi du nombre d'etp réalisés par genre

### DIFF
--- a/dbt/models/marts/etp_par_genre.sql
+++ b/dbt/models/marts/etp_par_genre.sql
@@ -1,0 +1,15 @@
+select
+    {{ pilo_star(ref('suivi_etp_realises_v2'), relation_alias='etp_r') }},
+    etp_c."effectif_mensuel_conventionné",
+    etp_c."effectif_annuel_conventionné",
+    case
+        when salarie.salarie_rci_libelle = 'MME' then 'Femme'
+        when salarie.salarie_rci_libelle = 'M.' then 'Homme'
+        else 'Non renseigné'
+    end as genre_salarie
+from
+    {{ ref('suivi_etp_realises_v2') }} as etp_r
+left join {{ ref('stg_salarie') }} as salarie
+    on etp_r.identifiant_salarie = salarie.salarie_id
+left join {{ ref('suivi_etp_conventionnes_v2') }} as etp_c
+    on etp_c.id_annexe_financiere = etp_r.id_annexe_financiere

--- a/dbt/models/marts/properties.yml
+++ b/dbt/models/marts/properties.yml
@@ -63,3 +63,9 @@ models:
     description: >
       Table créée pour récupérer la dernière embauche (si elle existe) d'un candidat.
       Cette information est utilisée dans la table stats du C1 afin des filtrer les données des candidats par dernière date d'embauche.
+  - name: etp_par_genre
+    description: >
+      Table créée pour suivre le nombre d'etp réalisés par genre
+    tests:
+      - dbt_utils.equal_rowcount:
+          compare_model: ref('suivi_etp_realises_v2')

--- a/dbt/models/staging/properties.yml
+++ b/dbt/models/staging/properties.yml
@@ -69,3 +69,9 @@ models:
   - name: stg_candidats_candidatures
     description: >
       Vue créée pour joindre les dates d'embauche de chaque candidat. Cette vue est utilisée dans candidats_derniere_embauche.sql pour extraire la dernière date d'embauche d'un candidat.
+  - name: stg_salarie
+    description: >
+      Vue créée pour récupérer les id uniques des salarié(e)s ainsi que leur genre afin de permettre le calcul des ETPs par genre.
+    tests:
+      - dbt_utils.equal_rowcount:
+          compare_model: source('fluxIAE', 'fluxIAE_Salarie')

--- a/dbt/models/staging/stg_salarie.sql
+++ b/dbt/models/staging/stg_salarie.sql
@@ -1,0 +1,8 @@
+/* This table is needed to gather the gender of all the distincts employees in the asp flux
+Indeed, some employees are referenced more than once which induces a wrong amount of ETP per gender */
+
+select distinct
+    salarie.salarie_id,
+    salarie.salarie_rci_libelle
+from
+    {{ source('fluxIAE', 'fluxIAE_Salarie') }} as salarie


### PR DESCRIPTION
**Carte Notion : ** [Créer un nouvel indicateur “budget genré” de l’IAE](https://www.notion.so/plateforme-inclusion/Suivi-des-cartes-b3082fffe3f34eaea8fff8ba69338005?p=ab1860c9819f494f9efbc2ca2f8e0c9a&pm=c)
### Pourquoi ?

A la demande du métier, création d'une table permettant le calcul des ETPs réalisés par genre

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

