### PR TITLE
Ajout des types de structures correspondant à celle des emplois

### DIFF
--- a/dbt/models/marts/etp_par_salarie.sql
+++ b/dbt/models/marts/etp_par_salarie.sql
@@ -15,3 +15,4 @@ left join {{ ref('stg_salarie') }} as salarie
     on etp_r.identifiant_salarie = salarie.salarie_id
 left join {{ ref('suivi_etp_conventionnes_v2') }} as etp_c
     on etp_c.id_annexe_financiere = etp_r.id_annexe_financiere
+where etp_r.type_structure not in ('ACIPA_DC', 'EIPA_DC', 'FDI')

--- a/dbt/models/marts/suivi_etp_realises_v2.sql
+++ b/dbt/models/marts/suivi_etp_realises_v2.sql
@@ -18,6 +18,7 @@ select distinct
     firmi.rmi_valeur,
     af.af_mesure_dispositif_code,
     ref_asp.type_structure,
+    ref_asp.type_structure_emplois,
     structure.structure_denomination,
     structure.structure_adresse_admin_commune                                           as commune_structure,
     structure.structure_adresse_admin_code_insee                                        as code_insee_structure,

--- a/dbt/seeds/ref_mesure_dispositif_asp.csv
+++ b/dbt/seeds/ref_mesure_dispositif_asp.csv
@@ -1,11 +1,11 @@
-af_mesure_dispositif_code,type_structure
-ETTI_DC,ETTI Droit commun
-ACIPA_DC,ACIPA Droit commun
-FDI_DC,FDI Droit commun
-EI_MP,EI Milieu pénitentiaire
-EI_DC,EI Droit commun
-ACI_MP,ACI Milieu pénitentiaire
-EIPA_DC,EIPA Droit commun
-ACI_DC,ACI Droit commun
-EITI_DC,EITI Droit commun
-AI_DC,AI Droit commun
+af_mesure_dispositif_code,type_structure,type_structure_emplois
+ETTI_DC,ETTI Droit commun,ETTI
+ACIPA_DC,ACIPA Droit commun,ACIPA
+FDI_DC,FDI Droit commun,FDI
+EI_MP,EI Milieu pénitentiaire,EI
+EI_DC,EI Droit commun,EI
+ACI_MP,ACI Milieu pénitentiaire,ACI
+EIPA_DC,EIPA Droit commun,EIPA
+ACI_DC,ACI Droit commun,ACI
+EITI_DC,EITI Droit commun,EITI
+AI_DC,AI Droit commun,AI


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Ajout des types de structures correspondant à celle des emplois afin d'avoir un filtre homogène dans le TB 216

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

