### PR TITLE
Remplacement de siae_staff en employer

### DIFF
--- a/dbt/models/marts/suivi_utilisateurs_tb_prive_semaine.sql
+++ b/dbt/models/marts/suivi_utilisateurs_tb_prive_semaine.sql
@@ -6,7 +6,7 @@ select
     visits.region                                                                                           as region,
     case
         when visits.user_kind = 'prescriber' then 'prescripteur'
-        when visits.user_kind = 'siae_staff' then 'siae'
+        when visits.user_kind = 'employer' then 'siae'
         when visits.user_kind = 'labor_inspector' then 'institution'
         when visits.user_kind = 'itou_staff' then 'staff interne'
     end                                                                                                     as type_utilisateur,
@@ -22,7 +22,7 @@ left join {{ ref('metabase_dashboards') }} as metabase_ids
 left join {{ ref('stg_organisations') }} as organisations
     on organisations.id = cast(visits.current_prescriber_organization_id as INTEGER) and visits.user_kind = 'prescriber'
 left join {{ source('emplois', 'structures') }} as structures
-    on structures.id = cast(visits.current_siae_id as INTEGER) and visits.user_kind = 'siae_staff'
+    on structures.id = cast(visits.current_siae_id as INTEGER) and visits.user_kind = 'employer'
 left join {{ source('emplois', 'institutions') }} as institutions
     on institutions.id = cast(visits.current_institution_id as INTEGER) and visits.user_kind = 'labor_inspector'
 left join {{ source('emplois', 'utilisateurs') }} as c1_users


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Suite à une prochaine mep C1 modification, dans nos scripts, de `siae_staff` en `employer`
MEP C1/C2 à coordonner

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

