### PR TITLE
DAG : Gestion du `--full-refresh` pour la tâche `dbt_run`

### DIFF
--- a/dags/dbt_daily.py
+++ b/dags/dbt_daily.py
@@ -39,7 +39,7 @@ with airflow.DAG(
         is_full_refresh = params.get("full_refresh")
         if is_full_refresh:
             kwargs["ti"].xcom_push("dbt_seed_args", "--full-refresh")
-            kwargs["ti"].xcom_push("dbt_run_args", "--exclude marts.weekly")
+            kwargs["ti"].xcom_push("dbt_run_args", "--full-refresh --exclude marts.weekly")
         else:
             kwargs["ti"].xcom_push("dbt_seed_args", "")
             kwargs["ti"].xcom_push("dbt_run_args", "--select marts.daily legacy.daily ephemeral staging")

--- a/dags/dbt_daily.py
+++ b/dags/dbt_daily.py
@@ -38,11 +38,11 @@ with airflow.DAG(
     def params_check(params=None, **kwargs):
         is_full_refresh = params.get("full_refresh")
         if is_full_refresh:
-            kwargs["ti"].xcom_push("dbt_run_args", "--exclude marts.weekly")
             kwargs["ti"].xcom_push("dbt_seed_args", "--full-refresh")
+            kwargs["ti"].xcom_push("dbt_run_args", "--exclude marts.weekly")
         else:
-            kwargs["ti"].xcom_push("dbt_run_args", "--select marts.daily legacy.daily ephemeral staging")
             kwargs["ti"].xcom_push("dbt_seed_args", "")
+            kwargs["ti"].xcom_push("dbt_run_args", "--select marts.daily legacy.daily ephemeral staging")
 
     params_check = python.PythonOperator(task_id="params_check", provide_context=True, python_callable=params_check)
 

--- a/dags/dbt_weekly.py
+++ b/dags/dbt_weekly.py
@@ -39,7 +39,7 @@ with airflow.DAG(
         is_full_refresh = params.get("full_refresh")
         if is_full_refresh:
             kwargs["ti"].xcom_push("dbt_seed_args", "--full-refresh")
-            kwargs["ti"].xcom_push("dbt_run_args", "--exclude marts.daily")
+            kwargs["ti"].xcom_push("dbt_run_args", "--full-refresh --exclude marts.daily")
         else:
             kwargs["ti"].xcom_push("dbt_seed_args", "")
             kwargs["ti"].xcom_push("dbt_run_args", "--select marts.weekly legacy.weekly ephemeral indexed staging")

--- a/dags/dbt_weekly.py
+++ b/dags/dbt_weekly.py
@@ -38,11 +38,11 @@ with airflow.DAG(
     def params_check(params=None, **kwargs):
         is_full_refresh = params.get("full_refresh")
         if is_full_refresh:
-            kwargs["ti"].xcom_push("dbt_run_args", "--exclude marts.daily")
             kwargs["ti"].xcom_push("dbt_seed_args", "--full-refresh")
+            kwargs["ti"].xcom_push("dbt_run_args", "--exclude marts.daily")
         else:
-            kwargs["ti"].xcom_push("dbt_run_args", "--select marts.weekly legacy.weekly ephemeral indexed staging")
             kwargs["ti"].xcom_push("dbt_seed_args", "")
+            kwargs["ti"].xcom_push("dbt_run_args", "--select marts.weekly legacy.weekly ephemeral indexed staging")
 
     params_check = python.PythonOperator(task_id="params_check", provide_context=True, python_callable=params_check)
 


### PR DESCRIPTION
### Pourquoi ?

La config DAG `full_refresh` n'est prise en compte que pour la tâche `dbt_seed` et pas `dbt_run`.

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

