### PR TITLE
Utiliser la même version d'airflow dans le Dockerfile que celle dans `requirements-ci.txt`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # build me as docker build . -t my-airflow
 # run me as docker run -ti -p 8080:8080 --env-file=.env my-airflow
 
-FROM apache/airflow:2.5.1-python3.10
+FROM apache/airflow:2.6.2-python3.10
 
 USER root
 


### PR DESCRIPTION
### Pourquoi ?

Si mon cas de reproduction est correct alors cela devrais corriger l'erreur empêchant le déploiement :
```
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_NOTIFY_POLICY'. Did you mean: 'X509_V_FLAG_EXPLICIT_POLICY'?
```
Et au pire ça ne peux pas faire de mal je pense ;).

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

