### PR TITLE
Ajout de la colonne "catégorie de structures"

### DIFF
--- a/dbt/models/marts/structures.sql
+++ b/dbt/models/marts/structures.sql
@@ -1,5 +1,6 @@
 select
-    {{ pilo_star(source('emplois','structures_v0'), relation_alias='s') }}
+    {{ pilo_star(source('emplois','structures_v0'), relation_alias='s') }},
+    grp_strct.groupe as categorie_structure
 from
     {{ source('emplois','structures_v0') }} as s
 left join


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/de268046f9a044b2a7c80cdbf98ad8b7?v=ccdf191df6ef4578b5d6a1b9936ed790&p=3b19079b107d400a8ef9b5c946bfa959&pm=c

### Pourquoi ?

Ajout de la colonne "catégorie de structures" afin de cabler tous les filtres suite à la demande du métier

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

