### PR TITLE
Demandes de prolongation : pass ne faisant pas l’objet d’une demande de prolongation

### DIFF
--- a/dbt/models/marts/pass_iae_et_demandes.sql
+++ b/dbt/models/marts/pass_iae_et_demandes.sql
@@ -1,0 +1,11 @@
+select
+    {{ pilo_star(source('emplois','pass_agréments'), relation_alias='pass') }},
+    demandes_prolong."id_pass_agrément",
+    demandes_prolong.motif,
+    demandes_prolong."état",
+    demandes_prolong.date_de_demande
+from
+    {{ source('emplois','pass_agréments') }} as pass
+left join {{ source('emplois', 'demandes_de_prolongation') }} as demandes_prolong
+    on pass.id = demandes_prolong."id_pass_agrément"
+where pass.id_candidat is not null

--- a/dbt/models/marts/properties.yml
+++ b/dbt/models/marts/properties.yml
@@ -172,3 +172,7 @@ models:
     tests:
     - dbt_utils.equal_rowcount:
         compare_model: source('emplois', 'utilisateurs')
+  - name: pass_iae_et_demandes
+    description: >
+      Table permettant de suivre les PASS IAE n'ayant jamais été associés à une demande de prolongation et ceux associés à une (ou plusieurs) demande de prolongation.
+      A noter, le même pass IAE peut avoir deux entrées dans cette table car une demande peut etre refusée, ce qui amène souvent à une nouvelle demande, qui elle peut être acceptée.


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Cr-er-un-indicateur-de-pass-ne-faisant-pas-l-objet-d-une-demande-de-prolongation-9a20e37d9e754e07bfb8d6c7268fff0e

### Pourquoi ?

Parce que nos utilisateurs en ont besoin et qu'on les aime !

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

