### PR TITLE
Add c1 structure type to etp_par_salarie table

### DIFF
--- a/dbt/models/marts/etp_par_salarie.sql
+++ b/dbt/models/marts/etp_par_salarie.sql
@@ -8,7 +8,8 @@ select
         when salarie.salarie_rci_libelle = 'MME' then 'Femme'
         when salarie.salarie_rci_libelle = 'M.' then 'Homme'
         else 'Non renseigné'
-    end                                                                                  as genre_salarie
+    end                                                                                  as genre_salarie,
+    (string_to_array(etp_r.af_mesure_dispositif_code, '_'))[1]                           as type_structure_emploi
 from
     {{ ref('suivi_etp_realises_v2') }} as etp_r
 left join {{ ref('stg_salarie') }} as salarie


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Pour unifier les histogrammes provenant des données fluxIAE et ceux provenant du c1 entre les indicateurs du tb genre.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

