### PR TITLE
Correction d'un bug amenant à la duplication de certaines lignes dans suivi_etp_realises_v2

### DIFF
--- a/dbt/models/marts/weekly/suivi_etp_realises_v2.sql
+++ b/dbt/models/marts/weekly/suivi_etp_realises_v2.sql
@@ -4,6 +4,7 @@ select distinct
     emi.emi_part_etp                                                                    as nombre_etp_consommes_asp,
     emi.emi_nb_heures_travail                                                           as nombre_heures_travaillees,
     emi.emi_afi_id                                                                      as identifiant_annexe_fin,
+    emi.emi_dsm_id,
     emi.emi_sme_mois,
     emi.emi_sme_annee,
     emi.emi_esm_etat_code,
@@ -60,6 +61,7 @@ left join {{ ref('stg_etat_mensuel_individuel_avec_brsa') }} as brsa
         and emi.emi_pph_id = brsa.emi_pph_id
         and emi.emi_sme_annee = brsa.emi_sme_annee
         and emi.emi_sme_mois = brsa.emi_sme_mois
+        and emi.emi_dsm_id = brsa.emi_dsm_id
 where
     emi.emi_sme_annee >= constantes.annee_en_cours_2
     and firmi.rmi_libelle = 'Nombre d''heures annuelles théoriques pour un salarié à taux plein'

--- a/dbt/models/staging/stg_etat_mensuel_individuel_avec_brsa.sql
+++ b/dbt/models/staging/stg_etat_mensuel_individuel_avec_brsa.sql
@@ -4,6 +4,7 @@ select
     emi.emi_sme_mois,
     emi.emi_sme_annee,
     emi.emi_sme_version,
+    emi.emi_dsm_id,
     case
         when ctr.contrat_salarie_rsa = 'OUI-M' then 'RSA majoré'
         when ctr.contrat_salarie_rsa = 'OUI-NM' then 'RSA non majoré'
@@ -31,4 +32,5 @@ group by
     emi.emi_sme_mois,
     emi.emi_sme_annee,
     emi.emi_sme_version,
+    emi.emi_dsm_id,
     ctr.contrat_salarie_rsa

--- a/dbt/tests/properties.yml
+++ b/dbt/tests/properties.yml
@@ -4,3 +4,6 @@ tests:
   - name: test_sum_etp
     description: >
       Test permettant de vérifier l'intégrité d'une table à l'aide de la somme d'etp
+  - name: test_etp_realises
+    description: >
+      Test permettant de vérifier l'absence de doublons dans la table suivi_etp_realises_v2

--- a/dbt/tests/test_etp_realises.sql
+++ b/dbt/tests/test_etp_realises.sql
@@ -1,0 +1,15 @@
+with etp_realises as (
+    select
+        (
+            select count(distinct emi_dsm_id)
+            from {{ ref("suivi_etp_realises_v2") }}
+        ) as count_distinct,
+        (
+            select count(*)
+            from {{ ref("suivi_etp_realises_v2") }}
+        ) as count_all
+)
+
+select *
+from etp_realises
+where count_all != count_distinct


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Correction d'un bug amenant à la duplication de certaines lignes dans suivi_etp_realises_v2. 


### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

