### PR TITLE
Ajout d'informations de l'orga prescriptrice sur la table candidats odc

### DIFF
--- a/dbt/models/marts/candidats_odc.sql
+++ b/dbt/models/marts/candidats_odc.sql
@@ -1,5 +1,9 @@
-select distinct {{ pilo_star(source('emplois', 'candidats'), relation_alias="cdd") }}
+select distinct
+    {{ pilo_star(source('emplois', 'candidats'), relation_alias='cdd') }},
+    candidatures_odc.dept_org_prescripteur,
+    candidatures_odc.nom_dept_org_prescripteur,
+    candidatures_odc.region_dept_org_prescripteur,
+    candidatures_odc.nom_org_prescripteur
 from {{ source('emplois', 'candidats') }} as cdd
 inner join
-    {{ ref('candidatures_odc') }} as candidatures_odc
-    on cdd.id = candidatures_odc.id_candidat
+    {{ ref('candidatures_odc') }} as candidatures_odc on cdd.id = candidatures_odc.id_candidat


### PR DESCRIPTION
### Pourquoi ?

permettre de connecter les filtres localisation de l'organisation sur le TB 330

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

