### PR TITLE
add date of last application to candidates table

### DIFF
--- a/dbt/models/marts/daily/candidats.sql
+++ b/dbt/models/marts/daily/candidats.sql
@@ -1,5 +1,6 @@
 select
     {{ pilo_star(ref('stg_candidats')) }},
+    derniere_candidature.date_derniere_candidature,
     case
         when date_diagnostic > current_date - interval '6 months' then 1
         else 0
@@ -25,4 +26,7 @@ select
         else 'NON'
     end as eligible_cdi_inclusion
 from
-    {{ ref('stg_candidats') }}
+    {{ ref('stg_candidats') }} as candidats
+left join
+    {{ ref('stg_candidatures_candidats') }} as derniere_candidature
+    on derniere_candidature.id_candidat = candidats.id

--- a/dbt/models/staging/stg_candidatures.sql
+++ b/dbt/models/staging/stg_candidatures.sql
@@ -2,7 +2,7 @@ select
     {{ pilo_star(source('emplois', 'candidatures'),
         except=["id", "date_mise_à_jour_metabase", "état", "motif_de_refus", "origine", "origine_détaillée"]) }},
     {{ pilo_star(ref('stg_organisations'),
-        except=["id", "date_mise_à_jour_metabase", "ville", "code_commune", "type", "date_inscription", "total_candidatures", "total_membres", "total_embauches", "date_derniere_candidature"], relation_alias='org_prescripteur') }},
+        except=["id", "date_mise_à_jour_metabase", "ville", "code_commune", "type", "date_inscription", "total_candidatures", "total_membres", "total_embauches", "date_dernière_candidature"], relation_alias='org_prescripteur') }},
     candidatures.id                                        as id,
     struct.bassin_d_emploi                                 as bassin_emploi_structure,
     org_prescripteur.zone_emploi                           as bassin_emploi_prescripteur,

--- a/dbt/models/staging/stg_candidatures_candidats.sql
+++ b/dbt/models/staging/stg_candidatures_candidats.sql
@@ -1,0 +1,7 @@
+select
+    id_candidat,
+    max(date_candidature) as date_derniere_candidature
+from
+    {{ ref('stg_candidatures') }}
+group by
+    id_candidat


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Ajouter-nouvel-indicateur-et-mettre-jour-le-TB216-Place-des-femmes-dans-les-candidatures-l-IAE-ebdcfabe03c74c39bbd55e1a46dcfc50?pvs=4

### Pourquoi ?

pouvoir brancher le filtre date candidature aux indicateurs candidat

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

