### PR TITLE
Correction d'une coquille dans les tests ETP

### DIFF
--- a/dbt/tests/test_fluxIAE_EtatMensuelIndiv_v2_sum_etp.sql
+++ b/dbt/tests/test_fluxIAE_EtatMensuelIndiv_v2_sum_etp.sql
@@ -4,12 +4,7 @@ with etp_sum as (
             select sum(emi_part_etp)
             from {{ source('fluxIAE', 'fluxIAE_EtatMensuelIndiv') }}
             where
-                emi_sme_annee in
-                (
-                    date_part('year', current_date),
-                    date_part('year', current_date) - 1,
-                    date_part('year', current_date) - 2
-                )
+                emi_sme_annee >= 2021
         ) as theirs,
         (
             select sum(emi_part_etp)

--- a/dbt/tests/test_suivi_etp_realises_v2_sum_etp.sql
+++ b/dbt/tests/test_suivi_etp_realises_v2_sum_etp.sql
@@ -10,7 +10,7 @@ with etp_sum as (
                 left join {{ source('fluxIAE', 'fluxIAE_RefMontantIae') }} as firmi
                     on af.af_mesure_dispositif_id = firmi.rme_id
                 where
-                    emi.emi_sme_annee >= constantes.annee_en_cours
+                    emi.emi_sme_annee = constantes.annee_en_cours
                     and firmi.rmi_libelle = 'Nombre d''heures annuelles théoriques pour un salarié à taux plein'
                     and af.af_etat_annexe_financiere_code in (
                         'VALIDE',
@@ -25,7 +25,7 @@ with etp_sum as (
             from {{ ref('stg_dates_etat_mensuel_individualise') }} as constantes
             cross join {{ ref("suivi_etp_realises_v2") }} as etp
             where
-                etp.emi_sme_annee >= constantes.annee_en_cours
+                etp.emi_sme_annee = constantes.annee_en_cours
         ) as ours
 )
 


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Correction d'une coquille dans les tests ETP. L'erreur n'etait pas apparue lors de mes essais car le --full-refresh avait déjà été fait avec les données etp récupérées du dump.

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

