### PR TITLE
Ajout suivi de 2 tbs privés

### DIFF
--- a/dbt/seeds/pilotage_interne/metabase_dashboards.csv
+++ b/dbt/seeds/pilotage_interne/metabase_dashboards.csv
@@ -36,4 +36,6 @@ id_tb,nom_tb,public,type
 301,tb 301 - Données de candidatures (Réseaux IAE),Réseaux,TB privé
 310,tb 310 - DDETS/DREETS/DIHAL - Suivi des prescriptions,DDETS/DREETS/DIHAL,TB privé
 327,tb 327 - ACI - Suivi du cofinancement CD,SIAE,TB privé
+330,tb 330 - CD - Suivi des prescriptions des accompagnateurs des publics bRSA,CD,TB privé
+346,tb 346 - CD - Facilitation des embauches en IAE,CD,TB privé
 357,tb 357 - DDETS/DREETS - Suivi des demandes de prolongation réalisées par les SIAE,DDETS/DREETS,TB privé


### PR DESCRIPTION
**Carte Notion : ** : https://itou-inclusion.slack.com/archives/C04SAGUGJFJ/p1701095297789729

### Pourquoi ?

A la demande du métier, ajout du suivi de deux TBs privés

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

