### PR TITLE
Retrait des doublons introduits dans la table etp_par_genre

### DIFF
--- a/dbt/models/indexed/fluxIAE_Salarie_v2.sql
+++ b/dbt/models/indexed/fluxIAE_Salarie_v2.sql
@@ -5,7 +5,7 @@
     ]
  ) }}
 
-select
-    {{ pilo_star(source('fluxIAE', 'fluxIAE_Salarie')) }}
+select distinct
+    {{ pilo_star(source('fluxIAE', 'fluxIAE_Salarie'), except=["hash_numéro_pass_iae"]) }}
 from
     {{ source('fluxIAE', 'fluxIAE_Salarie') }}


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Retrait des doublons introduits dans la table etp_par_genre

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

