### PR TITLE
Préciser opcs dans la source pour ces structures

### DIFF
--- a/dbt/models/marts/daily/structures.sql
+++ b/dbt/models/marts/daily/structures.sql
@@ -1,6 +1,11 @@
 select
-    {{ pilo_star(source('emplois','structures_v0'), relation_alias='s') }},
-    grp_strct.groupe as categorie_structure
+    {{ pilo_star(source('emplois','structures_v0'), except=['source'], relation_alias='s') }},
+    grp_strct.groupe as categorie_structure,
+    case
+        when type = 'OPCS' and source = 'Utilisateur (Antenne)' then 'Utilisateur (OPCS)'
+        when type = 'OPCS' and source = 'Staff Itou' then 'Staff Itou (OPCS)'
+        else source
+    end              as source
 from
     {{ source('emplois','structures_v0') }} as s
 left join

--- a/dbt/tests/properties.yml
+++ b/dbt/tests/properties.yml
@@ -13,3 +13,6 @@ tests:
   - name: test_suivi_etp_realises_v2_sum_etp
     description: >
       Test permettant de vérifier la somme des ETP entre la source et notre modèle
+  - name: test_source_opcs
+    description: >
+      Permet de vérifier que le nb de structures opcs est le même que le nb de structures qui ont pour source un opcs.

--- a/dbt/tests/test_source_opcs.sql
+++ b/dbt/tests/test_source_opcs.sql
@@ -1,0 +1,17 @@
+with nb_opcs as (
+    select
+        (
+            select count(*)
+            from structures_v0
+            where type = 'OPCS'
+        ) as nb_opcs_structs,
+        (
+            select count(*)
+            from structures
+            where source = 'Staff Itou (OPCS)' or source = 'Utilisateur (OPCS)'
+        ) as nb_opcs_sources
+)
+
+select *
+from nb_opcs
+where nb_opcs_structs != nb_opcs_sources


### PR DESCRIPTION
**Fil slack : ** https://itou-inclusion.slack.com/archives/CT7986ULC/p1703279405148309

### Pourquoi ?

Pour résoudre un pb de filtre sur le tb employeur

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

