### PR TITLE
modification afin de prendre en compte la création de structures_v0 côté emplois

### DIFF
--- a/dbt/models/_sources.yml
+++ b/dbt/models/_sources.yml
@@ -53,6 +53,7 @@ sources:
       - name: utilisateurs
       - name: demandes_de_prolongation
       - name: prolongations
+      - name: structures_v0
 
   - name: oneshot
     schema: public

--- a/dbt/models/legacy/tx_refus_siae.sql
+++ b/dbt/models/legacy/tx_refus_siae.sql
@@ -60,7 +60,7 @@ left join
 left join
     {{ source('emplois', 'fiches_de_poste') }} as fdp on fdpc.id_fiche_de_poste = fdp.id
 left join
-    {{ source('emplois', 'structures') }} as structures on structures.id = cel.id_structure
+    {{ ref('structures') }} as structures on structures.id = cel.id_structure
 left join
     etp_conventionnes
     on

--- a/dbt/models/marts/pass_iae_et_demandes.sql
+++ b/dbt/models/marts/pass_iae_et_demandes.sql
@@ -10,6 +10,6 @@ from
     {{ source('emplois','pass_agréments') }} as pass
 left join {{ source('emplois', 'demandes_de_prolongation') }} as demandes_prolong
     on pass.id = demandes_prolong."id_pass_agrément"
-left join {{ source('emplois', 'structures') }} as s
+left join {{ ref('structures') }} as s
     on pass.id_structure = s.id
 where pass.id_candidat is not null

--- a/dbt/models/marts/properties.yml
+++ b/dbt/models/marts/properties.yml
@@ -191,3 +191,9 @@ models:
   - name: recrutements
     description: >
       Table permettant de suivre les recrutements réalisés et déclarés à l'ASP.
+  - name: structures
+    description: >
+      Copie de la table structures_v0 du c1 enrichie de données pour faire marcher certains filtres sur metabase.
+    tests:
+      - dbt_utils.equal_rowcount:
+          compare_model: source('emplois', 'structures_v0')

--- a/dbt/models/marts/structures.sql
+++ b/dbt/models/marts/structures.sql
@@ -1,0 +1,7 @@
+select
+    {{ pilo_star(source('emplois','structures_v0'), relation_alias='s') }}
+from
+    {{ source('emplois','structures_v0') }} as s
+left join
+    {{ ref('groupes_structures') }} as grp_strct
+    on grp_strct.structure = s.type

