### PR TITLE
Ajout de la colonne genre du candidat à la table candidature

### DIFF
--- a/dbt/models/legacy/metier_candidatures.sql
+++ b/dbt/models/legacy/metier_candidatures.sql
@@ -1,6 +1,5 @@
 select
     cel.*,
-    cand.sexe_selon_nir,
     crdp."grand_domaine" as metier,
     fdp."nom_rome"       as nom_rome,
     crdp."code_rome"     as code_rome

--- a/dbt/models/marts/candidatures_echelle_locale.sql
+++ b/dbt/models/marts/candidatures_echelle_locale.sql
@@ -11,6 +11,7 @@ select
     candidats.eligibilite_dispositif,
     candidats.tranche_age,
     candidats.eligible_cej,
+    candidats.sexe_selon_nir          as genre_candidat,
     candidats.eligible_cdi_inclusion,
     candidats.date_inscription        as date_inscription_candidat,
     org_prescripteur.date_inscription as date_inscription_orga


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Cr-er-une-table-pour-les-indicateurs-du-TB-genre-o-les-jointures-sont-faites-directement-sur-metaba-09130d84066747d69e084697dcd3d6aa?pvs=4

### Pourquoi ?

refacto tu tableau de bord genre pour éviter les jointures metabase et donc accélerer le temps de chargement


### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

