### PR TITLE
ajout des filtres nouveaux vs anciens prescripteurs

### DIFF
--- a/dbt/models/marts/candidatures_echelle_locale.sql
+++ b/dbt/models/marts/candidatures_echelle_locale.sql
@@ -1,6 +1,6 @@
 select
     {{ pilo_star(ref('stg_candidatures'), relation_alias='candidatures') }},
-    {{ pilo_star(ref('stg_org_prescripteur'), except=["id_org"], relation_alias='org_prescripteur') }},
+    {{ pilo_star(ref('stg_organisations'), except=["id", "date_mise_à_jour_metabase", "ville", "code_commune"], relation_alias='org_prescripteur') }},
     {{ pilo_star(ref('stg_bassin_emploi'), except=["nom_departement", "nom_region", "type_epci", "id_structure"],
     relation_alias='bassin_emploi') }},
     case
@@ -16,8 +16,8 @@ from
     {{ ref('stg_candidatures') }} as candidatures
 left join {{ ref('stg_bassin_emploi') }} as bassin_emploi
     on bassin_emploi.id_structure = candidatures.id_structure
-left join {{ ref('stg_org_prescripteur') }} as org_prescripteur
-    on org_prescripteur.id_org = candidatures.id_org_prescripteur
+left join {{ ref('stg_organisations') }} as org_prescripteur
+    on org_prescripteur.id = candidatures.id_org_prescripteur
 left join {{ ref('nom_prescripteur') }} as nom_org
     on nom_org.origine_detaille = candidatures."origine_détaillée"
 left join {{ ref('candidats_enriched') }} as candidats

--- a/dbt/models/marts/organisations_enriched.sql
+++ b/dbt/models/marts/organisations_enriched.sql
@@ -1,0 +1,4 @@
+select
+    {{ pilo_star(ref('stg_organisations')) }}
+from
+    {{ ref('stg_organisations') }}

