### PR TITLE
Ajout d'un nouveau motif de refus de prolongation

### DIFF
--- a/dbt/models/staging/stg_suivi_demandes_prolongations_non_acceptees.sql
+++ b/dbt/models/staging/stg_suivi_demandes_prolongations_non_acceptees.sql
@@ -19,7 +19,7 @@ select
     demandes_prolong.date_de_demande                                                        as "date_de_création",
     case
         when demandes_prolong.motif_de_refus = 'IAE'
-            then 'L IAE ne correspond plus aux besoins / à la situation de la personne'
+            then 'L’IAE ne correspond plus aux besoins / à la situation de la personne'
         when demandes_prolong.motif_de_refus = 'SIAE'
             then 'La typologie de SIAE ne correspond plus aux besoins / à la situation de la personne'
         when demandes_prolong.motif_de_refus = 'DURATION'

--- a/dbt/models/staging/stg_suivi_demandes_prolongations_non_acceptees.sql
+++ b/dbt/models/staging/stg_suivi_demandes_prolongations_non_acceptees.sql
@@ -24,6 +24,8 @@ select
             then 'La typologie de SIAE ne correspond plus aux besoins / à la situation de la personne'
         when demandes_prolong.motif_de_refus = 'DURATION'
             then 'La durée de prolongation demandée n’est pas adaptée à la situation du candidat'
+        when demandes_prolong.motif_de_refus = 'REASON'
+            then 'Le motif de prolongation demandé n’est pas adapté à la situation du candidat.'
         else 'Pas de donnée disponible'
     end                                                                                     as motif_de_refus,
     case


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Ajouter-un-nouveau-motif-de-refus-de-prolongation-motif-pas-adapt-boost-daabbc0f2ec94259b0a2ca3a179c14a1?pvs=4

### Pourquoi ?

Les emplois rajoutent un motif qu'il va falloir gérer coté pilotage.

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

