### PR TITLE
Remplacer les valeurs nulles de tranche_age et genre par 'Non renseigné'

### DIFF
--- a/dbt/models/marts/daily/candidatures_echelle_locale.sql
+++ b/dbt/models/marts/daily/candidatures_echelle_locale.sql
@@ -3,20 +3,20 @@ select
     case
         when candidatures.injection_ai = 0 then 'Non'
         else 'Oui'
-    end                                   as reprise_de_stock_ai,
+    end                                                 as reprise_de_stock_ai,
     case
         when candidatures.type_org_prescripteur = org.code
             then org.label
         else candidatures."origine_détaillée"
-    end                                   as "origine_détaillée",
-    candidats.sous_type_auteur_diagnostic as auteur_diag_candidat_detaille,
-    candidats.type_auteur_diagnostic      as auteur_diag_candidat,
+    end                                                 as "origine_détaillée",
+    coalesce(candidats.tranche_age, 'Non renseigné')    as tranche_age,
+    coalesce(candidats.sexe_selon_nir, 'Non renseigné') as genre_candidat,
+    candidats.sous_type_auteur_diagnostic               as auteur_diag_candidat_detaille,
+    candidats.type_auteur_diagnostic                    as auteur_diag_candidat,
     candidats.eligibilite_dispositif,
-    candidats.tranche_age,
     candidats.eligible_cej,
-    candidats.sexe_selon_nir              as genre_candidat,
     candidats.eligible_cdi_inclusion,
-    candidats.date_inscription            as date_inscription_candidat
+    candidats.date_inscription                          as date_inscription_candidat
 from
     {{ ref('stg_candidatures') }} as candidatures
 left join {{ ref('candidats') }} as candidats


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/D-cliner-donn-es-genre-et-ge-dans-les-TB-candidatures-6c3ab0018bc04e9d9ee41856a660bd17?pvs=4

### Pourquoi ?

Pour permettre l'ajout de filtres genre et age au tb suivi des candidatures de PE.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

