### PR TITLE
Retrait du filtre PE dans le delai d'embauche

### DIFF
--- a/dbt/models/marts/delai_1ere_candidature_embauche.sql
+++ b/dbt/models/marts/delai_1ere_candidature_embauche.sql
@@ -40,9 +40,6 @@ with date_1ere_candidature as (
     from
         {{ source('emplois', 'candidatures') }} as c
     inner join {{ ref('candidats') }} as candidats on c.id_candidat = candidats.id
-    where
-        c.origine = 'Prescripteur habilité'
-        and c."origine_détaillée" = 'Prescripteur habilité PE'
     group by
         c.id_candidat,
         candidats."nom_département",


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Retrait du filtre PE dans le delai d'embauche afin de proposer cette donnée aux structures

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

