### PR TITLE
Retrait d'un test inutile

### DIFF
--- a/dbt/models/staging/properties.yml
+++ b/dbt/models/staging/properties.yml
@@ -72,6 +72,3 @@ models:
   - name: stg_salarie
     description: >
       Vue créée pour récupérer les id uniques des salarié(e)s ainsi que leur genre afin de permettre le calcul des ETPs par genre.
-    tests:
-      - dbt_utils.equal_rowcount:
-          compare_model: source('fluxIAE', 'fluxIAE_Salarie')


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Ce test est finalement peu (pas) utile, l'autre test ajouté dans cette [PR](https://github.com/gip-inclusion/pilotage-airflow/pull/83) permet à lui seul d'identifier s'il y a un problème dans la table finale + vue associée.  

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

