### PR TITLE
Création de la documentation de la table pour le marché

### DIFF
--- a/dbt/models/marts/weekly/marche_suivi_structure.sql
+++ b/dbt/models/marts/weekly/marche_suivi_structure.sql
@@ -1,12 +1,15 @@
 select
     etp_r.identifiant_salarie,
+    etp_r.id_annexe_financiere,
+    etp_r.emi_sme_annee,
+    etp_r.nombre_etp_consommes_reels_annuels,
+    etp_r.nombre_etp_consommes_reels_mensuels,
     etp_c."effectif_annuel_conventionné",
+    etp_c."effectif_mensuel_conventionné",
     s.structure_siret_signature,
     s.structure_siret_actualise,
     s.structure_denomination,
     ctr.contrat_salarie_rqth,
-    etp_r.id_annexe_financiere,
-    etp_r.emi_sme_annee,
     salarie.salarie_annee_naissance,
     case
         when salarie.salarie_adr_qpv_type = 'QP' then 'QPV'
@@ -36,7 +39,10 @@ left join {{ ref('fluxIAE_ContratMission_v2') }} as ctr
 where etp_r.type_structure not in ('ACIPA_DC', 'EIPA_DC', 'FDI')
 group by
     etp_r.identifiant_salarie,
+    etp_r.nombre_etp_consommes_reels_annuels,
+    etp_r.nombre_etp_consommes_reels_mensuels,
     etp_c."effectif_annuel_conventionné",
+    etp_c."effectif_mensuel_conventionné",
     s.structure_siret_signature,
     s.structure_siret_actualise,
     s.structure_denomination,

--- a/dbt/models/marts/weekly/properties.yml
+++ b/dbt/models/marts/weekly/properties.yml
@@ -87,6 +87,35 @@ models:
   - name: marche_suivi_structure
     description: >
       Table créée afin que le marché puisse produire des rapports sur les salariées des structures travaillant avec eux.
-
-
-
+      Afin de permettre au marché d'être autonome dans l'utilisation de cette table, ci dessous la description des colonnes
+    columns:
+      - name: identifiant_salarie
+        description: identifiant unique du salarie PAR STRUCTURE ce dernier est répertorié dans l'ASP dès qu'un contrat est signé. Un salarié peut signer des contrats dans deux structure différentes sans que nous le sachions car l'identifiant est propre à la structure (et non au flux de l'asp). Les autres colonnes de la table indiquent si le salarié est zrr/qpv/etc. Si un salarié a été en zrr 3 mois puis non zrr 9 mois sur une année, il y aura deux entrées pour ce salarié.
+      - name: id_annexe_financiere
+        description: id unique d'annexe financiere, il y a un ID par année d'annexe. Attention une structure peut avoir deux annexes sur la même année, donc nous pouvons nous retrouver avec deux ID pour la même année. Pour éviter des confusions, il a été décidé de fournir que l'ID d'annexe sans le numéro d'annexe financiere.
+      - name: emi_sme_annee
+        description: année où le salarie a travaillée dans le structure et donc par extension année de l'annexe;
+      - name: nombre_etp_consommes_reels_annuels
+        description: nombre d'ETP annuels réalisés par salarié. Si un salarié a travaillé 0h dans la structure son réalisé sera de 0
+      - name: nombre_etp_consommes_reels_mensuels
+        description: nombre d'ETP mensuels réalisés par salarié. Si un salarié a travaillé 0h dans la structure son réalisé sera de 0
+      - name: effectif_annuel_conventionné
+        description: nombre d'ETP annuels conventionnés pour la structure. Attention ici on a les ETPs conventionnés pour toute la structure qui sont répétés pour chaque salarié. Afin d'avoir le bon effectif conventionné il faut soit prendre individuellement une valeur ou faire somme(etp_conventionnés)/identifiant_salarie uniques
+      - name: effectif_mensuel_conventionné
+        description: nombre d'ETP mensuels réalisés par salarié. Attention ici on a les ETPs conventionnés pour toute la structure qui sont répétés pour chaque salarié. Afin d'avoir le bon effectif conventionné il faut soit prendre individuellement une valeur ou faire somme(etp_conventionnés)/identifiant_salarie uniques
+      - name: structure_siret_signature
+        description: SIRET de la structure à la signature de l'annexe financiere
+      - name: structure_siret_actualise
+        description: SIRET de la structure actualisé en fonction de l'année et de l'id d'annexe financiere
+      - name: structure_denomination
+        description: nom de la structure
+      - name: contrat_salarie_rqth
+        description: Salarie RQTH
+      - name: salarie_annee_naissance
+        description: Année de naissance salarié
+      - name: adresse_qpv
+        description: salarie vivant en qpv (oui/non/non renseigné)
+      - name: adresse_zrr
+        description: salarie vivant en zrr (oui/non/non renseigné)
+      - name: genre_salarie
+        description: genre salarié (oui/non/non renseigné)


### PR DESCRIPTION
**Carte Notion : ** : https://www.notion.so/plateforme-inclusion/Ajouter-ETP-r-alis-s-table-march-doc-API-20f0fbd4aebe4e5d83d04741faf89755?pvs=4

### Pourquoi ?

Création de la documentation de la table pour le marché afin que ces derniers soient autonomes dans l'utilisation de cette dernière.
A fusionner uniquement après le go d'Aurélie sur les etp réalisés 
### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

