### PR TITLE
Calcul des communes des structures à partir des données insee

### DIFF
--- a/dbt/models/marts/daily/structures.sql
+++ b/dbt/models/marts/daily/structures.sql
@@ -1,13 +1,17 @@
 select
-    {{ pilo_star(source('emplois','structures_v0'), except=['source'], relation_alias='s') }},
-    grp_strct.groupe as categorie_structure,
+    {{ pilo_star(source('emplois','structures_v0'), except=['source', 'ville'], relation_alias='struct') }},
+    insee.libelle_commune as ville,
+    grp_strct.groupe      as categorie_structure,
     case
-        when type = 'OPCS' and source = 'Utilisateur (Antenne)' then 'Utilisateur (OPCS)'
-        when type = 'OPCS' and source = 'Staff Itou' then 'Staff Itou (OPCS)'
-        else source
-    end              as source
+        when struct.type = 'OPCS' and struct.source = 'Utilisateur (Antenne)' then 'Utilisateur (OPCS)'
+        when struct.type = 'OPCS' and struct.source = 'Staff Itou' then 'Staff Itou (OPCS)'
+        else struct.source
+    end                   as source
 from
-    {{ source('emplois','structures_v0') }} as s
+    {{ source('emplois','structures_v0') }} as struct
 left join
     {{ ref('groupes_structures') }} as grp_strct
-    on grp_strct.structure = s.type
+    on grp_strct.structure = struct.type
+left join
+    {{ ref('insee_communes') }} as insee
+    on coalesce(ltrim(struct.code_commune, '0'), ltrim(struct.code_commune_c1, '0')) = insee.code_insee


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Uniformiser-la-colonne-commune-pour-qu-il-soit-associ-aux-codes-communes-INSEE-edc3ef3246ee4f6f90edcdc58c78e9d6?pvs=4

### Pourquoi ?

Pour éviter les communes crassoues entrées sur les emplois: doublons de commune à cause des différences de casse, code postaux dans le libelle, etc...

Quelques notes : 
- je n'ai pas compris pourquoi on a deux colonnes pour le code_commune : code_commune_c1 vs code_commune donc je fais un tricky move pour prendre celui qui n'est pas vide (car des fois l'un est vide et l'autre non), typiquement un exemple de truc crassou à discuter en point tech pour améliorer ensemble @rsebille 
- en faisant de la sorte j'ai 92 communes au CC non rempli, 
- en résultat j'ai 98/7327 villes introuvables, dont les 92 du dessus et quelques autres où le CC n'est pas dans le cog (piste: remettre la seed à jour - mais j'ai regardé vite fait et je ne trouve nulle part ces CC dans les csv du cog - en revanche je les trouve bien en faisant une recherche sur le moteur de l'insee)
- pour les villes sans cc j'aurais pu récupérer le libelle commune c1 mais étant donné le faible nombre, je choisis de ne pas le faire pour qu'on ait des libelle 100% propres (et de toute manière quand on visualise c'est basé sur le CC)

En conclusion, on pourra sans doute mieux faire quand on en aura parlé ensemble 

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

