### PR TITLE
Ajout de l'information de première visite sur la table du suivi des utilisateurs des TBs privés

### DIFF
--- a/dbt/models/marts/suivi_utilisateurs_tb_prive_semaine.sql
+++ b/dbt/models/marts/suivi_utilisateurs_tb_prive_semaine.sql
@@ -32,7 +32,7 @@ left join {{ source('emplois', 'institutions') }} as institutions
 left join {{ source('emplois', 'utilisateurs') }} as c1_users
     on c1_users.id = cast(visits.user_id as INTEGER)
 left join {{ ref('stg_premiere_visite') }} as first_visit
-    on visits.user_id = first_visit.user_id
+    on visits.user_id = first_visit.user_id and visits.dashboard_id = first_visit.dashboard_id
 -- ignore intern staff and 119 dashboard (c1 intern stats)
 where c1_users.email not in (select email from {{ ref('pilotage_c1_users') }}) and visits.dashboard_id != '119'
 group by

--- a/dbt/models/staging/properties.yml
+++ b/dbt/models/staging/properties.yml
@@ -123,3 +123,6 @@ models:
   - name: stg_suivi_demandes_prolongations_non_acceptees
     description: >
       Vue permettant de récupérer les demandes de prolongation non acceptées
+  - name: stg_premiere_visite
+    description: >
+      Vue permettant de récupérer la première visite d'un utilisateur sur l'un de nos tableaux de bord privés

--- a/dbt/models/staging/stg_premiere_visite.sql
+++ b/dbt/models/staging/stg_premiere_visite.sql
@@ -1,0 +1,5 @@
+select
+    user_id,
+    min(measured_at) as premiere_visite
+from {{ source('emplois', 'c1_private_dashboard_visits_v0') }}
+group by user_id

--- a/dbt/models/staging/stg_premiere_visite.sql
+++ b/dbt/models/staging/stg_premiere_visite.sql
@@ -1,5 +1,8 @@
 select
     user_id,
+    dashboard_id,
     min(measured_at) as premiere_visite
 from {{ source('emplois', 'c1_private_dashboard_visits_v0') }}
-group by user_id
+group by
+    user_id,
+    dashboard_id


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Suivi-des-cartes-b3082fffe3f34eaea8fff8ba69338005?p=99873ddcabc24251bfed294bc8954f20&pm=c

### Pourquoi ?

A la demande de Pierre, afin de faire des trucs de bizdev trop stylés, ajout de l'information de première visite sur la table du suivi des utilisateurs des TBs privés

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

