### PR TITLE
Amelioration calcul des sorties des AI & ETTI + correction bug dates

### DIFF
--- a/dbt/models/staging/stg_contrats.sql
+++ b/dbt/models/staging/stg_contrats.sql
@@ -4,7 +4,7 @@ select distinct
     ctr.contrat_date_embauche,
     ctr.contrat_date_fin_contrat,
     ctr.contrat_type_contrat,
-    ctr.contrat_date_sortie_definitive,
+    to_date(ctr.contrat_date_sortie_definitive, 'DD/MM/YYYY')                      as contrat_date_sortie_definitive,
     sum(case
         when ctr.contrat_type_contrat = 0 then 1
         else 0

--- a/dbt/models/staging/stg_sorties_ai_etti.sql
+++ b/dbt/models/staging/stg_sorties_ai_etti.sql
@@ -3,15 +3,19 @@ select
     except=["emi_nb_heures_travail", "emi_sme_version", "af_id_annexe_financiere", "emi_afi_id", "emi_sme_annee", "emi_sme_mois"]) }},
     disp.type_structure,
     disp.type_structure_emplois,
-    sum(sorties.emi_nb_heures_travail) as total_heures_travaillees
+    nbr_h.total_heures_travaillees_derniere_af as total_heures_travaillees
 from {{ ref('sorties_v2') }} as sorties
 left join {{ ref('ref_mesure_dispositif_asp') }} as disp
     on sorties.af_mesure_dispositif_code = disp.af_mesure_dispositif_code
+left join {{ ref('nombre_heures_travaillees_af') }} as nbr_h
+    on nbr_h.emi_pph_id = sorties.emi_pph_id
 where
-    sorties.rcs_libelle != 'Retrait des sorties constatées' and disp.type_structure_emplois in ('AI', 'ETTI')
+    nbr_h.total_heures_travaillees_derniere_af >= 150
+    and sorties.rcs_libelle != 'Retrait des sorties constatées'
+    and disp.type_structure_emplois in ('AI', 'ETTI')
 group by
     {{ pilo_star(ref('sorties_v2'), relation_alias="sorties",
     except=["emi_nb_heures_travail", "emi_sme_version", "af_id_annexe_financiere", "emi_afi_id", "emi_sme_annee", "emi_sme_mois"]) }},
     disp.type_structure,
-    disp.type_structure_emplois
-having sum(sorties.emi_nb_heures_travail) >= 150
+    disp.type_structure_emplois,
+    nbr_h.total_heures_travaillees_derniere_af


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Modification techniques afin de prendre en compte correctement les sorties des AI & ETTI + correction bug dates (merci Laurine !!!!)

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

