### PR TITLE
Patch pour tenter de résoudre le plantage de dbt sur suivi_tb_prive_semaine

### DIFF
--- a/dbt/models/marts/daily/suivi_tb_prive_semaine.py
+++ b/dbt/models/marts/daily/suivi_tb_prive_semaine.py
@@ -32,11 +32,8 @@ def add_past_and_current_users(dtf):
         all_col.append(list(preceding))
         nb_all.append(len(preceding))
 
-    dtf["nouveaux"] = new_col
     dtf["nb_nouveaux"] = nb_new
-    dtf["anciens"] = already_visited_col
     dtf["nb_anciens"] = nb_ancient
-    dtf["tous"] = all_col
     dtf["nb_visiteurs_cumulé"] = nb_all
     return dtf
 


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

dbt plante sur cette table trop volumineuse -> retrait des array agg non necessaires

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

