### PR TITLE
Ajout de l'ID ASP des SIAE

### DIFF
--- a/dbt/models/marts/suivi_realisation_convention_mensuelle.sql
+++ b/dbt/models/marts/suivi_realisation_convention_mensuelle.sql
@@ -10,6 +10,7 @@ select
     etp_c.duree_annexe,
     etp_c."effectif_mensuel_conventionné",
     etp_c."effectif_annuel_conventionné",
+    etp_c.structure_id_siae,
     etp_c.type_structure,
     etp_c.structure_denomination,
     etp_c.commune_structure,


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Ajout de l'ID ASP des SIAE, absent d'une table.

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

