### PR TITLE
Calcul du delta des ETPs conventionnés et réalisés par structure 

### DIFF
--- a/dbt/models/marts/properties.yml
+++ b/dbt/models/marts/properties.yml
@@ -154,3 +154,7 @@ models:
   - name: nps_hebdo_reco_hebdo_par_tb
     description: >
       Table permettant le suivi du nps de tous les tbs du pilotage à partir de la table suivi_satisfaction.
+  - name: suivi_realisation_convention_par_structure
+    description: >
+      Table permettant de suivre par id d'annexe financiere (i.e. par structure et par an) les etps conventionnés, réalisés et la différence entre ces derniers.
+      Le delta calculé ici permet de calculer un % de réalisation sur les états mensuels validés très utile au pilotage de l'activité des structures effectuée par les réseaux.

--- a/dbt/models/marts/suivi_realisation_convention_par_structure.sql
+++ b/dbt/models/marts/suivi_realisation_convention_par_structure.sql
@@ -1,0 +1,29 @@
+select
+    etp.id_annexe_financiere,
+    etp.emi_esm_etat_code,
+    etp.annee_af,
+    etp.type_structure,
+    etp.structure_denomination,
+    etp.commune_structure,
+    etp.code_insee_structure,
+    etp.siret_structure,
+    etp.code_departement_af,
+    etp.nom_departement_af,
+    etp.nom_region_af,
+    sum(etp."effectif_mensuel_conventionné" - etp.nombre_etp_consommes_reels_mensuels)
+    as delta_etp_conventionnes_realises,
+    sum(etp.nombre_etp_consommes_reels_mensuels)
+    as somme_etp_realises
+from {{ ref('suivi_realisation_convention_mensuelle') }} as etp
+group by
+    etp.id_annexe_financiere,
+    etp.emi_esm_etat_code,
+    etp.annee_af,
+    etp.type_structure,
+    etp.structure_denomination,
+    etp.commune_structure,
+    etp.code_insee_structure,
+    etp.siret_structure,
+    etp.code_departement_af,
+    etp.nom_departement_af,
+    etp.nom_region_af


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Afin de créer un indicateur très utile dans le pilotage des ETPs par les réseaux, il est nécessaire de calculer le delta entre etps conventionnés et réalisés par structure. 

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

