### PR TITLE
Ajout du diag du candidat sur candidatures et metiers_candidatures

### DIFF
--- a/dbt/models/marts/candidatures_echelle_locale.sql
+++ b/dbt/models/marts/candidatures_echelle_locale.sql
@@ -2,19 +2,21 @@ select
     {{ pilo_star(ref('stg_candidatures'), relation_alias='candidatures') }},
     {{ pilo_star(ref('stg_organisations'), except=["id", "date_mise_à_jour_metabase", "ville", "code_commune", "type", "date_inscription", "total_candidatures", "total_membres", "total_embauches", "date_derniere_candidature"], relation_alias='org_prescripteur') }},
     {{ pilo_star(ref('stg_bassin_emploi'), except=["nom_departement", "nom_region", "type_epci", "id_structure"], relation_alias='bassin_emploi') }},
-    org_prescripteur.type             as type_org_prescripteur,
+    org_prescripteur.type                 as type_org_prescripteur,
     case
         when candidatures.injection_ai = 0 then 'Non'
         else 'Oui'
-    end                               as reprise_de_stock_ai,
+    end                                   as reprise_de_stock_ai,
     nom_org.type_auteur_diagnostic_detaille,
+    candidats.sous_type_auteur_diagnostic as auteur_diag_candidat,
+    candidats.type_auteur_diagnostic      as auteur_diag_candidat_detaille,
     candidats.eligibilite_dispositif,
     candidats.tranche_age,
     candidats.eligible_cej,
-    candidats.sexe_selon_nir          as genre_candidat,
+    candidats.sexe_selon_nir              as genre_candidat,
     candidats.eligible_cdi_inclusion,
-    candidats.date_inscription        as date_inscription_candidat,
-    org_prescripteur.date_inscription as date_inscription_orga
+    candidats.date_inscription            as date_inscription_candidat,
+    org_prescripteur.date_inscription     as date_inscription_orga
 from
     {{ ref('stg_candidatures') }} as candidatures
 left join {{ ref('stg_bassin_emploi') }} as bassin_emploi


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Cr-er-une-table-pour-les-indicateurs-du-TB-genre-o-les-jointures-sont-faites-directement-sur-metaba-09130d84066747d69e084697dcd3d6aa?pvs=4

### Pourquoi ?

Ajout du diag du candidat pour faire fonctionner les filtres du tb genre

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

