### PR TITLE
Création d'une table permettant de calculer le nombre de sorties par SIAE

### DIFF
--- a/dbt/models/indexed/nombre_heures_travaillees_af.sql
+++ b/dbt/models/indexed/nombre_heures_travaillees_af.sql
@@ -1,0 +1,16 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['emi_pph_id','af_numero_annexe_financiere'], 'unique' : False},
+    ]
+ ) }}
+
+select
+    emi_pph_id,
+    af_numero_annexe_financiere,
+    sum(emi_nb_heures_travail) as total_heures_travaillees_derniere_af
+from {{ ref('sorties_v2') }}
+where emi_sme_annee = annee_sortie_definitive
+group by
+    emi_pph_id,
+    af_numero_annexe_financiere

--- a/dbt/models/indexed/nombre_mois_travailles.sql
+++ b/dbt/models/indexed/nombre_mois_travailles.sql
@@ -1,0 +1,14 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['emi_pph_id'], 'unique' : False},
+    ]
+ ) }}
+
+select
+    emi_pph_id,
+    count(emi_pph_id) as nombre_mois_travailles
+from
+    {{ ref('fluxIAE_EtatMensuelIndiv_v2') }}
+where emi_nb_heures_travail > 0
+group by emi_pph_id

--- a/dbt/models/indexed/properties.yml
+++ b/dbt/models/indexed/properties.yml
@@ -13,3 +13,13 @@ models:
   - name: fluxIAE_RefCategorieSort_v2
     description: >
       Table introduite afin d'ajouter des index aux tables provenant du fluxIAE.
+  - name: sorties_v2
+    description: >
+      Table introduite afin d'extraire toutes les informations du fluxIAE, nécessaires au calcul des sorties.
+  - name: nombre_mois_travailles
+    description: >
+      Table introduite afin de calculer le nombre de mois travailles par un salarie lorsqu'il a travaillé plus de 0 heure.
+  - name: nombre_heures_travaillees_af
+    description: >
+      Table introduite afin de calculer le nombre d'heures travaillées quand l'année de sortie est égale à l'année de l'af.
+      Ce cas particulier est nécessaire au calcul des sorties.

--- a/dbt/models/marts/properties.yml
+++ b/dbt/models/marts/properties.yml
@@ -123,6 +123,6 @@ models:
   - name: delai_1ere_candidature_embauche
     description : >
       Contient pour chaque candidat le délai entre sa première candidature et l'embauche.
-   - name: sorties_finales
+  - name: sorties_finales
     description: >
       Table contenant les motifs de sorties pour tous les salariés ayant travaillé dans une SIAE entre l'année N et l'année N-2.

--- a/dbt/models/marts/properties.yml
+++ b/dbt/models/marts/properties.yml
@@ -121,6 +121,7 @@ models:
     description: >
       Contient le nombre d'acceptations par candidat et par prescripteur pour permettre le calcul du taux de transformation par prescripteur.
   - name: delai_1ere_candidature_embauche
+    description : >
       Contient pour chaque candidat le délai entre sa première candidature et l'embauche.
    - name: sorties_finales
     description: >

--- a/dbt/models/marts/properties.yml
+++ b/dbt/models/marts/properties.yml
@@ -122,3 +122,6 @@ models:
       Contient le nombre d'acceptations par candidat et par prescripteur pour permettre le calcul du taux de transformation par prescripteur.
   - name: delai_1ere_candidature_embauche
       Contient pour chaque candidat le délai entre sa première candidature et l'embauche.
+   - name: sorties_finales
+    description: >
+      Table contenant les motifs de sorties pour tous les salariés ayant travaillé dans une SIAE entre l'année N et l'année N-2.

--- a/dbt/models/marts/sorties_toutes_structures.sql
+++ b/dbt/models/marts/sorties_toutes_structures.sql
@@ -1,0 +1,11 @@
+select
+    {{ pilo_star(ref('stg_sorties_aci_ei'),
+    except=["duree_contrat_regles_asp", "nombre_mois_travailles", "total_heures_travaillees_derniere_af", "duree_contrat_regles_asp"]) }}
+from {{ ref('stg_sorties_aci_ei') }}
+union all
+select
+    {{ pilo_star(ref('stg_sorties_ai_etti'), except=["total_heures_travaillees"]) }}
+from {{ ref('stg_sorties_ai_etti') }}
+union all
+select {{ pilo_star(ref('stg_sorties_eiti')) }}
+from {{ ref('stg_sorties_eiti') }}

--- a/dbt/models/staging/properties.yml
+++ b/dbt/models/staging/properties.yml
@@ -90,3 +90,16 @@ models:
   - name: stg_c1_private_dashboards_visits_v1
     description: >
       Vue contenant les visiteurs des TBs privés provenant des emplois de l'inclusion.
+  - name: stg_sorties_eiti
+    description: >
+      Vue contenant les sorties pour chaque salarié(e) des EITI. Les EITI n'ont pas de règle particulière définissant lorsqu'une sortie doit être prise en compte.
+  - name: stg_sorties_ai_etti
+    description: >
+      Vue contenant les sorties pour chaque salarié(e) des AI et ETTI.
+      Pour ces deux type de SIAE, une sortie est prise en compte lorsque la personne a travaillé plus de 150h en cumulé dans la SIAE.
+  - name: stg_sorties_aci_ei
+    description: >
+      Vue contenant les sorties pour chaque salarié(e) des ACI et EI.
+      Pour ces deux type de SIAE, une sortie est prise en compte lorsque :
+        - la personne a travaillé plus de 3 mois au total dans une ACI/EI
+        - la personne a travaillé au moins une heure dans l'année de sortie de la SIAE.