--- a/dbt/models/marts/suivi_cap.sql
+++ b/dbt/models/marts/suivi_cap.sql
@@ -4,7 +4,7 @@ with nb_structures_par_dept as (
         "nom_département",
         cast(count(*) as float) as nb_struct
     from
-        {{ source('emplois', 'structures') }}
+        {{ ref('structures') }}
     group by
         "département",
         "nom_département"
@@ -81,7 +81,7 @@ select
     sum(cap_struct_cnt."nb_contrôlées") / max(nb_tot_dep.nb_struct) as "part_structures_contrôlées"
 from
     cap_struct_counts as cap_struct_cnt
-left join {{ source('emplois', 'structures') }} as struct on cap_struct_cnt.id_structure = struct.id
+left join {{ ref('structures') }} as struct on cap_struct_cnt.id_structure = struct.id
 left join {{ source('emplois', 'cap_campagnes') }} as cap_camp on cap_camp.id = cap_struct_cnt.id_cap_campagne
 left join nb_structures_par_dept as nb_tot_dep on nb_tot_dep."nom_département" = struct."nom_département"
 where struct.active = 1

--- a/dbt/models/marts/suivi_utilisateurs_tb_prive_semaine.sql
+++ b/dbt/models/marts/suivi_utilisateurs_tb_prive_semaine.sql
@@ -25,7 +25,7 @@ left join {{ ref('metabase_dashboards') }} as metabase_ids
     on metabase_ids.id_tb = cast(visits.dashboard_id as INTEGER)
 left join {{ ref('stg_organisations') }} as organisations
     on organisations.id = cast(visits.current_prescriber_organization_id as INTEGER) and visits.user_kind = 'prescriber'
-left join {{ source('emplois', 'structures') }} as structures
+left join {{ ref('structures') }} as structures
     on structures.id = cast(visits.current_company_id as INTEGER) and visits.user_kind = 'employer'
 left join {{ source('emplois', 'institutions') }} as institutions
     on institutions.id = cast(visits.current_institution_id as INTEGER) and visits.user_kind = 'labor_inspector'

--- a/dbt/models/staging/stg_bassin_emploi.sql
+++ b/dbt/models/staging/stg_bassin_emploi.sql
@@ -11,6 +11,6 @@ select
     /* on récupère que l'id des structures de la table structure */
     s.id                    as id_structure
 from {{ source('oneshot', 'sa_zones_infradepartementales') }} as be
-left join {{ source('emplois', 'structures') }} as s
+left join {{ ref('structures') }} as s
     /* il faut rajouter le département car la France n'est pas originale en terme de noms de ville */
     on s.ville = be.libelle_commune and s."nom_département" = be.nom_departement

--- a/dbt/models/staging/stg_c1_private_dashboards_visits_v1.sql
+++ b/dbt/models/staging/stg_c1_private_dashboards_visits_v1.sql
@@ -7,7 +7,7 @@ select
     count(distinct cp.id) as visiteurs_uniques
 from
     {{ source('emplois', 'c1_private_dashboard_visits_v0') }} as cp
-left join {{ source('emplois', 'structures') }} as s
+left join {{ ref('structures') }} as s
     on cp.department = s."département"
 left join {{ ref('metabase_dashboards') }} as md
     on (cp.dashboard_id)::integer = md.id_tb

--- a/dbt/models/staging/stg_candidats.sql
+++ b/dbt/models/staging/stg_candidats.sql
@@ -16,7 +16,7 @@ left join
     {{ ref('stg_organisations') }} as organisations
     on organisations.id = candidats.id_auteur_diagnostic_prescripteur
 left join
-    {{ source('emplois', 'structures') }} as structures
+    {{ ref('structures') }} as structures
     on structures.id = candidats.id_auteur_diagnostic_employeur
 left join
     {{ ref('groupes_structures') }} as grp_strct

--- a/dbt/models/staging/stg_fdp.sql
+++ b/dbt/models/staging/stg_fdp.sql
@@ -52,7 +52,7 @@ from
     {{ ref('stg_fdp_candidatures') }} as fdpc
 left join {{ ref('code_rome_domaine_professionnel') }} as rome
     on fdpc.code_rome_fpd = rome.code_rome
-left join {{ source('emplois', 'structures') }} as s
+left join {{ ref('structures') }} as s
     on fdpc.id_structure = s.id
 left join {{ ref('stg_insee_appartenance_geo_communes') }} as app_geo
     on s.code_commune = app_geo.code_insee

--- a/dbt/models/staging/stg_fdp_candidatures.sql
+++ b/dbt/models/staging/stg_fdp_candidatures.sql
@@ -41,7 +41,7 @@ left join {{ source('emplois', 'candidatures') }} as cdd
     on fdpc.id_candidature = cdd.id
 left join {{ ref('code_rome_domaine_professionnel') }} as crdp
     on fdp.code_rome = crdp.code_rome
-left join {{ source('emplois', 'structures') }} as s
+left join {{ ref('structures') }} as s
     on s.id = fdp.id_employeur
 left join {{ ref('groupes_structures') }} as grp_strct
     on grp_strct.structure = fdp.type_employeur

--- a/dbt/models/staging/stg_reseaux.sql
+++ b/dbt/models/staging/stg_reseaux.sql
@@ -5,5 +5,5 @@ select
 from {{ source('oneshot', 'reseau_iae_adherents') }} as ria
 left join {{ ref('reseau_iae_ids') }} as rid
     on ria."Réseau IAE" = rid.nom
-left join {{ source('emplois', 'structures') }} as s
+left join {{ ref('structures') }} as s
     on s.siret = ria."SIRET"

--- a/dbt/models/staging/stg_structures.sql
+++ b/dbt/models/staging/stg_structures.sql
@@ -11,7 +11,7 @@ select
     insee_geo.nom_zone_emploi as bassin_d_emploi,
     s.nom_complet             as "nom_structure_complet"
 from
-    {{ source('emplois', 'structures') }} as s
+    {{ ref('structures') }} as s
 left join
     {{ ref('stg_insee_appartenance_geo_communes') }} as insee_geo
     on ltrim(s.code_commune, '0') = insee_geo.code_insee

--- a/dbt/models/staging/stg_suivi_demandes_prolongations_acceptees.sql
+++ b/dbt/models/staging/stg_suivi_demandes_prolongations_acceptees.sql
@@ -29,7 +29,7 @@ left join {{ source('emplois', 'demandes_de_prolongation') }} as demandes_prolon
     on prolong.id = demandes_prolong.id_prolongation
 left join {{ ref('stg_organisations') }} as o
     on prolong.id_organisation_prescripteur = o.id
-left join {{ source('emplois', 'structures') }} as s
+left join {{ ref('structures') }} as s
     on prolong."id_structure_déclarante" = s.id
 left join {{ source('emplois', 'pass_agréments') }} as pass
     on prolong."id_pass_agrément" = pass.id

--- a/dbt/models/staging/stg_suivi_demandes_prolongations_non_acceptees.sql
+++ b/dbt/models/staging/stg_suivi_demandes_prolongations_non_acceptees.sql
@@ -39,7 +39,7 @@ select
 from {{ source('emplois', 'demandes_de_prolongation') }} as demandes_prolong
 left join {{ ref('stg_organisations') }} as o
     on demandes_prolong.id_organisation_prescripteur = o.id
-left join {{ source('emplois', 'structures') }} as s
+left join {{ ref('structures') }} as s
     on demandes_prolong."id_structure_déclarante" = s.id
 left join {{ source('emplois', 'pass_agréments') }} as pass
     on demandes_prolong."id_pass_agrément" = pass.id


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Afin de simplifier la vie des data analystos et éviter de casser plusieurs indicateurs metabase on créé une table structures_v0 côté emplois pour créer une table structures sur dbt. [PR coté emplois ](https://github.com/betagouv/itou/pull/3316)


### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

