### PR TITLE
Ajout de l'année de la candidature

### DIFF
--- a/dbt/models/staging/stg_candidatures.sql
+++ b/dbt/models/staging/stg_candidatures.sql
@@ -28,7 +28,8 @@ select
         else candidatures."origine_détaillée"
     end                                                    as "origine_détaillée",
     extract(day from candidatures."délai_de_réponse")      as temps_de_reponse,
-    extract(day from candidatures."délai_prise_en_compte") as temps_de_prise_en_compte
+    extract(day from candidatures."délai_prise_en_compte") as temps_de_prise_en_compte,
+    extract(year from candidatures.date_candidature)       as annee_candidature
 from
     {{ source('emplois', 'candidatures') }} as candidatures
 left join {{ ref('stg_structures') }} as struct


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Permettre l'ajout d'un filtre annuel sur le tb vision annuel des candidatures pour les SIAE

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

