### PR TITLE
Ajout de deux tbs privés à la seed des tbs

### DIFF
--- a/dbt/seeds/pilotage_interne/metabase_dashboards.csv
+++ b/dbt/seeds/pilotage_interne/metabase_dashboards.csv
@@ -30,6 +30,7 @@ id_tb,nom_tb,public,type
 235,tb 235 - Suivi des prescriptions (DIHAL),DIHAL,TB privé
 265,tb 265 - Suivi CAP DREETS/DDETS,DREETS/DDETS,TB privé
 267,tb 267 - Focus auto-prescription DREETS/DDETS,DREETS/DDETS,TB privé
+289,tb 289 - Suivi des prescriptions des PH DDETS/DREETS,DDETS/DREETS, TB privé
 295,tb 295 - Suivi de l'auto-prescription (SIAE),SIAE,TB privé
 298,tb 298 - Suivi du contrôle a posteriori (SIAE),SIAE,TB privé
 300,tb 300 - Suivi du contrôle a posteriori,tous,TB public
@@ -40,3 +41,4 @@ id_tb,nom_tb,public,type
 346,tb 346 - CD - Facilitation des embauches en IAE,CD,TB privé
 349,tb 349 - SIAE - Déclaration d’embauche,SIAE,TB privé
 357,tb 357 - DDETS/DREETS - Suivi des demandes de prolongation réalisées par les SIAE,DDETS/DREETS,TB privé
+389,tb 389 - Fiches de poste en tension DDETS/DREETS,DDETS/DREETS, TB privé


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Ajout-des-suivis-de-connexion-TB389-TB289-743a5f1f46124117b53a91a77cd7d2a1?pvs=4

### Pourquoi ?

Pour le suivi des utilisateurs

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

