### PR TITLE
Retrait des structures mères du potentiel

### DIFF
--- a/dbt/models/marts/daily/nb_utilisateurs_potentiels.py
+++ b/dbt/models/marts/daily/nb_utilisateurs_potentiels.py
@@ -12,6 +12,8 @@ def model(dbt, session):
     organisations = organisations[organisations["total_membres"] != 0]
     institutions = dbt.source("emplois", "institutions")
     structures = dbt.source("emplois", "structures")
+    # we only consider mother structures
+    structures = structures[structures["source"] != "Utilisateur (Antenne)"]
     regions = filter(None, institutions["région"].unique())
 
     potential_records = []

--- a/dbt/tests/properties.yml
+++ b/dbt/tests/properties.yml
@@ -16,3 +16,6 @@ tests:
   - name: test_source_opcs
     description: >
       Permet de vérifier que le nb de structures opcs est le même que le nb de structures qui ont pour source un opcs.
+   - name: test_potentiel_structures
+    description: >
+      Permet de vérifier que le nb de structures comptées dans le potentiel correspond bien au nombre de structures mères de la table structure

--- a/dbt/tests/test_potentiel_structures.sql
+++ b/dbt/tests/test_potentiel_structures.sql
@@ -1,0 +1,17 @@
+with nb_structures_meres as (
+    select
+        (
+            select count(*)
+            from structures
+            where source != 'Utilisateur (Antenne)' and "nom_département" is not null
+        ) as structures_meres,
+        (
+            select sum(potentiel)
+            from nb_utilisateurs_potentiels
+            where type_utilisateur = 'siae'
+        ) as structures_mere_potentiel
+)
+
+select *
+from nb_structures_meres
+where structures_meres != structures_mere_potentiel


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Enlever-les-antennes-SIAE-du-TB-potentiel-utilisateur-97c716135826499f802f7d9cb47c72cf?pvs=4

### Pourquoi ?
Ne pas les compter dans les statistiques de pilotage


### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

