### PR TITLE
Correction du cast

### DIFF
--- a/dbt/models/staging/stg_suivi_demandes_prolongations_acceptees.sql
+++ b/dbt/models/staging/stg_suivi_demandes_prolongations_acceptees.sql
@@ -17,8 +17,8 @@ select
     s."nom_département"                                                        as "département_structure",
     s."région"                                                                 as "région_structure",
     prolong."date_de_création",
+    cast((demandes_prolong.date_traitement - demandes_prolong.date_de_demande) as int) as delai_traitement,
     demandes_prolong.motif_de_refus,
-    (demandes_prolong.date_traitement - demandes_prolong.date_de_demande)::int as delai_traitement,
     case
         when pass.injection_ai = 0 then 'Non'
         else 'Oui'

--- a/dbt/models/staging/stg_suivi_demandes_prolongations_acceptees.sql
+++ b/dbt/models/staging/stg_suivi_demandes_prolongations_acceptees.sql
@@ -3,28 +3,28 @@ select
     prolong."date_début",
     prolong.date_fin,
     prolong.motif,
-    'Acceptée'                                                                 as "état",
+    'Acceptée'                                                                         as "état",
     demandes_prolong.date_de_demande,
     demandes_prolong.date_traitement,
     demandes_prolong.date_envoi_rappel,
-    o.nom                                                                      as nom_prescripteur,
-    o.type_complet                                                             as type_prescripteur,
-    o."nom_département"                                                        as "département_prescripteur",
-    o."région"                                                                 as "région_prescripteur",
-    s.nom                                                                      as nom_structure,
-    s.nom_complet                                                              as nom_complet_structure,
-    s.type                                                                     as type_structure,
-    s."nom_département"                                                        as "département_structure",
-    s."région"                                                                 as "région_structure",
+    o.nom                                                                              as nom_prescripteur,
+    o.type_complet                                                                     as type_prescripteur,
+    o."nom_département"                                                                as "département_prescripteur",
+    o."région"                                                                         as "région_prescripteur",
+    s.nom                                                                              as nom_structure,
+    s.nom_complet                                                                      as nom_complet_structure,
+    s.type                                                                             as type_structure,
+    s."nom_département"                                                                as "département_structure",
+    s."région"                                                                         as "région_structure",
     prolong."date_de_création",
     cast((demandes_prolong.date_traitement - demandes_prolong.date_de_demande) as int) as delai_traitement,
     demandes_prolong.motif_de_refus,
     case
         when pass.injection_ai = 0 then 'Non'
         else 'Oui'
-    end                                                                        as reprise_de_stock_ai,
+    end                                                                                as reprise_de_stock_ai,
     /* we fill the null values with a -100 value in order to avoid some metabase problems */
-    (current_date - demandes_prolong.date_de_demande)                          as duree_depuis_demande
+    (current_date - demandes_prolong.date_de_demande)                                  as duree_depuis_demande
 from {{ source('emplois', 'prolongations') }} as prolong
 left join {{ source('emplois', 'demandes_de_prolongation') }} as demandes_prolong
     on prolong.id = demandes_prolong.id_prolongation

--- a/dbt/models/staging/stg_suivi_demandes_prolongations_non_acceptees.sql
+++ b/dbt/models/staging/stg_suivi_demandes_prolongations_non_acceptees.sql
@@ -17,7 +17,7 @@ select
     s."nom_département"                                                        as "département_structure",
     s."région"                                                                 as "région_structure",
     demandes_prolong.date_de_demande                                           as "date_de_création",
-    (demandes_prolong.date_traitement - demandes_prolong.date_de_demande)::int as delai_traitement,
+    cast((demandes_prolong.date_traitement - demandes_prolong.date_de_demande) as int) as delai_traitement,
     case
         when demandes_prolong.motif_de_refus = 'IAE'
             then 'L IAE ne correspond plus aux besoins / à la situation de la personne'

--- a/dbt/models/staging/stg_suivi_demandes_prolongations_non_acceptees.sql
+++ b/dbt/models/staging/stg_suivi_demandes_prolongations_non_acceptees.sql
@@ -7,16 +7,16 @@ select
     demandes_prolong.date_de_demande,
     demandes_prolong.date_traitement,
     demandes_prolong.date_envoi_rappel,
-    o.nom                                                                      as nom_prescripteur,
-    o.type_complet                                                             as type_prescripteur,
-    o."nom_département"                                                        as "département_prescripteur",
-    o."région"                                                                 as "région_prescripteur",
-    s.nom                                                                      as nom_structure,
-    s.nom_complet                                                              as nom_complet_structure,
-    s.type                                                                     as type_structure,
-    s."nom_département"                                                        as "département_structure",
-    s."région"                                                                 as "région_structure",
-    demandes_prolong.date_de_demande                                           as "date_de_création",
+    o.nom                                                                              as nom_prescripteur,
+    o.type_complet                                                                     as type_prescripteur,
+    o."nom_département"                                                                as "département_prescripteur",
+    o."région"                                                                         as "région_prescripteur",
+    s.nom                                                                              as nom_structure,
+    s.nom_complet                                                                      as nom_complet_structure,
+    s.type                                                                             as type_structure,
+    s."nom_département"                                                                as "département_structure",
+    s."région"                                                                         as "région_structure",
+    demandes_prolong.date_de_demande                                                   as "date_de_création",
     cast((demandes_prolong.date_traitement - demandes_prolong.date_de_demande) as int) as delai_traitement,
     case
         when demandes_prolong.motif_de_refus = 'IAE'
@@ -24,14 +24,14 @@ select
         when demandes_prolong.motif_de_refus = 'SIAE'
             then 'La typologie de SIAE ne correspond plus aux besoins / à la situation de la personne'
         else 'Pas de motif indiqué'
-    end                                                                        as motif_de_refus,
+    end                                                                                as motif_de_refus,
     case
         when pass.injection_ai = 0 then 'Non'
         else 'Oui'
-    end                                                                        as reprise_de_stock_ai,
+    end                                                                                as reprise_de_stock_ai,
     /* delai_traitement is in days*/
     /* we fill the null values with a -100 value in order to avoid some metabase problems */
-    (current_date - demandes_prolong.date_de_demande)                          as duree_depuis_demande
+    (current_date - demandes_prolong.date_de_demande)                                  as duree_depuis_demande
 from {{ source('emplois', 'demandes_de_prolongation') }} as demandes_prolong
 left join {{ ref('stg_organisations') }} as o
     on demandes_prolong.id_organisation_prescripteur = o.id


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Correction du cast, oblige de faire cast (xxxx as int) notre serveur ne gère pas xxx::int (alors qu'en local ça marche...)


### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

