### PR TITLE
DBT : Retour arrière pour les modèles incrémentaux

### DIFF
--- a/dbt/models/indexed/fluxIAE_EtatMensuelIndiv_v2.sql
+++ b/dbt/models/indexed/fluxIAE_EtatMensuelIndiv_v2.sql
@@ -1,8 +1,5 @@
 {{ config(
-    materialized='incremental',
-    unique_key='emi_dsm_id',
     indexes=[
-      {'columns': ['emi_dsm_id'], 'unique' : True},
       {'columns': ['emi_pph_id'], 'unique' : False},
       {'columns': ['emi_afi_id'], 'unique' : False},
       {'columns': ['emi_ctr_id'], 'unique' : False},
@@ -17,6 +14,3 @@ from
     {{ source('fluxIAE', 'fluxIAE_EtatMensuelIndiv') }} as emi
 where
     emi.emi_sme_annee >= 2021
-{% if is_incremental() %}
-    and {{ to_timestamp('emi.emi_date_modification') }} > (select max({{ to_timestamp('emi_date_modification') }}) from {{ this }})
-{% endif %}

--- a/dbt/models/marts/weekly/suivi_etp_realises_v2.sql
+++ b/dbt/models/marts/weekly/suivi_etp_realises_v2.sql
@@ -1,11 +1,3 @@
-{{ config(
-    materialized='incremental',
-    unique_key='emi_dsm_id',
-    indexes=[
-      {'columns': ['emi_dsm_id'], 'unique' : True},
-    ]
- ) }}
-
 select distinct
     emi.emi_pph_id                                                                      as identifiant_salarie,
     emi.emi_afi_id                                                                      as id_annexe_financiere,
@@ -76,6 +68,3 @@ where
     and firmi.rmi_libelle = 'Nombre d''heures annuelles théoriques pour un salarié à taux plein'
     and af.af_etat_annexe_financiere_code in ('VALIDE', 'PROVISOIRE', 'CLOTURE')
     and af.af_mesure_dispositif_code not like '%FDI%'
-{% if is_incremental() %}
-    and {{ to_timestamp('emi.emi_date_modification') }} > (select max({{ to_timestamp('emi_date_modification') }}) from {{ this }})
-{% endif %}


### PR DESCRIPTION
### Pourquoi ?

Le DAG `dbt_weekly` échoue, à juste titre, à cause des tests pour ses 2 modèles après un nouvel import hebdomadaire du Flux IAE.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

