### PR TITLE
Candidats recherche active : ajout de tests et d'une table candidatures pour suivi des motifs

### DIFF
--- a/dbt/models/marts/daily/candidatures_candidats_recherche_active.sql
+++ b/dbt/models/marts/daily/candidatures_candidats_recherche_active.sql
@@ -1,0 +1,3 @@
+select {{ pilo_star(ref('stg_candidats_candidatures')) }}
+from {{ ref('stg_candidats_candidatures') }}
+where date_candidature >= current_date - interval '6 months'

--- a/dbt/tests/test_candidats_recherche_active.sql
+++ b/dbt/tests/test_candidats_recherche_active.sql
@@ -1,0 +1,16 @@
+with nb_candidats_recherche_active as (
+    select
+        (
+            select count(distinct id)
+            from stg_candidats_candidatures
+            where date_candidature >= current_date - interval '6 months'
+        ) as cdd_stg,
+        (
+            select count(*)
+            from candidats_recherche_active
+        ) as cdd_candidats_recherche_active
+)
+
+select *
+from nb_candidats_recherche_active
+where cdd_stg != cdd_candidats_recherche_active

--- a/dbt/tests/test_candidatures_candidats_recherche_active.sql
+++ b/dbt/tests/test_candidatures_candidats_recherche_active.sql
@@ -1,0 +1,16 @@
+with nb_candidatures as (
+    select
+        (
+            select count(*)
+            from candidatures_echelle_locale
+            where date_candidature >= current_date - interval '6 months'
+        ) as candidatures_cel,
+        (
+            select count(*)
+            from candidatures_candidats_recherche_active
+        ) as candidatures_cra
+)
+
+select *
+from nb_candidatures
+where candidatures_cel != candidatures_cra

--- a/dbt/tests/test_stg_candidats_candidature.sql
+++ b/dbt/tests/test_stg_candidats_candidature.sql
@@ -1,0 +1,15 @@
+with nb_candidats as (
+    select
+        (
+            select count(distinct id)
+            from {{ ref("stg_candidats_candidatures") }}
+        ) as nb_candidats_stg,
+        (
+            select count(*)
+            from {{ ref("candidats") }}
+        ) as nb_candidats
+)
+
+select *
+from nb_candidats
+where nb_candidats_stg != nb_candidats


### PR DESCRIPTION
**Carte Notion : **  https://www.notion.so/plateforme-inclusion/Tableau-d-taill-de-r-partition-des-motifs-de-refus-par-origine-d-taill-de-la-candidature-en-nb--1212704d6b7148cb9e3a9a4fcf1cd517?pvs=4

### Pourquoi ?

Fiabiliser les tables (tests) et permettre de calculer des indicateurs sur les motifs de refus (nouvelle table)

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