--- a/dbt/models/marts/taux_transformation_prescripteurs.sql
+++ b/dbt/models/marts/taux_transformation_prescripteurs.sql
@@ -26,7 +26,6 @@ with candidats_p as (
         cdd.type_inscription,
         cdd.injection_ai,
         cdd.pe_inscrit,
-        cdd."type_structure_dernière_embauche",
         case
             /* On soustrait 6 mois à la date de diagnostic pour déterminer s'il est toujours en cours ou pas */
             when date_diagnostic >= date_trunc('month', current_date) - interval '5 months' then 'Oui'
@@ -36,23 +35,13 @@ with candidats_p as (
         {{ source('emplois', 'candidats') }} as cdd /* cdd pour CanDiDats */
     where
         type_auteur_diagnostic = ('Prescripteur')
-),
-
-prescripteurs as (
-    select
-        id,
-        "nom_département" as "nom_département_prescripteur",
-        /* Ajout du département du prescripteur pour les TBs privés */
-        "région"          as "nom_région_prescripteur"
-    from
-        {{ source('emplois', 'organisations') }}
 )
 
 select
     /* On selectionne les colonnes finales qui nous intéressent */
     id_candidat,
     /* TODO dejafait drop as soon as analistos have migrated to the new deanonymized column */
-    id_candidat_anonymise as id_candidat_anonymise,
+    id_candidat_anonymise           as id_candidat_anonymise,
     actif,
     age,
     date_diagnostic,
@@ -63,56 +52,24 @@ select
     type_auteur_diagnostic,
     nom_auteur_diagnostic,
     id_org_prescripteur,
-    "nom_département_prescripteur",
-    "nom_région_prescripteur",
-    total_candidatures,
-    total_diagnostics,
-    total_embauches,
+    candidats_p.total_candidatures,
+    candidats_p.total_diagnostics,
+    candidats_p.total_embauches,
     type_inscription,
     pe_inscrit,
     injection_ai,
-    "type_structure_dernière_embauche",
+    organisations_libelles.libelle  as type_auteur_diagnostic_detaille,
+    prescripteurs.type_prescripteur as type_prescripteur,
+    prescripteurs."nom_département" as "nom_département_prescripteur",
+    prescripteurs."région"          as "nom_région_prescripteur",
     case
         /* ajout d'une colonne permettant de calculer le taux de candidats acceptées tout en faisant une jointure avec la table candidatures */
-        when total_embauches > 0 then concat(cast(id_candidat as varchar), '_accepté')
-    end                   as "candidature_acceptée",
-    case
-        /* Modification des noms pour plus de clarté */
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur AFPA' then 'AFPA - Agence nationale pour la formation professionnelle des adultes'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur ASE' then 'ASE - Aide sociale à l''enfance'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur Autre' then 'Autre'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CAARUD' then 'CAARUD - Centre d''accueil et d''accompagnement à la réduction de risques pour usagers de drogues'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CADA' then 'CADA - Centre d''accueil de demandeurs d''asile'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CAF' then 'CAF - Caisse d''allocations familiales'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CAP_EMPLOI' then 'CAP emploi'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CAVA' then 'ACAVA - Centre d''adaptation à la vie active'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CCAS' then 'CCAS - Centre communal d''action sociale ou centre intercommunal d''action sociale'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CHRS' then 'CHRS - Centre d''hébergement et de réinsertion sociale'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CHU' then 'CHU - Centre d''hébergement d''urgence'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CIDFF' then 'CIDFF - Centre d''information sur les droits des femmes et des familles'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CPH' then 'CPH - Centre provisoire d''hébergement'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur CSAPA' then 'CSAPA - Centre de soins, d''accompagnement et de prévention en addictologie'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur DEPT' then 'Service social du conseil départemental'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur E2C' then 'E2C - École de la deuxième chance'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur EPIDE' then 'EPIDE - Établissement pour l''insertion dans l''emploi'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur HUDA' then 'HUDA - Hébergement d''urgence pour demandeurs d''asile'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur ML' then 'Mission Locale'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur MSA' then 'MSA - Mutualité Sociale Agricole'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur None' then 'Autre'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur OACAS' then 'OACAS - Structure porteuse d''un agrément national organisme d''accueil communautaire et d''activité solidaire'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur ODC' then 'Organisation délégataire d''un CD'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur OIL' then 'Opérateur d''intermédiation locative'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur PE' then 'Pôle emploi'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur PENSION' then 'Pension de famille / résidence accueil'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur PIJ_BIJ' then 'PIJ-BIJ - Point/Bureau information jeunesse'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur PJJ' then 'PJJ - Protection judiciaire de la jeunesse'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur PLIE' then 'PLIE - Plan local pour l''insertion et l''emploi'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur PREVENTION' then 'Service ou club de prévention'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur RS_FJT' then 'Résidence sociale / FJT - Foyer de Jeunes Travailleurs'
-        when candidats_p.sous_type_auteur_diagnostic = 'Prescripteur SPIP' then 'SPIP - Service pénitentiaire d''insertion et de probation'
-    end                   as type_auteur_diagnostic_detaille
+        when candidats_p.total_embauches > 0 then concat(cast(id_candidat as varchar), '_accepté')
+    end                             as "candidature_acceptée"
 from
     candidats_p
-left join prescripteurs
+left join {{ ref('stg_organisations') }} as prescripteurs
     on
         prescripteurs.id = candidats_p.id_org_prescripteur
+left join {{ ref('organisations_libelles') }} as organisations_libelles
+    on candidats_p.sous_type_auteur_diagnostic = concat('Prescripteur ', organisations_libelles.type)


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/REX-Utilisateur-Ajouter-un-niveau-de-filtre-suppl-mentaire-par-type-de-prescripteur-8261c1c366514b9cb736323883e894e2?pvs=4

### Pourquoi ?

Pour pouvoir distinguer les prescripteurs historiques des nouveaux sur 3 tableaux de bord : 

- TB136 “Taux de transformation”
- TB52 “Zoom prescripteurs” 
- TB116 “Etat et suivi des candidatures orientées”

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

