### PR TITLE
Condition permettant de prendre en compte les changements d'années dans les etps

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,14 +14,14 @@
         "comments": false,
         "strings": true
     },
-    "editor.wordBasedSuggestions": true,
+    "editor.wordBasedSuggestions": "matchingDocuments",
     "files.trimTrailingWhitespace": true,
     "html.format.enable": true,
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter",
         "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
-            "source.organizeImports": true
+            "source.organizeImports": "explicit"
         }
     },
     "explorer.confirmDragAndDrop": false,

--- a/dbt/models/marts/weekly/suivi_complet_etps_conventionnes.py
+++ b/dbt/models/marts/weekly/suivi_complet_etps_conventionnes.py
@@ -40,6 +40,8 @@ def get_zero_etp(df):
     # and remove the duplicates where df_replicate[etp] != 0
     for year in three_last_years:
         df_temp = df[df["annee_af"] == year]
+        if df_temp.empty:
+            continue
         df_temp["af_date_debut_effet_v2"] = pd.to_datetime(df_temp["af_date_debut_effet_v2"])
         df_temp["af_date_fin_effet_v2"] = pd.to_datetime(df_temp["af_date_fin_effet_v2"])
 

--- a/dbt/tests/test_suivi_etp_realises_v2_sum_etp.sql
+++ b/dbt/tests/test_suivi_etp_realises_v2_sum_etp.sql
@@ -10,7 +10,7 @@ with etp_sum as (
                 left join {{ source('fluxIAE', 'fluxIAE_RefMontantIae') }} as firmi
                     on af.af_mesure_dispositif_id = firmi.rme_id
                 where
-                    emi.emi_sme_annee >= constantes.annee_en_cours_2
+                    emi.emi_sme_annee >= constantes.annee_en_cours
                     and firmi.rmi_libelle = 'Nombre d''heures annuelles théoriques pour un salarié à taux plein'
                     and af.af_etat_annexe_financiere_code in (
                         'VALIDE',
@@ -21,8 +21,11 @@ with etp_sum as (
             ) as tmp
         ) as theirs,
         (
-            select sum(nombre_etp_consommes_asp)
-            from {{ ref("suivi_etp_realises_v2") }}
+            select sum(etp.nombre_etp_consommes_asp)
+            from {{ ref('stg_dates_etat_mensuel_individualise') }} as constantes
+            cross join {{ ref("suivi_etp_realises_v2") }} as etp
+            where
+                etp.emi_sme_annee >= constantes.annee_en_cours
         ) as ours
 )
 


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

L'ASP a un délai dans la prise en compte du changement d'année, il était donc nécessaire d'ajouter une condition permettant de prendre en compte les changements d'années dans les etps

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

