### PR TITLE
Ajout de l'année et du mois pour suivre la consommation annuelle par genre

### DIFF
--- a/dbt/models/marts/suivi_etp_realises_v2.sql
+++ b/dbt/models/marts/suivi_etp_realises_v2.sql
@@ -4,6 +4,8 @@ select distinct
     emi.emi_part_etp                                                                    as nombre_etp_consommes_asp,
     emi.emi_nb_heures_travail                                                           as nombre_heures_travaillees,
     emi.emi_afi_id                                                                      as identifiant_annexe_fin,
+    emi.emi_sme_mois,
+    emi.emi_sme_annee,
     af.af_numero_convention,
     /*Nous calculons directement les ETPs réalisés pour éviter des problèmes de filtres/colonnes/etc sur metabase*/
     /* ETPs réalisés = Nbr heures travaillées / montant d'heures necessaires pour avoir 1 ETP */


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Ajout de l'année et du mois pour suivre la consommation annuelle par genre

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

