### PR TITLE
Ajout d'une colonne département/région filtre

### DIFF
--- a/dbt/models/staging/stg_suivi_demandes_prolongations_acceptees.sql
+++ b/dbt/models/staging/stg_suivi_demandes_prolongations_acceptees.sql
@@ -16,6 +16,8 @@ select
     s.type                                                                                  as type_structure,
     s."nom_département_c1"                                                                  as "département_structure",
     s."région_c1"                                                                           as "région_structure",
+    s."nom_département_c1"                                                                  as "département_structure_filtre",
+    s."région_c1"                                                                           as "région_structure_filtre",
     prolong."date_de_création",
     demandes_prolong.motif_de_refus,
     case

--- a/dbt/models/staging/stg_suivi_demandes_prolongations_non_acceptees.sql
+++ b/dbt/models/staging/stg_suivi_demandes_prolongations_non_acceptees.sql
@@ -16,6 +16,8 @@ select
     s.type                                                                                  as type_structure,
     s."nom_département_c1"                                                                  as "département_structure",
     s."région_c1"                                                                           as "région_structure",
+    s."nom_département_c1"                                                                  as "département_structure_filtre",
+    s."région_c1"                                                                           as "région_structure_filtre",
     demandes_prolong.date_de_demande                                                        as "date_de_création",
     case
         when demandes_prolong.motif_de_refus = 'IAE'


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Suite à un bug dans l'affichage des filtres metabase sur les TBs privés en prod, nous avons remarqué qu'il était impossible d'avoir deux filtres "département" cablés sur la même colonne tout en ayant un des deux filtres verrouillé côté metabase.
Le problème a été réglé en spécifiant côté metabase que les deux filtres sont modifiables, malheureusement cela implique des problèmes potentiels et n'est pas une bonne solution.

Nous voulons donc tester le fait d'avoir deux colonnes de lieu, une pour le filtre verrouillé et l'autre pour le filtre modifiable.
Les modifications sur ces deux tables nous permettront de tester si cette hypothèse est bonne avant une MEP à grande échelle.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

