### PR TITLE
Ajout de l'âge d'une demande de prolongation

### DIFF
--- a/dbt/models/marts/suivi_demandes_prolongations.sql
+++ b/dbt/models/marts/suivi_demandes_prolongations.sql
@@ -14,7 +14,8 @@ select
         else 'Oui'
     end                                                 as reprise_de_stock_ai,
     /* delai_traitement is in days*/
-    (prolong.date_traitement - prolong.date_de_demande) as delai_traitement
+    (prolong.date_traitement - prolong.date_de_demande) as delai_traitement,
+    (current_date - prolong.date_de_demande)            as duree_depuis_demande
 from {{ source('emplois', 'demandes_de_prolongation') }} as prolong
 left join {{ ref('stg_organisations') }} as o
     on prolong.id_organisation_prescripteur = o.id


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

A la demande des réseaux, ajout de la demande de l'âge d'une demande pour suivre une demande de prolongation sans réponse depuis + de 30j

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

