### PR TITLE
Correction de la date dans les sorties

### DIFF
--- a/dbt/models/indexed/fluxIAE_EtatMensuelIndiv_v2.sql
+++ b/dbt/models/indexed/fluxIAE_EtatMensuelIndiv_v2.sql
@@ -16,12 +16,7 @@ select
 from
     {{ source('fluxIAE', 'fluxIAE_EtatMensuelIndiv') }} as emi
 where
-    emi.emi_sme_annee in
-    (
-        date_part('year', current_date),
-        date_part('year', current_date) - 1,
-        date_part('year', current_date) - 2
-    )
+    emi.emi_sme_annee >= 2021
 {% if is_incremental() %}
     and {{ to_timestamp('emi.emi_date_modification') }} > (select max({{ to_timestamp('emi_date_modification') }}) from {{ this }})
 {% endif %}

--- a/dbt/models/indexed/sorties_v2.sql
+++ b/dbt/models/indexed/sorties_v2.sql
@@ -72,8 +72,7 @@ where
     af.af_etat_annexe_financiere_code in ('VALIDE', 'PROVISOIRE', 'CLOTURE')
     and
     rms.rms_libelle is not null
-    and emi.emi_sme_annee in (
-        date_part('year', current_date),
-        date_part('year', current_date) - 1,
-        date_part('year', current_date) - 2
-    )
+    /* Gardons un historique à partir de 2022.
+    Néamoins, pour que les sorties soient de 2022 soient calculées correctement
+    il faut prendre en compte l'année 2021 */
+    and emi.emi_sme_annee >= 2021


### PR DESCRIPTION
year fix

fixing a typo

**Carte Notion : **

### Pourquoi ?

Afin de calculer les sorties de 2022, il faut aussi calculer les sorties de 2021. Ces corrections prennent ça en compte. 

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

