### PR TITLE
Ajout du suivi du TB privé 349 - Déclaration d'embauche

### DIFF
--- a/dbt/seeds/pilotage_interne/metabase_dashboards.csv
+++ b/dbt/seeds/pilotage_interne/metabase_dashboards.csv
@@ -38,4 +38,5 @@ id_tb,nom_tb,public,type
 327,tb 327 - ACI - Suivi du cofinancement CD,SIAE,TB privé
 330,tb 330 - CD - Suivi des prescriptions des accompagnateurs des publics bRSA,CD,TB privé
 346,tb 346 - CD - Facilitation des embauches en IAE,CD,TB privé
+349,tb 349 - SIAE - Déclaration d’embauche,SIAE,TB privé
 357,tb 357 - DDETS/DREETS - Suivi des demandes de prolongation réalisées par les SIAE,DDETS/DREETS,TB privé


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/MEP-le-TB394-D-claration-d-embauche-pour-les-SIAE-sur-la-r-gion-d-Occitanie-exp-actions-data--46beaba3b3c04d5d8ca8764d86278669?pvs=4#60d1c57665a848249127361010ff8d86

### Pourquoi ?

Ajout du suivi du TB privé 349 - Déclaration d'embauche

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

