### PR TITLE
DBT : Introduction de modèles incrémentaux

### DIFF
--- a/dbt/macros/to_timestamp.sql
+++ b/dbt/macros/to_timestamp.sql
@@ -1,0 +1,3 @@
+{% macro to_timestamp(field) -%}
+to_timestamp({{ field }}, 'DD/MM/YYYY HH24:MI:SS')
+{%- endmacro -%}

--- a/dbt/models/indexed/fluxIAE_EtatMensuelIndiv_v2.sql
+++ b/dbt/models/indexed/fluxIAE_EtatMensuelIndiv_v2.sql
@@ -1,6 +1,8 @@
 {{ config(
-    materialized = 'table',
+    materialized='incremental',
+    unique_key='emi_dsm_id',
     indexes=[
+      {'columns': ['emi_dsm_id'], 'unique' : True},
       {'columns': ['emi_pph_id'], 'unique' : False},
       {'columns': ['emi_afi_id'], 'unique' : False},
       {'columns': ['emi_ctr_id'], 'unique' : False},
@@ -19,3 +21,6 @@ where
         date_part('year', current_date) - 1,
         date_part('year', current_date) - 2
     )
+{% if is_incremental() %}
+    and {{ to_timestamp('emi.emi_date_modification') }} > (select max({{ to_timestamp('emi_date_modification') }}) from {{ this }})
+{% endif %}

--- a/dbt/models/marts/weekly/suivi_etp_realises_v2.sql
+++ b/dbt/models/marts/weekly/suivi_etp_realises_v2.sql
@@ -1,3 +1,11 @@
+{{ config(
+    materialized='incremental',
+    unique_key='emi_dsm_id',
+    indexes=[
+      {'columns': ['emi_dsm_id'], 'unique' : True},
+    ]
+ ) }}
+
 select distinct
     emi.emi_pph_id                                                                      as identifiant_salarie,
     emi.emi_afi_id                                                                      as id_annexe_financiere,
@@ -8,6 +16,7 @@ select distinct
     emi.emi_sme_mois,
     emi.emi_sme_annee,
     emi.emi_esm_etat_code,
+    emi.emi_date_modification,
     brsa.majoration_brsa,
     brsa.salarie_brsa,
     af.af_numero_annexe_financiere,
@@ -67,3 +76,6 @@ where
     and firmi.rmi_libelle = 'Nombre d''heures annuelles théoriques pour un salarié à taux plein'
     and af.af_etat_annexe_financiere_code in ('VALIDE', 'PROVISOIRE', 'CLOTURE')
     and af.af_mesure_dispositif_code not like '%FDI%'
+{% if is_incremental() %}
+    and {{ to_timestamp('emi.emi_date_modification') }} > (select max({{ to_timestamp('emi_date_modification') }}) from {{ this }})
+{% endif %}

--- a/dbt/tests/properties.yml
+++ b/dbt/tests/properties.yml
@@ -10,3 +10,6 @@ tests:
   - name: test_fluxIAE_EtatMensuelIndiv_v2_sum_etp
     description: >
       Test permettant de vérifier la somme des ETP entre la source et notre modèle
+  - name: test_suivi_etp_realises_v2_sum_etp
+    description: >
+      Test permettant de vérifier la somme des ETP entre la source et notre modèle

--- a/dbt/tests/properties.yml
+++ b/dbt/tests/properties.yml
@@ -7,3 +7,6 @@ tests:
   - name: test_etp_realises
     description: >
       Test permettant de vérifier l'absence de doublons dans la table suivi_etp_realises_v2
+  - name: test_fluxIAE_EtatMensuelIndiv_v2_sum_etp
+    description: >
+      Test permettant de vérifier la somme des ETP entre la source et notre modèle

--- a/dbt/tests/test_fluxIAE_EtatMensuelIndiv_v2_sum_etp.sql
+++ b/dbt/tests/test_fluxIAE_EtatMensuelIndiv_v2_sum_etp.sql
@@ -1,0 +1,22 @@
+with etp_sum as (
+    select
+        (
+            select sum(emi_part_etp)
+            from {{ source('fluxIAE', 'fluxIAE_EtatMensuelIndiv') }}
+            where
+                emi_sme_annee in
+                (
+                    date_part('year', current_date),
+                    date_part('year', current_date) - 1,
+                    date_part('year', current_date) - 2
+                )
+        ) as theirs,
+        (
+            select sum(emi_part_etp)
+            from {{ ref("fluxIAE_EtatMensuelIndiv_v2") }}
+        ) as ours
+)
+
+select *
+from etp_sum
+where round(theirs) != round(ours)

--- a/dbt/tests/test_suivi_etp_realises_v2_sum_etp.sql
+++ b/dbt/tests/test_suivi_etp_realises_v2_sum_etp.sql
@@ -1,0 +1,31 @@
+with etp_sum as (
+    select
+        (
+            select sum(emi_part_etp) from (
+                select distinct on (emi.emi_dsm_id) emi.emi_part_etp
+                from {{ ref('stg_dates_etat_mensuel_individualise') }} as constantes
+                cross join {{ source('fluxIAE', 'fluxIAE_EtatMensuelIndiv') }} as emi
+                left join {{ ref('fluxIAE_AnnexeFinanciere_v2') }} as af
+                    on emi.emi_afi_id = af.af_id_annexe_financiere
+                left join {{ source('fluxIAE', 'fluxIAE_RefMontantIae') }} as firmi
+                    on af.af_mesure_dispositif_id = firmi.rme_id
+                where
+                    emi.emi_sme_annee >= constantes.annee_en_cours_2
+                    and firmi.rmi_libelle = 'Nombre d''heures annuelles théoriques pour un salarié à taux plein'
+                    and af.af_etat_annexe_financiere_code in (
+                        'VALIDE',
+                        'PROVISOIRE',
+                        'CLOTURE'
+                    )
+                    and af.af_mesure_dispositif_code not like '%FDI%'
+            ) as tmp
+        ) as theirs,
+        (
+            select sum(nombre_etp_consommes_asp)
+            from {{ ref("suivi_etp_realises_v2") }}
+        ) as ours
+)
+
+select *
+from etp_sum
+where round(theirs) != round(ours)


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/Cr-er-des-mod-les-incr-mentaux-pour-les-tables-ETPs-23232b10cc74495cac0e1b50da2ed6a4?pvs=4

### Pourquoi ?

Recréer seulement la donnée qui change plutôt que tout le contenu lors du lancement du modèle. Reprise de https://github.com/gip-inclusion/pilotage-airflow/pull/199.

Je n'ai fait que ces 2 modèles car dès que j'en ouvre un autre je ne suis pas sûr si les modifications (étapes détaillés en dessous pour reproduction) ne vont pas casser des choses ou comment cela va se propager derrière, donc si on souhaite aller plus loin sur le chemin des modèles incrémentaux je pense que ça sera plus efficace de faire ça en binômage.

#### Étape pour mettre en place un modèle incrémental

1. La clé unique.
Cela peux être un identifiant unique (ex: `emi_dsm_id`) ou une combinaison de champs (ex: `['emi_pph_id', 'emi_afi_id', 'emi_ctr_id', 'emi_sme_annee', 'emi_sme_mois', ]`).
Une fois la clé identifiée, il faut créer un `UNIQUE INDEX` _via_ `config.indexes` si ce n'est pas encore le cas, mais aussi déclarer la clé dans [`config.unique_key`](https://docs.getdbt.com/docs/build/incremental-models#defining-a-unique-key-optional) afin d'avoir un comportement d'[upsert](https://en.wiktionary.org/wiki/upsert) au lieu que les lignes existantes modifiés soient dupliquées.
La clé n'a pas à être dans la source principale de donnée mais elle doit exister dans la table générée.
2. Le marqueur de changement.
C'est en général un horodatage (ex: `emi_date_modification`), une fois celui-ci identifié il faut l'utiliser en tant que prédicat du `WHERE` dans un bloc conditionnel utilisant la macro [`is_incremental()`](https://docs.getdbt.com/docs/build/incremental-models#understanding-the-is_incremental-macro).
Le marqueur de changement doit donc être dans la source principale de donnée mais aussi dans la table générée.
3. Changer l'option de matérialisation `config.materialized` à `incremental`

#### Limitations
- Uniquement les modèles SQL semblent pouvoir être incrémentaux, je n'ai rien vu qui semble permettre de faire cela pour les modèles Python.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

