### PR TITLE
Refonte de la table suivi_demandes_prolongations

### DIFF
--- a/dbt/models/marts/properties.yml
+++ b/dbt/models/marts/properties.yml
@@ -149,10 +149,10 @@ models:
       Grâce à cette table nous pouvons réaliser des indicateurs suivant sur le même plot les conventionnements et consommation mois par mois de toutes les structures quelle que soit leur durée de conventionnement.
   - name: suivi_demandes_prolongations
     description: >
-      Cette table permet de suivre les demandes de prolongation. Sa création est nécessaire afin d'identifier le type de prescipteur traitant la prolongation ainsi que les demandes gérées par ces derniers.
-    tests:
-      - dbt_utils.equal_rowcount:
-          compare_model: source('emplois', 'prolongations')
+      Cette table permet de suivre toutes les demandes de prolongation (passant ou pas par les prescipteurs habilités).
+      Sa création est nécessaire afin d'identifier les SIAE ainsi que les types de prescipteur traitant la prolongation ainsi que les demandes gérées par ces derniers.
+      Cette table est une union entre une vue regroupant les demandes/prolongations acceptées et une vue regroupant les demandes non acceptées.
+      Cette union est nécessaire car l'architecture des tables prolongations et demandes_de_prolongation ne permettent pas une jointure simple.
   - name: candidats_prescripteurs_habilites
     description: >
       Table permettant de suivre les candidats qui ont été diagnostiqués par des prescripteurs habilités et d'avoir des infos sur leur diagnostic.

--- a/dbt/models/marts/suivi_demandes_prolongations.sql
+++ b/dbt/models/marts/suivi_demandes_prolongations.sql
@@ -1,36 +1,9 @@
 select
-    {{ pilo_star(source('emplois','prolongations'), relation_alias='prolong') }},
-    demandes_prolong.motif                                                as motif_demande,
-    demandes_prolong."état",
-    demandes_prolong.date_de_demande,
-    demandes_prolong.date_traitement,
-    demandes_prolong.date_envoi_rappel,
-    o.nom                                                                 as nom_prescripteur,
-    o.type_complet                                                        as type_prescripteur,
-    o."nom_département"                                                   as "département_prescripteur",
-    o."région"                                                            as "région_prescripteur",
-    s.nom                                                                 as nom_structure,
-    s.nom_complet                                                         as nom_complet_structure,
-    s.type                                                                as type_structure,
-    s."nom_département"                                                   as "département_structure",
-    s."région"                                                            as "région_structure",
-    case
-        when pass.injection_ai = 0 then 'Non'
-        else 'Oui'
-    end                                                                   as reprise_de_stock_ai,
-    /* delai_traitement is in days*/
-    (demandes_prolong.date_traitement - demandes_prolong.date_de_demande) as delai_traitement,
-    (current_date - demandes_prolong.date_de_demande)                     as duree_depuis_demande
-from {{ source('emplois', 'prolongations') }} as prolong
-left join {{ source('emplois', 'demandes_de_prolongation') }} as demandes_prolong
-    on prolong.id = demandes_prolong.id_prolongation
-left join {{ ref('stg_organisations') }} as o
-    on prolong.id_organisation_prescripteur = o.id
-left join {{ source('emplois', 'structures') }} as s
-    on prolong."id_structure_déclarante" = s.id
-left join {{ source('emplois', 'pass_agréments') }} as pass
-    on prolong."id_pass_agrément" = pass.id
-/* Sometimes you find duplicates, in the pass_agréments table, either on the id
-or hash_pass_iae. The "bad" duplicate always never has an id_candidat.
-Therefore we can remove these duplicate by filtering them */
-where pass.id_candidat is not null
+    {{ pilo_star(ref('stg_suivi_demandes_prolongations_acceptees')) }}
+from
+    {{ ref('stg_suivi_demandes_prolongations_acceptees') }}
+union all
+select
+    {{ pilo_star(ref('stg_suivi_demandes_prolongations_non_acceptees')) }}
+from
+    {{ ref('stg_suivi_demandes_prolongations_non_acceptees') }}

--- a/dbt/models/staging/properties.yml
+++ b/dbt/models/staging/properties.yml
@@ -114,3 +114,12 @@ models:
   - name: stg_test_suivi_etp_realises_par_structure
     description: >
       Vue permettant de tester le nombre de lignes de la table suivi_etp_realises_par_structure.
+  - name: stg_suivi_demandes_prolongations_acceptees
+    description: >
+      Vue permettant de récupérer les demandes de prolongation & prolongations acceptées
+    tests:
+      - dbt_utils.equal_rowcount:
+          compare_model: source('emplois', 'prolongations')
+  - name: stg_suivi_demandes_prolongations_non_acceptees
+    description: >
+      Vue permettant de récupérer les demandes de prolongation non acceptées