--- a/dbt/models/staging/stg_sorties_aci_ei.sql
+++ b/dbt/models/staging/stg_sorties_aci_ei.sql
@@ -1,0 +1,41 @@
+/* For the ACI and EI the exit will be considered only
+if the employee worked at least 3 months in the enteprise */
+
+select
+    {{ pilo_star(ref('sorties_v2'), relation_alias="sorties",
+    except=["emi_nb_heures_travail", "emi_sme_version", "af_id_annexe_financiere", "emi_afi_id", "emi_sme_annee", "emi_sme_mois"]) }},
+    nbr.nombre_mois_travailles,
+    nbr_h.total_heures_travaillees_derniere_af,
+    disp.type_structure,
+    disp.type_structure_emplois,
+    case
+        when sorties.annee_debut_contrat = sorties.annee_sortie_definitive
+            then
+                (extract(month from age(
+                    sorties.contrat_date_sortie_definitive::DATE, sorties.contrat_date_embauche::DATE
+                )) + 1)
+        else
+            (extract(month from age(
+                sorties.contrat_date_sortie_definitive::DATE,
+                ((sorties.annee_sortie_definitive) || '-01-01')::DATE
+            )) + 1)
+    end as duree_contrat_regles_asp
+from {{ ref('sorties_v2') }} as sorties
+left join {{ ref('nombre_mois_travailles') }} as nbr
+    on sorties.emi_pph_id = nbr.emi_pph_id
+left join {{ ref('nombre_heures_travaillees_af') }} as nbr_h
+    on
+        sorties.emi_pph_id = nbr_h.emi_pph_id
+        and sorties.af_numero_annexe_financiere = nbr_h.af_numero_annexe_financiere
+left join {{ ref('ref_mesure_dispositif_asp') }} as disp
+    on sorties.af_mesure_dispositif_code = disp.af_mesure_dispositif_code
+where
+    sorties.rcs_libelle != 'Retrait des sorties constatées' and disp.type_structure_emplois in ('ACI', 'EI')
+    and nbr.nombre_mois_travailles >= 3 and nbr_h.total_heures_travaillees_derniere_af > 0
+group by
+    {{ pilo_star(ref('sorties_v2'), relation_alias="sorties",
+    except=["emi_nb_heures_travail", "emi_sme_version", "af_id_annexe_financiere", "emi_afi_id", "emi_sme_annee", "emi_sme_mois"]) }},
+    nbr.nombre_mois_travailles,
+    nbr_h.total_heures_travaillees_derniere_af,
+    disp.type_structure,
+    disp.type_structure_emplois

--- a/dbt/models/staging/stg_sorties_ai_etti.sql
+++ b/dbt/models/staging/stg_sorties_ai_etti.sql
@@ -1,0 +1,17 @@
+select
+    {{ pilo_star(ref('sorties_v2'), relation_alias="sorties",
+    except=["emi_nb_heures_travail", "emi_sme_version", "af_id_annexe_financiere", "emi_afi_id", "emi_sme_annee", "emi_sme_mois"]) }},
+    disp.type_structure,
+    disp.type_structure_emplois,
+    sum(sorties.emi_nb_heures_travail) as total_heures_travaillees
+from {{ ref('sorties_v2') }} as sorties
+left join {{ ref('ref_mesure_dispositif_asp') }} as disp
+    on sorties.af_mesure_dispositif_code = disp.af_mesure_dispositif_code
+where
+    sorties.rcs_libelle != 'Retrait des sorties constatées' and disp.type_structure_emplois in ('AI', 'ETTI')
+group by
+    {{ pilo_star(ref('sorties_v2'), relation_alias="sorties",
+    except=["emi_nb_heures_travail", "emi_sme_version", "af_id_annexe_financiere", "emi_afi_id", "emi_sme_annee", "emi_sme_mois"]) }},
+    disp.type_structure,
+    disp.type_structure_emplois
+having sum(sorties.emi_nb_heures_travail) >= 150

--- a/dbt/models/staging/stg_sorties_eiti.sql
+++ b/dbt/models/staging/stg_sorties_eiti.sql
@@ -1,0 +1,15 @@
+select
+    {{ pilo_star(ref('sorties_v2'), relation_alias="sorties",
+    except=["emi_nb_heures_travail", "emi_sme_version", "af_id_annexe_financiere", "emi_afi_id", "emi_sme_annee", "emi_sme_mois"]) }},
+    disp.type_structure,
+    disp.type_structure_emplois
+from {{ ref('sorties_v2') }} as sorties
+left join {{ ref('ref_mesure_dispositif_asp') }} as disp
+    on sorties.af_mesure_dispositif_code = disp.af_mesure_dispositif_code
+where
+    sorties.rcs_libelle != 'Retrait des sorties constatées' and disp.type_structure_emplois in ('EITI')
+group by
+    {{ pilo_star(ref('sorties_v2'), relation_alias="sorties",
+    except=["emi_nb_heures_travail", "emi_sme_version", "af_id_annexe_financiere", "emi_afi_id", "emi_sme_annee", "emi_sme_mois"]) }},
+    disp.type_structure,
+    disp.type_structure_emplois


### PR DESCRIPTION
**Carte Notion : ** [Etude technique sorties](https://www.notion.so/plateforme-inclusion/Suivi-des-cartes-b3082fffe3f34eaea8fff8ba69338005?p=f6420279061a4812a321343fb1d1ceda&pm=c
)
### Pourquoi ?

Afin de permettre aux DDETS/DREETS/SIAE de piloter leur activité, création d'une table permettant de calculer le nombre de sorties par SIAE

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

