### PR TITLE
 mise à dispo des données de visites pour les campagnes matomo du c0 (version propre de la PR 84)

### DIFF
--- a/dags/common/matomo.py
+++ b/dags/common/matomo.py
@@ -1,0 +1,60 @@
+import requests
+
+
+produits = {
+    "carnet de bord": 209,
+    "emplois": 117,  # ITOU
+    "dora": 211,
+    "immersion facile": 207,
+    "inclusion": 212,
+    "communauté": 206,
+    "marché": 136,
+    "pilotage": 146,
+}
+
+
+def get_visits_per_campaign_from_matomo(matomo_base_url, tok):
+    """
+    creates a dataframe composed of all visits for all c0 campaigns and all gip products
+    """
+    import pandas as pd
+
+    headers = {"Accept": "application/json"}
+
+    dtf = pd.DataFrame()
+
+    for produit, idsite in produits.items():
+        url = (
+            f"{matomo_base_url}"
+            "?module=API"
+            "&method=Live.getLastVisitsDetails"
+            "&apiModule=Referrers"
+            # we recover all campaigns that are launched by c0
+            "&segment=referrerType==campaign;referrerName==c0"
+            f"&idSite={idsite}"
+            "&expanded=1"
+            "&period=month"
+            "&format=json"
+            f"&token_auth={tok}"
+        )
+
+        rep = requests.get(url, headers=headers)
+
+        def get_visit_info(produit, json_visit):
+            """
+            from a json visit extracted from matomo via api, returns a dict of relevant informations
+            """
+            infos = {
+                "produit": produit,
+                "poste": json_visit["referrerKeyword"],
+                "date": json_visit["serverDate"],
+                "visiteur": json_visit["visitorId"],
+                "nb_actions": len(json_visit["actionDetails"]),
+                "duree": json_visit["visitDurationPretty"],
+            }
+            return infos
+
+        for json in rep.json():
+            infos = get_visit_info(produit, json)
+            dtf = dtf._append(infos, ignore_index=True)
+    return dtf

--- a/dags/properties.yml
+++ b/dags/properties.yml
@@ -9,3 +9,7 @@ models:
     description: >
       Ce DAG permet de récupérer, de façon hebdomadaire, les notes de recommendation des différents groupes de TB du pilotage de l'inclusion à partir de la table nps_pilotage.
       Ainsi, il est possible de suivre l'évolution hebdomadaire du NPS de tous les TBs, les TBs PE, SIAE et DDETS.
+- name: suivi_visites_campagnes_c0
+    description: >
+      Ce DAG permet de récupérer (de manière hebdomadaire) pour chaque campagne matomo du c0 et chaque produit du gip les visiteurs et leurs actions.
+      Mise à disposition de cette table sur metabase pour les statistiques internes du c0.

--- a/dags/suivi_visites_campagnes_c0.py
+++ b/dags/suivi_visites_campagnes_c0.py
@@ -1,0 +1,27 @@
+from airflow import DAG
+from airflow.decorators import task
+from airflow.models import Variable
+from airflow.operators import empty
+
+from dags.common import db, default_dag_args, matomo, slack
+
+
+with DAG(
+    "suivi_visites_campagnes_c0",
+    schedule_interval="@monthly",
+    **default_dag_args(),
+) as dag:
+    start = empty.EmptyOperator(task_id="start")
+
+    end = slack.success_notifying_task()
+
+    @task(task_id="get_visits_per_campaign")
+    def get_visits_per_campaign(**kwargs):
+        matomo_base_url = Variable.get("MATOMO_BASE_URL")
+        tok = Variable.get("GIP_MATOMO_TOKEN")
+        out_dtf = matomo.get_visits_per_campaign_from_matomo(matomo_base_url, tok)
+        out_dtf.to_sql("visits_per_campaign_c0", con=db.connection_engine(), if_exists="replace", index=False)
+
+    visits_per_campaign = get_visits_per_campaign()
+
+    (start >> visits_per_campaign >> end)


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Extraction-MATOMO-des-campagnes-pour-le-c0-7e12a0d84e944cd08acf40252ba2a304?pvs=4
Pourquoi ?

mise à dispo des données de visites pour les campagnes matomo du c0
Checks

[x]J'ai lancé le modèle ou seed sur un dump local (si pertinent)
[] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
[x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)