### PR TITLE
Historisation de la table candidats recherche active

### DIFF
--- a/dags/dbt_daily.py
+++ b/dags/dbt_daily.py
@@ -60,13 +60,6 @@ with airflow.DAG(
         append_env=True,
     )
 
-    dbt_snapshot = bash.BashOperator(
-        task_id="dbt_snapshot",
-        bash_command="dbt snapshot",
-        env=env_vars,
-        append_env=True,
-    )
-
     dbt_clean = bash.BashOperator(
         task_id="dbt_clean",
         bash_command="dbt clean",
@@ -78,4 +71,4 @@ with airflow.DAG(
         trigger_dag_id="data_consistency", task_id="trigger_data_consistency"
     )
 
-    (start >> dbt_debug >> dbt_deps >> dbt_seed >> dbt_run >> dbt_snapshot >> dbt_clean >> dag_data_consistency >> end)
+    (start >> dbt_debug >> dbt_deps >> dbt_seed >> dbt_run >> dbt_clean >> dag_data_consistency >> end)

--- a/dags/dbt_snapshot.py
+++ b/dags/dbt_snapshot.py
@@ -1,0 +1,56 @@
+import airflow
+from airflow.models.param import Param
+from airflow.operators import bash, empty, trigger_dagrun
+
+from dags.common import db, dbt, default_dag_args, slack
+
+
+dag_args = default_dag_args() | {"default_args": dbt.get_default_args()}
+
+with airflow.DAG(
+    dag_id="dbt_weekly",
+    schedule_interval=None,
+    params={
+        "full_refresh": Param(False, type="boolean"),
+    },
+    **dag_args,
+) as dag:
+    start = empty.EmptyOperator(task_id="start")
+
+    end = slack.success_notifying_task()
+
+    env_vars = db.connection_envvars()
+
+    dbt_debug = bash.BashOperator(
+        task_id="dbt_debug",
+        bash_command="dbt debug",
+        env=env_vars,
+        append_env=True,
+    )
+
+    dbt_deps = bash.BashOperator(
+        task_id="dbt_deps",
+        bash_command="dbt deps",
+        env=env_vars,
+        append_env=True,
+    )
+
+    dbt_snapshot = bash.BashOperator(
+        task_id="dbt_snapshot",
+        bash_command="dbt snapshot",
+        env=env_vars,
+        append_env=True,
+    )
+
+    dbt_clean = bash.BashOperator(
+        task_id="dbt_clean",
+        bash_command="dbt clean",
+        env=env_vars,
+        append_env=True,
+    )
+
+    dag_data_consistency = trigger_dagrun.TriggerDagRunOperator(
+        trigger_dag_id="data_consistency", task_id="trigger_data_consistency"
+    )
+
+    (start >> dbt_debug >> dbt_deps >> dbt_snapshot >> dbt_clean >> dag_data_consistency >> end)

--- a/dags/dbt_weekly.py
+++ b/dags/dbt_weekly.py
@@ -60,13 +60,6 @@ with airflow.DAG(
         append_env=True,
     )
 
-    dbt_snapshot = bash.BashOperator(
-        task_id="dbt_snapshot",
-        bash_command="dbt snapshot",
-        env=env_vars,
-        append_env=True,
-    )
-
     dbt_clean = bash.BashOperator(
         task_id="dbt_clean",
         bash_command="dbt clean",
@@ -78,4 +71,4 @@ with airflow.DAG(
         trigger_dag_id="data_consistency", task_id="trigger_data_consistency"
     )
 
-    (start >> dbt_debug >> dbt_deps >> dbt_seed >> dbt_run >> dbt_snapshot >> dbt_clean >> dag_data_consistency >> end)
+    (start >> dbt_debug >> dbt_deps >> dbt_seed >> dbt_run >> dbt_clean >> dag_data_consistency >> end)

--- a/dbt/snapshots/candidats_recherche_active_snapshot.sql
+++ b/dbt/snapshots/candidats_recherche_active_snapshot.sql
@@ -1,0 +1,14 @@
+{% snapshot candidats_recherche_active_snapshot %}
+
+    {{
+        config(
+          target_schema='public',
+          strategy='check',
+          unique_key='id',
+          check_cols=['date_derniere_candidature', 'date_derniere_embauche','date_derniere_candidature_acceptee'],
+          invalidate_hard_deletes=True,
+        )
+    }}
+
+    select * from {{ ref('candidats_recherche_active') }}
+{% endsnapshot %}

--- a/dbt/snapshots/properties.yml
+++ b/dbt/snapshots/properties.yml
@@ -4,3 +4,7 @@ snapshots:
   - name: etp_conventionne_snapshot
     description: >
       Ce snapshot permet de suivre les modifications au sein des annexes financières pour l'année en cours.
+  - name: candidats_recherche_active_snapshot
+    description: >
+      Ce snapshot permet de suivre les modifications au sein des candidats en recherche active.
+      Il suit l'ajout de nouveaux candidats (via l'id) et les nouvelles dates de derniere candidature, d'embauche et de candidature acceptée.


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/historiser-les-donn-es-des-candidats-sans-solutions-cb5376f4af00401a98d4bae39e1b81f8?pvs=4

### Pourquoi ?

A la demande nos partenaires, historisation de la table candidats recherche active.
Cette derniere se base sur la modification des 3 colonnes : `'date_derniere_candidature', 'date_derniere_embauche','date_derniere_candidature_acceptee'`

Lorsqu'une de ces colonnes est modifiée, dbt le trackera.
Afin de ne pas se retrouver avec une historisation quotidienne et non régulière, j'ai retiré dbt snapshot des dags daily/weekly et j'ai créé un dag spécifique au snapshot qu'il faudra faire tourner toutes les semaines. Cela nécessite un ajout côté C1, à étudier avec Romain et/ou Vermeer.



### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

