### PR TITLE
Création d'une table contenant les informations sur les structures et prescripteurs faisant des demandes de prolongation

### DIFF
--- a/dbt/models/_sources.yml
+++ b/dbt/models/_sources.yml
@@ -51,6 +51,7 @@ sources:
       - name: pass_agréments
       - name: structures
       - name: utilisateurs
+      - name: demandes_de_prolongation
 
   - name: oneshot
     schema: public

--- a/dbt/models/marts/properties.yml
+++ b/dbt/models/marts/properties.yml
@@ -135,3 +135,6 @@ models:
     description: >
       Cette table nous permet d'obtenir une vue mensuelle du conventionnement ET de la consommation en etp des différentes structures de l'IAE.
       Grâce à cette table nous pouvons réaliser des indicateurs suivant sur le même plot les conventionnements et consommation mois par mois de toutes les structures quelle que soit leur durée de conventionnement.
+  - name: suivi_demandes_prolongations
+    description: >
+      Cette table permet de suivre les demandes de prolongation. Sa création est nécessaire afin d'identifier le type de prescipteur traitant la prolongation ainsi que les demandes gérées par ces derniers.

--- a/dbt/models/marts/suivi_demandes_prolongations.sql
+++ b/dbt/models/marts/suivi_demandes_prolongations.sql
@@ -1,0 +1,17 @@
+select
+    /* TODO(ypassa): change pilo_star to dbt_utils.star once Victor's PR will be merged */
+    {{ pilo_star(source('emplois','demandes_de_prolongation'), relation_alias='ddp') }},
+    o.nom               as nom_prescripteur,
+    o.type_complet      as type_prescripteur,
+    o."nom_département" as "département_prescripteur",
+    o."région"          as "région_prescripteur",
+    s.nom               as nom_structure,
+    s.nom_complet       as nom_complet_structure,
+    s.type              as type_structure,
+    s."nom_département" as "département_structure",
+    s."région"          as "région_structure"
+from {{ source('emplois', 'demandes_de_prolongation') }} as ddp
+left join {{ source('emplois', 'organisations') }} as o
+    on ddp.id_organisation_prescripteur = o.id
+left join {{ source('emplois', 'structures') }} as s
+    on ddp."id_structure_déclarante" = s.id


### PR DESCRIPTION
**Carte Notion : ** [Tableau de bord de pilotage des demandes de prolongation](https://www.notion.so/plateforme-inclusion/Suivi-des-cartes-b3082fffe3f34eaea8fff8ba69338005?p=4327e4e093ba45db91bb0b1df6c13ee9&pm=c)

### Pourquoi ?

Afin de créer les indicateurs demandés par le métier, création d'une table contenant les informations sur les structures et prescripteurs faisant des demandes de prolongation.

A noter qu'une colonne calculant le délai entre la demande et son acceptation/refus sera créée dès que l'information sera présente dans la table source. 

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

