### PR TITLE
calcul des candidats sans solutions

### DIFF
--- a/dbt/models/marts/daily/candidats.sql
+++ b/dbt/models/marts/daily/candidats.sql
@@ -1,6 +1,10 @@
 select
     {{ pilo_star(ref('stg_candidats')) }},
     case
+        when date_diagnostic > current_date - interval '6 months' then 1
+        else 0
+    end as diagnostic_valide,
+    case
         when age_selon_nir <= 25 then 'Jeune (- de 26 ans)'
         when age_selon_nir > 25 and age_selon_nir <= 54 then 'Adulte (26-54 ans)'
         when age_selon_nir >= 55 then 'Senior (55 ans et +)'

--- a/dbt/models/marts/daily/candidats_sans_solutions.sql
+++ b/dbt/models/marts/daily/candidats_sans_solutions.sql
@@ -1,0 +1,51 @@
+select
+    c.id,
+    min(date_diagnostic)    as date_diagnostic,
+    min(c.date_candidature) as date_premiere_candidature,
+    max(c.date_candidature) as date_derniere_candidature,
+    case
+        when not exists (
+            select 1
+            from {{ ref('stg_candidatures_candidats_entres') }} as c2
+            where
+                c2.id = c.id
+                and c2."état" = 'Candidature acceptée'
+                and c2.date_diagnostic + interval '30 days' > c2.date_candidature
+        ) then 1
+        else 0
+    end                     as sans_solution_30,
+    case
+        when not exists (
+            select 1
+            from {{ ref('stg_candidatures_candidats_entres') }} as c2
+            where
+                c2.id = c.id
+                and c2."état" = 'Candidature acceptée'
+                and c2.date_diagnostic + interval '45 days' > c2.date_candidature
+        ) then 1
+        else 0
+    end                     as sans_solution_45,
+    case
+        when not exists (
+            select 1
+            from {{ ref('stg_candidatures_candidats_entres') }} as c2
+            where
+                c2.id = c.id
+                and c2."état" = 'Candidature acceptée'
+                and c2.date_diagnostic + interval '60 days' > c2.date_candidature
+        ) then 1
+        else 0
+    end                     as sans_solution_60,
+    case
+        when not exists (
+            select 1
+            from {{ ref('stg_candidatures_candidats_entres') }} as c2
+            where
+                c2.id = c.id
+                and c2."état" = 'Candidature acceptée'
+                and c2.date_diagnostic + interval '90 days' > c2.date_candidature
+        ) then 1
+        else 0
+    end                     as sans_solution_90
+from {{ ref('stg_candidatures_candidats_entres') }} as c
+group by c.id

--- a/dbt/models/marts/daily/properties.yml
+++ b/dbt/models/marts/daily/properties.yml
@@ -158,4 +158,6 @@ models:
       Table faisant appel a plusieurs ephemeral tables (anciennement des CTEs) afin de pouvoir montrer différentes informations sans être limité par les filtres de Metabase.
       Ainsi nous pouvons montrer le nombre total de candidatures reçues par une structure dans une colonne tout en ne montrant que les candidatures acceptées provenant d'un PH dans une autre.
       Table peu évidente à comprendre, c'est un héritage du passé du pilotage. Nous évitons ce genre de constructions désormais et nous divisons l'information en plusieurs tables & indicateurs.
-
+  - name: candidats_sans_solutions
+    description: >
+      Candidats sans solution à 30 jours (et leurs candidatures).

--- a/dbt/models/staging/properties.yml
+++ b/dbt/models/staging/properties.yml
@@ -164,3 +164,7 @@ models:
   - name: stg_nb_utilisateurs_revenus_semaine
     description: >
       Compte le nb d'utilisateurs qui se sont connectés plusieurs fois sur un tableau de bord sur une semaine donnée.
+  - name: stg_candidatures_candidats_entres
+    description: >
+      Contient les candidats et les candidatures des candidats qui ont au moins une candidature émise ou un diagnostic réalisé.
+      Pour le suivi des candidats sans solution.

--- a/dbt/models/staging/stg_candidats_candidatures.sql
+++ b/dbt/models/staging/stg_candidats_candidatures.sql
@@ -1,6 +1,11 @@
 select
     {{ pilo_star(ref('candidats'),  relation_alias="c") }},
-    cd.date_embauche
+    cd.id as id_candidature,
+    cd.date_embauche,
+    cd.date_candidature,
+    cd."état",
+    cd.id_structure,
+    cd.origine
 from {{ ref('candidats') }} as c
-left join {{ source('emplois', 'candidatures') }} as cd
+left join {{ ref('candidatures_echelle_locale') }} as cd
     on c.id = cd.id_candidat

--- a/dbt/models/staging/stg_candidatures_candidats_entres.sql
+++ b/dbt/models/staging/stg_candidatures_candidats_entres.sql
@@ -1,0 +1,17 @@
+select
+    {{ pilo_star(ref('candidats'),  relation_alias="c") }},
+    cd.date_embauche,
+    cd.date_candidature,
+    cd."état",
+    cd.id_structure,
+    cd.origine,
+    case
+        when pass.id is null then 'Non'
+        else 'Oui'
+    end as "Pass en cours de validité"
+from {{ ref('candidats') }} as c
+left join {{ source('emplois', 'candidatures') }} as cd
+    on c.id = cd.id_candidat
+left join {{ ref('pass_agrements_valides') }} as pass
+    on pass.id_candidat = c.id
+where (total_candidatures > 0 or diagnostic_valide = 1) and (date_diagnostic is null or date_diagnostic <= date_candidature)


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Explo-data-sur-sur-les-candidats-sans-solution-9628477024f64d01b8f9e7b09a11b104?pvs=4

### Pourquoi ? table permettant de suivre les délais des candidats sans solutions


### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

