### PR TITLE
Ajout d'une colonne reprise de stock AI pour le suivi des prolongations

### DIFF
--- a/dbt/models/marts/properties.yml
+++ b/dbt/models/marts/properties.yml
@@ -138,3 +138,6 @@ models:
   - name: suivi_demandes_prolongations
     description: >
       Cette table permet de suivre les demandes de prolongation. Sa création est nécessaire afin d'identifier le type de prescipteur traitant la prolongation ainsi que les demandes gérées par ces derniers.
+    tests:
+      - dbt_utils.equal_rowcount:
+          compare_model: source('emplois', 'demandes_de_prolongation')


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

A la demande du métier ajout d'une colonne reprise de stock AI pour le suivi des prolongations

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

