### PR TITLE
Makefile: Correction des recettes `.PHONY`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,22 +4,15 @@
 # > practice; so for compatibility, you must explicitly request it
 .DELETE_ON_ERROR:
 
-PYTHON_VERSION := python3.10
-
 VIRTUAL_ENV ?= $(shell pwd)/.venv
 export PATH := $(VIRTUAL_ENV)/bin:$(PATH)
 
-DUMP_DIR ?= .latest.dump
-RESTORE_DIR ?= .latest.restore
 
-MONITORED_DIRS := dags dbt tests
+# Python
+# =============================================================================
+.PHONY: venv_ci update
 
-# FIXME(vperron): In the long run we should include "references.consistent,references.from,references.qualification" rules.
-SQLFLUFF_OPTIONS := \
-	--exclude-rules ambiguous.distinct,layout.long_lines,references.consistent,references.from,references.qualification,references.special_chars \
-	--disable-progress-bar --nocolor
-
-.PHONY: venv_ci update clean compile-deps airflow_init dbt_clean dbt_docs fix quality test load_dump
+PYTHON_VERSION := python3.10
 
 venv_ci:
 	$(PYTHON_VERSION) -m venv $(VIRTUAL_ENV)
@@ -27,6 +20,40 @@ venv_ci:
 update:
 	$(VIRTUAL_ENV)/bin/pip install --force-reinstall --no-color --progress-bar off -r requirements-ci.txt
 	$(VIRTUAL_ENV)/bin/pip install --force-reinstall --no-color --progress-bar off dbt-fal==1.5.4 dbt-core==1.5.1
+
+
+# Quality
+# =============================================================================
+.PHONY: fix quality test clean
+
+MONITORED_DIRS := dags dbt tests
+# FIXME(vperron): In the long run we should include "references.consistent,references.from,references.qualification" rules.
+SQLFLUFF_OPTIONS := \
+	--exclude-rules ambiguous.distinct,layout.long_lines,references.consistent,references.from,references.qualification,references.special_chars \
+	--disable-progress-bar --nocolor
+
+# if `sqlfluff fix` does not work, use `sqlfluff parse` to investigate.
+fix:
+	black $(MONITORED_DIRS)
+	ruff check --fix $(MONITORED_DIRS)
+	sqlfluff fix --force $(SQLFLUFF_OPTIONS) $(MONITORED_DIRS)
+
+quality:
+	black --check $(MONITORED_DIRS)
+	ruff check $(MONITORED_DIRS)
+	sqlfluff lint $(SQLFLUFF_OPTIONS) $(MONITORED_DIRS)
+
+test:
+	pytest -v -W ignore::DeprecationWarning
+
+clean: dbt_clean
+	find . -depth -type d -name "__pycache__" -exec rm -rf '{}' \;
+	find . -type d -empty -delete
+
+
+# DBT
+# =============================================================================
+.PHONY: dbt_clean dbt_docs dbt_run dbt_weekly dbt_daily
 
 dbt_clean:
 	rm -rf $(DBT_TARGET_PATH)
@@ -48,31 +75,13 @@ dbt_daily:
 	dbt run --select marts.daily legacy.daily ephemeral staging
 	dbt test
 
-clean: dbt_clean
-	find . -depth -type d -name "__pycache__" -exec rm -rf '{}' \;
-	find . -type d -empty -delete
 
-# if `sqlfluff fix` does not work, use `sqlfluff parse` to investigate.
-fix:
-	black $(MONITORED_DIRS)
-	ruff check --fix $(MONITORED_DIRS)
-	sqlfluff fix --force $(SQLFLUFF_OPTIONS) $(MONITORED_DIRS)
+# Database
+# =============================================================================
+.PHONY: pg_dump pg_restore load_dump
 
-quality:
-	black --check $(MONITORED_DIRS)
-	ruff check $(MONITORED_DIRS)
-	sqlfluff lint $(SQLFLUFF_OPTIONS) $(MONITORED_DIRS)
-
-airflow_initdb:
-	createdb airflow || true
-	airflow db reset -y && \
-		airflow db upgrade && \
-		airflow variables import dag-variables.json && \
-		airflow users create --role Admin --email admin@example.com --username admin --password password -f "" -l ""
-
-test:
-	pytest -v -W ignore::DeprecationWarning
-
+DUMP_DIR ?= .latest.dump
+RESTORE_DIR ?= .latest.restore
 
 pg_dump:
 	@PGDATABASE=${PROD_PGDATABASE} PGHOST=${PROD_PGHOST} PGPORT=${PROD_PGPORT} PGUSER=${PROD_PGUSER} PGPASSWORD=${PROD_PGPASSWORD} \
@@ -101,3 +110,15 @@ else
 endif
 
 load_dump: pg_dump pg_restore
+
+
+# Airflow
+# =============================================================================
+.PHONY: airflow_initdb
+
+airflow_initdb:
+	createdb airflow || true
+	airflow db reset -y && \
+		airflow db upgrade && \
+		airflow variables import dag-variables.json && \
+		airflow users create --role Admin --email admin@example.com --username admin --password password -f "" -l ""


### PR DESCRIPTION
### Pourquoi ?

Le `.PHONY` n'étais plus à jour :
- `compile-deps` n'existe pas
- `airflow_init` se nomme `airflow_initdb`
- Quelques recettes étaient manquantes

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

