### PR TITLE
Création d'une colonne regroupant les SIAE/non SIAE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ dbt_docs:
 	dbt docs generate
 	cd $(DBT_TARGET_PATH) && python3 -m http.server
 
+dbt_run:
+	dbt run --exclude legacy.oneshot.*+ --exclude marts.oneshot+
+	dbt test
+
 clean: dbt_clean
 	find . -depth -type d -name "__pycache__" -exec rm -rf '{}' \;
 	find . -type d -empty -delete

--- a/dbt/models/staging/properties.yml
+++ b/dbt/models/staging/properties.yml
@@ -32,11 +32,6 @@ models:
       Ce modèle récupère les données de la table c1 organisations et y ajoute des colonnes pour faciliter le déploiement de tableaux metabase liés aux prescripteurs.
       Une colonne type_complet_avec_habilitation permet notamment de rendre cohérent le nom des prescripteurs avec celui de la table candidature.
       Elle pourra également être enrichie d'autres données sur les organisations comme le nombre de structures partenaires, le nombre de prescriptions réalisées, etc.
-    tests:
-      - dbt_utils.expression_is_true:
-          # we check that those columns match as much as possible, knowing that the first one is prefixed by the department code: "01 - Ain".
-          expression: >
-            split_part("nom_département", ' - ', 2) = "nom_département_insee"
   - name: stg_reseaux
     description: >
       Ce modèle récupère les données des tables reseau_iae_adherents et reseau_iae_ids afin d'associer l'id reseau correspondant à chaque structure.

--- a/dbt/models/staging/stg_candidats.sql
+++ b/dbt/models/staging/stg_candidats.sql
@@ -1,12 +1,14 @@
 select
     {{ pilo_star(source('emplois', 'candidats_v0'), relation_alias='candidats') }},
+    grp_strct.groupe                                                        as categorie_structure,
     coalesce(organisations."région", structures."région")                   as "région_diag",
     coalesce(organisations."nom_département", structures."nom_département") as "département_diag",
     -- for know only reliable to the year because we do not consider month for calculating the age
     -- todo : correct it to consider month also
     case
-        when annee_naissance_selon_nir < extract(year from current_date) - 2000 then extract(year from current_date) - (annee_naissance_selon_nir + 2000)
-        else extract(year from current_date) - (annee_naissance_selon_nir + 1900)
+        when candidats.annee_naissance_selon_nir < extract(year from current_date) - 2000
+            then extract(year from current_date) - (candidats.annee_naissance_selon_nir + 2000)
+        else extract(year from current_date) - (candidats.annee_naissance_selon_nir + 1900)
     end                                                                     as age_selon_nir
 from
     {{ source('emplois', 'candidats_v0') }} as candidats
@@ -16,3 +18,6 @@ left join
 left join
     {{ source('emplois', 'structures') }} as structures
     on structures.id = candidats.id_auteur_diagnostic_employeur
+left join
+    {{ ref('groupes_structures') }} as grp_strct
+    on grp_strct.structure = candidats."type_structure_dernière_embauche"

--- a/dbt/models/staging/stg_candidatures_autoprescription.sql
+++ b/dbt/models/staging/stg_candidatures_autoprescription.sql
@@ -20,6 +20,7 @@ select
     cd.origine                             as origine,
     cd."origine_détaillée"                 as "origine_détaillée",
     cd.type_structure                      as type_structure,
+    cd.categorie_structure,
     cd.nom_structure                       as nom_structure,
     cd."département_structure"             as "département_structure",
     cd."nom_département_structure"         as "nom_département_structure",

--- a/dbt/seeds/groupes_structures.csv
+++ b/dbt/seeds/groupes_structures.csv
@@ -1,0 +1,11 @@
+structure,groupe
+ACI,Structures IAE
+AI,Structures IAE
+EI,Structures IAE
+EITI,Structures IAE
+ETTI,Structures IAE
+EA,Structures hors IAE
+EATT,Structures hors IAE
+ESAT,Structures hors IAE
+GEIQ,Structures hors IAE
+OPCS,Structures hors IAE

--- a/dbt/seeds/properties.yml
+++ b/dbt/seeds/properties.yml
@@ -67,3 +67,6 @@ seeds:
     description: >
       liste des emails des utilisateurs internes à pilotage sur le c1.
       permet de filtrer pour ne considérer que les vrais utilisateurs dans le cadre du suivi des visites.
+  - name: groupe_structures
+    description: >
+      Seed permettant de regrouper les structures de l'IAE et hors IAE dans deux catégories distinctes.


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Suivi-des-cartes-b3082fffe3f34eaea8fff8ba69338005?p=69fe935f669846d887c0ceca5bdf52f1&pm=c

### Pourquoi ?

Certains de nos utilisateurs  oublient les ETTI quand ils veulent voir les chiffres de l'IAE et c'est pas sympa ! Donc on a pris les devants et on a créé une colonne qui prend en compte toutes les structures de l'IAE !

Deux ajouts supp parce qu'y en a un ptit peu plus, je vous le mets quand même :

+ Make file permettant de lancer le dbt run en excluant les one shot + dbt test
+ En attente d'une modif de la part de Laurine, retrait du test de stg_organisations qui n'est plus pertinent suite aux modifs de la vue

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

