### PR TITLE
Ajout d'une colonne permettant de filtrer sur les candidats en IAE

### DIFF
--- a/dbt/models/marts/daily/candidats_recherche_active.sql
+++ b/dbt/models/marts/daily/candidats_recherche_active.sql
@@ -5,13 +5,14 @@ select
     type_auteur_diagnostic,
     "région",
     "nom_département",
-    max(date_candidature)                                                                   as date_derniere_candidature,
-    current_date - max(date_candidature)                                                    as delai_derniere_candidature,
-    current_date - max(case when "état" = 'Candidature acceptée' then date_candidature end) as delai_derniere_candidature_acceptee,
-    max(case when "état" = 'Candidature acceptée' then date_candidature end)                as date_derniere_candidature_acceptee,
-    sum(case when "état" = 'Candidature acceptée' then 1 else 0 end)                        as nb_candidatures_acceptees,
-    sum(case when "état" != 'Candidature acceptée' then 1 else 0 end)                       as nb_candidatures_sans_accept,
-    coalesce(sum(case when "état" = 'Candidature acceptée' then 1 else 0 end) > 0)          as a_eu_acceptation
+    coalesce(sum(case when "type_structure" in ('ACI', 'AI', 'EI', 'EITI', 'ETTI') then 1 else 0 end) > 0) as candidat_iae,
+    max(date_candidature)                                                                                  as date_derniere_candidature,
+    current_date - max(date_candidature)                                                                   as delai_derniere_candidature,
+    current_date - max(case when "état" = 'Candidature acceptée' then date_candidature end)                as delai_derniere_candidature_acceptee,
+    max(case when "état" = 'Candidature acceptée' then date_candidature end)                               as date_derniere_candidature_acceptee,
+    sum(case when "état" = 'Candidature acceptée' then 1 else 0 end)                                       as nb_candidatures_acceptees,
+    sum(case when "état" != 'Candidature acceptée' then 1 else 0 end)                                      as nb_candidatures_sans_accept,
+    coalesce(sum(case when "état" = 'Candidature acceptée' then 1 else 0 end) > 0)                         as a_eu_acceptation
 from {{ ref('stg_candidats_candidatures') }}
 where date_candidature >= current_date - interval '6 months'
 group by


### PR DESCRIPTION
**Carte Notion : ** https://itou-inclusion.slack.com/archives/C053YHWGK41/p1707381920503299

### Pourquoi ?

je comptabilisais tous les candidats et pas uniquement czeux qui ont émis une candidature vers une siae.
j'ai fait le choix d'ajouter une colonne booléenne pour qu'on garde une trace des autres candidats pour le jour où on généralisera ces indicateurs aux autres structures

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

