### PR TITLE
follow first connexion without considering tb

### DIFF
--- a/dbt/models/staging/properties.yml
+++ b/dbt/models/staging/properties.yml
@@ -117,7 +117,10 @@ models:
       Vue permettant de récupérer les demandes de prolongation non acceptées
   - name: stg_premiere_visite
     description: >
-      Vue permettant de récupérer la première visite d'un utilisateur sur l'un de nos tableaux de bord privés
+      Vue permettant de récupérer la première visite d'un utilisateur sur l'un de nos tableaux de bord privés.
+  - name: stg_premiere_visite_tous_tb
+    description: >
+      Vue permettant de récupérer la première visite d'un utilisateur sur l'un des tb privé du pilotage.
   - name: stg_test_suivi_etp_realises_par_structure
     description: >
       Vue permettant de tester le nombre de lignes de la table suivi_etp_realises_par_structure.

--- a/dbt/models/staging/stg_premiere_visite_tous_tb.sql
+++ b/dbt/models/staging/stg_premiere_visite_tous_tb.sql
@@ -1,0 +1,6 @@
+select
+    user_id,
+    min(measured_at) as premiere_visite
+from {{ source('emplois', 'c1_private_dashboard_visits_v0') }}
+group by
+    user_id


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Stats-interne-acquisition-b77c0f2feed041aa9bbb327cf884322a?pvs=4

### Pourquoi ?

Ajout d'une colonne premiere visite tous tb confondus pour pouvoir calculer le nb de nouveaux visiteurs au global. 

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