--- a/dbt/models/staging/stg_suivi_demandes_prolongations_acceptees.sql
+++ b/dbt/models/staging/stg_suivi_demandes_prolongations_acceptees.sql
@@ -1,0 +1,38 @@
+select
+    prolong."id_pass_agrément",
+    prolong."date_début",
+    prolong.date_fin,
+    prolong.motif,
+    'Acceptée'                                                            as "état",
+    demandes_prolong.date_de_demande,
+    demandes_prolong.date_traitement,
+    demandes_prolong.date_envoi_rappel,
+    o.nom                                                                 as nom_prescripteur,
+    o.type_complet                                                        as type_prescripteur,
+    o."nom_département"                                                   as "département_prescripteur",
+    o."région"                                                            as "région_prescripteur",
+    s.nom                                                                 as nom_structure,
+    s.nom_complet                                                         as nom_complet_structure,
+    s.type                                                                as type_structure,
+    s."nom_département"                                                   as "département_structure",
+    s."région"                                                            as "région_structure",
+    case
+        when pass.injection_ai = 0 then 'Non'
+        else 'Oui'
+    end                                                                   as reprise_de_stock_ai,
+    /* delai_traitement is in days*/
+    (demandes_prolong.date_traitement - demandes_prolong.date_de_demande) as delai_traitement,
+    (current_date - demandes_prolong.date_de_demande)                     as duree_depuis_demande
+from {{ source('emplois', 'prolongations') }} as prolong
+left join {{ source('emplois', 'demandes_de_prolongation') }} as demandes_prolong
+    on prolong.id = demandes_prolong.id_prolongation
+left join {{ ref('stg_organisations') }} as o
+    on prolong.id_organisation_prescripteur = o.id
+left join {{ source('emplois', 'structures') }} as s
+    on prolong."id_structure_déclarante" = s.id
+left join {{ source('emplois', 'pass_agréments') }} as pass
+    on prolong."id_pass_agrément" = pass.id
+/* Sometimes you find duplicates, in the pass_agréments table, either on the id
+or hash_pass_iae. The "bad" duplicate always never has an id_candidat.
+Therefore we can remove these duplicate by filtering them */
+where pass.id_candidat is not null

--- a/dbt/models/staging/stg_suivi_demandes_prolongations_non_acceptees.sql
+++ b/dbt/models/staging/stg_suivi_demandes_prolongations_non_acceptees.sql
@@ -1,0 +1,36 @@
+select
+    demandes_prolong."id_pass_agrément",
+    demandes_prolong."date_début",
+    demandes_prolong.date_fin,
+    demandes_prolong.motif,
+    demandes_prolong."état",
+    demandes_prolong.date_de_demande,
+    demandes_prolong.date_traitement,
+    demandes_prolong.date_envoi_rappel,
+    o.nom                                                                 as nom_prescripteur,
+    o.type_complet                                                        as type_prescripteur,
+    o."nom_département"                                                   as "département_prescripteur",
+    o."région"                                                            as "région_prescripteur",
+    s.nom                                                                 as nom_structure,
+    s.nom_complet                                                         as nom_complet_structure,
+    s.type                                                                as type_structure,
+    s."nom_département"                                                   as "département_structure",
+    s."région"                                                            as "région_structure",
+    case
+        when pass.injection_ai = 0 then 'Non'
+        else 'Oui'
+    end                                                                   as reprise_de_stock_ai,
+    /* delai_traitement is in days*/
+    (demandes_prolong.date_traitement - demandes_prolong.date_de_demande) as delai_traitement,
+    (current_date - demandes_prolong.date_de_demande)                     as duree_depuis_demande
+from {{ source('emplois', 'demandes_de_prolongation') }} as demandes_prolong
+left join {{ ref('stg_organisations') }} as o
+    on demandes_prolong.id_organisation_prescripteur = o.id
+left join {{ source('emplois', 'structures') }} as s
+    on demandes_prolong."id_structure_déclarante" = s.id
+left join {{ source('emplois', 'pass_agréments') }} as pass
+    on demandes_prolong."id_pass_agrément" = pass.id
+/* Sometimes you find duplicates, in the pass_agréments table, either on the id
+or hash_pass_iae. The "bad" duplicate always never has an id_candidat.
+Therefore we can remove these duplicate by filtering them */
+where pass.id_candidat is not null and demandes_prolong."état" != 'Acceptée'


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?
La table `prolongations` et `demandes_de_prolongation` sont faites d'une certaine façon qui rend la jointure entre les deux tables compliquée.

Afin de pouvoir prendre en compte toutes les prolongations ET les demandes il était nécessaire de refaire la table suivi_demandes_prolongations en utilisant des UNION


### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

