### PR TITLE
Création de la table permettant de suivre l'utilisation des tb prives de tous les utilisateurs inscrits sur les emplois

### DIFF
--- a/dbt/models/marts/properties.yml
+++ b/dbt/models/marts/properties.yml
@@ -167,3 +167,9 @@ models:
   - name: nb_utilisateurs_potentiels
     description: >
       Table pour le suivi des statistiques de pilotage en interne : pour chaque cible, donne le nb d'utilisateurs potentiels des TBs.
+  - name: utilisateurs_jamais_venus
+    description: >
+      Table permettant de récupérer les mails des utilisateurs ne s'étant jamais connectés sur les tb prives. A ce jour impossible de savoir à quelle orga cette utilisateur est rattaché mais cela arrive dans une v2.
+    tests:
+    - dbt_utils.equal_rowcount:
+        compare_model: source('emplois', 'utilisateurs')

--- a/dbt/models/marts/utilisateurs_jamais_venus.sql
+++ b/dbt/models/marts/utilisateurs_jamais_venus.sql
@@ -1,0 +1,19 @@
+select
+    utilisateurs_all.email,
+    utilisateurs_all.type,
+    case
+        when array_agg(nom_tb) = array[null] then null
+        else array_agg(nom_tb)
+    end as tb_visited,
+    case
+        when array_agg(nom_tb) = array[null] then 0
+        else array_length(array_agg(nom_tb), 1)
+    end as nb_tb_visited
+from
+    {{ source('emplois', 'utilisateurs') }} as utilisateurs_all
+left join
+    {{ ref('suivi_utilisateurs_tb_prive_semaine') }} as utilisateurs_tb_prives
+    on utilisateurs_tb_prives.email_utilisateur = utilisateurs_all.email
+group by
+    utilisateurs_all.email,
+    utilisateurs_all.type


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Utilisateurs-jamais-venus-sur-les-tableaux-de-bords-326a89b811e046ffa191ad5aecdb7fbb?pvs=4

### Pourquoi ?

création d'une table permettant de récupérer les emails des utilisateurs n'étant jamais venus sur les tableaux de bord privé en vue de cibler les contacts pour actions de déploiement.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

