### PR TITLE
Ajout du numéro d'AF sur une table de suivi des ETPs

### DIFF
--- a/dbt/models/marts/weekly/suivi_realisation_convention_par_structure.sql
+++ b/dbt/models/marts/weekly/suivi_realisation_convention_par_structure.sql
@@ -1,5 +1,6 @@
 select
     etp.id_annexe_financiere,
+    etp.af_numero_annexe_financiere,
     etp.emi_esm_etat_code,
     etp.annee_af,
     etp.type_structure,
@@ -21,6 +22,7 @@ select
 from {{ ref('suivi_realisation_convention_mensuelle') }} as etp
 group by
     etp.id_annexe_financiere,
+    etp.af_numero_annexe_financiere,
     etp.emi_esm_etat_code,
     etp.annee_af,
     etp.type_structure,


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Afin de mettre en prod une version privée du TB de suivi des ETPs il est nécessaire d'ajouter le numéro d'AF sur une table suivant les effectifs mensuels

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

