### PR TITLE
DAG : Gestion minimal des erreurs pour `suivi_visites_campagnes_c0` [GEN-4135]

### DIFF
--- a/dags/common/matomo.py
+++ b/dags/common/matomo.py
@@ -40,25 +40,14 @@ def get_visits_per_campaign_from_matomo(matomo_base_url, tok):
 
         rep = requests.get(url, headers=headers)
 
-        def get_visit_info(produit, json_visit):
-            """
-            from a json visit extracted from matomo via api, returns a dict of relevant informations
-            """
-
-            def get_rounded_minutes(seconds):
-                return round(int(seconds) / 60)
-
+        for json in rep.json():
             infos = {
                 "produit": produit,
-                "poste": json_visit["referrerKeyword"],
-                "date": json_visit["serverDate"],
-                "visiteur": json_visit["visitorId"],
-                "nb_actions": len(json_visit["actionDetails"]),
-                "duree": get_rounded_minutes(json_visit["visitDuration"]),
+                "poste": json["referrerKeyword"],
+                "date": json["serverDate"],
+                "visiteur": json["visitorId"],
+                "nb_actions": len(json["actionDetails"]),
+                "duree": round(int(json["visitDuration"]) / 60),
             }
-            return infos
-
-        for json in rep.json():
-            infos = get_visit_info(produit, json)
             dtf = dtf._append(infos, ignore_index=True)
     return dtf

--- a/dags/common/matomo.py
+++ b/dags/common/matomo.py
@@ -1,3 +1,5 @@
+import logging
+
 import requests
 
 
@@ -38,9 +40,19 @@ def get_visits_per_campaign_from_matomo(matomo_base_url, tok):
             f"&token_auth={tok}"
         )
 
-        rep = requests.get(url, headers=headers)
+        response = requests.get(url, headers=headers)
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as e:
+            logging.error("HTTP error: %s", str(e).replace(f"&token_auth={tok}", "&token_auth=[TOKEN]"))
+            continue
 
-        for json in rep.json():
+        data = response.json()
+        if isinstance(data, dict):
+            logging.error("Matomo %s: %s", data.get("result"), data.get("message"))
+            continue
+
+        for json in data:
             infos = {
                 "produit": produit,
                 "poste": json["referrerKeyword"],

--- a/dags/suivi_visites_campagnes_c0.py
+++ b/dags/suivi_visites_campagnes_c0.py
@@ -18,9 +18,10 @@ with DAG(
 
     @task(task_id="get_visits_per_campaign")
     def get_visits_per_campaign(**kwargs):
-        matomo_base_url = Variable.get("MATOMO_BASE_URL")
-        tok = Variable.get("GIP_MATOMO_TOKEN")
-        out_dtf = matomo.get_visits_per_campaign_from_matomo(matomo_base_url, tok)
+        out_dtf = matomo.get_visits_per_campaign_from_matomo(
+            Variable.get("MATOMO_BASE_URL"),
+            Variable.get("GIP_MATOMO_TOKEN"),
+        )
         out_dtf.to_sql(
             "visits_per_campaign_c0",
             con=db.connection_engine(),


### PR DESCRIPTION
### Pourquoi ?

Avoir un peu plus d'information en cas d'erreur que des `TypeError: string indices must be integers` :grin:.
La version actuelle ne casse quand il y a une erreur (les `continue`), je ne sais pas si c'est bien ou pas, à vous de me dire :).

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

