### PR TITLE
Calcul du delta d'etp annuels

### DIFF
--- a/dbt/models/marts/weekly/suivi_realisation_convention_par_structure.sql
+++ b/dbt/models/marts/weekly/suivi_realisation_convention_par_structure.sql
@@ -12,8 +12,12 @@ select
     etp.nom_region_af,
     sum(etp.nombre_etp_consommes_reels_mensuels - etp."effectif_mensuel_conventionné")
     as delta_etp_conventionnes_realises,
+    sum(etp.nombre_etp_consommes_reels_annuels - etp."effectif_annuel_conventionné")
+    as delta_etp_conventionnes_realises_annuel,
     sum(etp.nombre_etp_consommes_reels_mensuels)
-    as somme_etp_realises
+    as somme_etp_realises,
+    sum(etp.nombre_etp_consommes_reels_annuels)
+    as somme_etp_realises_annuel
 from {{ ref('suivi_realisation_convention_mensuelle') }} as etp
 group by
     etp.id_annexe_financiere,


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/D-cliner-l-indicateur-d-ETP-surconsomm-s-en-ETP-annuels-et-l-ajouter-dans-l-onglet-ETP-annuels-3c00639908f1427b83ee90c0fc54314e?pvs=4

### Pourquoi ?

A la demande de nos utilisateurs/trices (on les aime <3) ajout du delta de consommation d'etp annuels 

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

