### PR TITLE
Correction d'une erreur renvoyant un FALSE inattendu 

### DIFF
--- a/dbt/models/marts/daily/candidats_recherche_active.sql
+++ b/dbt/models/marts/daily/candidats_recherche_active.sql
@@ -16,7 +16,7 @@ select
     sum(case when "état" = 'Candidature acceptée' then 1 else 0 end)                                       as nb_candidatures_acceptees,
     sum(case when "état" != 'Candidature acceptée' then 1 else 0 end)                                      as nb_candidatures_sans_accept,
     coalesce(sum(case when "état" = 'Candidature acceptée' then 1 else 0 end) > 0)                         as a_eu_acceptation,
-    coalesce(max(date_embauche) >= current_date - interval '6 months')                                     as a_eu_embauche
+    coalesce(max(date_embauche) >= current_date - interval '6 months', max(date_embauche) is not null)     as a_eu_embauche
 from {{ ref('stg_candidats_candidatures') }}
 where date_candidature >= current_date - interval '6 months'
 group by


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

erreur inattention une condition manquait au coalesce et donc null était renvoyé au lieu de false

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

