### PR TITLE
Ajout d'un ref() manquant sur une vue

### DIFF
--- a/dbt/models/staging/stg_etat_mensuel_individuel_avec_brsa.sql
+++ b/dbt/models/staging/stg_etat_mensuel_individuel_avec_brsa.sql
@@ -20,8 +20,8 @@ select
     count(ctr.contrat_salarie_rsa) as nombre_salaries
 from
     {{ ref('stg_dates_etat_mensuel_individualise') }} as constantes
-cross join "fluxIAE_EtatMensuelIndiv_v2" as emi
-left join "fluxIAE_ContratMission_v2" as ctr
+cross join {{ ref('fluxIAE_EtatMensuelIndiv_v2') }} as emi
+left join {{ ref('fluxIAE_ContratMission_v2') }} as ctr
     on ctr.contrat_id_ctr = emi.emi_ctr_id
 where
     emi.emi_sme_annee >= constantes.annee_en_cours_2


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Ajout d'un ref() manquant sur une vue qui nous cause des problèmes dernièrement

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

