### PR TITLE
Ajout de la structure dernière embauche sur le tb taux de transformation

### DIFF
--- a/dbt/models/marts/delai_1ere_candidature_embauche.sql
+++ b/dbt/models/marts/delai_1ere_candidature_embauche.sql
@@ -20,6 +20,7 @@ with date_1ere_candidature as (
         date_embauche,
         origine,
         "origine_détaillée",
+        candidats."type_structure_dernière_embauche",
         id_org_prescripteur,
         min(date_candidature)       as date_1ere_candidature,
         min(
@@ -40,6 +41,7 @@ with date_1ere_candidature as (
         date_embauche,
         origine,
         "origine_détaillée",
+        candidats."type_structure_dernière_embauche",
         id_org_prescripteur
 ),
 
@@ -61,6 +63,7 @@ select
     "origine_détaillée",
     id_org_prescripteur,
     "nom_département_prescripteur",
+    "type_structure_dernière_embauche",
     case
         /* Division /30 pour passer du nombre de jour au mois */
         when ((date_1ere_embauche - date_1ere_candidature) / 30) < 1 then 'a- Moins d un mois'

--- a/dbt/models/marts/properties.yml
+++ b/dbt/models/marts/properties.yml
@@ -117,3 +117,8 @@ models:
     description: >
       Ce modèle python permet de calculer les visiteurs anciens et nouveaux chaque semaine à partir de la table suivi_visites_tb_prive_semaine.
       Il permet de calculer la rétention des utilisateurs sur les tableaux de bords privés.
+  - name: taux_transformation_prescripteurs
+    description: >
+      Contient le nombre d'acceptations par candidat et par prescripteur pour permettre le calcul du taux de transformation par prescripteur.
+  - name: delai_1ere_candidature_embauche
+      Contient pour chaque candidat le délai entre sa première candidature et l'embauche.

--- a/dbt/models/marts/taux_transformation_prescripteurs.sql
+++ b/dbt/models/marts/taux_transformation_prescripteurs.sql
@@ -26,6 +26,7 @@ with candidats_p as (
         cdd.type_inscription,
         cdd.injection_ai,
         cdd.pe_inscrit,
+        cdd."type_structure_dernière_embauche",
         case
             /* On soustrait 6 mois à la date de diagnostic pour déterminer s'il est toujours en cours ou pas */
             when date_diagnostic >= date_trunc('month', current_date) - interval '5 months' then 'Oui'
@@ -70,6 +71,7 @@ select
     type_inscription,
     pe_inscrit,
     injection_ai,
+    "type_structure_dernière_embauche",
     case
         /* ajout d'une colonne permettant de calculer le taux de candidats acceptées tout en faisant une jointure avec la table candidatures */
         when total_embauches > 0 then concat(cast(id_candidat as varchar), '_accepté')


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/TB169-Taux-de-transformation-ajouter-donn-es-plus-fines-sur-les-structures-58fb7fe40c404006be246bb5e2661205?pvs=4

### Pourquoi ?

Permettre l'ajout d'un filtre sur le taux de transformation.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

