### PR TITLE
Ajout du département comme catégorie de prescripteur historique

### DIFF
--- a/dbt/models/staging/stg_organisations.sql
+++ b/dbt/models/staging/stg_organisations.sql
@@ -17,6 +17,7 @@ select
     organisations_libelles.code                                                as type_org,
     case
         when organisations.type in ('ML', 'PE', 'CAP_EMPLOI') then 'SPE'
+        when organisations.type in ('DEPT', 'ODC') then 'Département'
         when organisations.type = 'Autre' then 'Autre'
         else 'Nouveaux prescripteurs'
     end                                                                        as type_prescripteur,


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Ajouter-dans-cat-gorie-prescripteurs-habilit-s-le-d-partement-b1d1c41a12c947848f50f283b7920fcf

### Pourquoi ?

A la demande du métier ajout du département comme catégorie de prescripteur historique

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

