### PR TITLE
Suivi visiteurs FT

### DIFF
--- a/dbt/models/marts/daily/properties.yml
+++ b/dbt/models/marts/daily/properties.yml
@@ -158,3 +158,6 @@ models:
     description: >
       Table contenant les candidats actifs les 6 derniers mois et permettant de savoir s'ils ont eu des candidatures acceptées ainsi que le délai depuis la dernière candidature émise.
       Utile pour le calcul des candidats sans solution selon la définition simplifiée 'candidat actif les 6 derniers mois n'ayant eu aucune candidature acceptée'.
+  - name: visites_ft
+    description: >
+      Table permettant le suivi des visites et visiteurs uniques sur le TB 406 - Requetage FT.

--- a/dbt/models/marts/daily/visites_ft.sql
+++ b/dbt/models/marts/daily/visites_ft.sql
@@ -1,0 +1,9 @@
+select
+    vp."Tableau de bord"                    as tableau_de_bord,
+    to_date(vp."Date", 'YYYY-MM-DD')        as semaine,
+    to_number(vp."Visits", '9999')          as visites,
+    to_number(vp."Unique visitors", '9999') as visiteurs_uniques
+from
+    /* Nouvelle table créée par Victor qui reprend toutes les infos des visiteurs des TBs publics */
+    {{ source('matomo', 'suivi_visiteurs_tb_publics_v1') }} as vp
+where vp."Tableau de bord" = 'tb 406 - Requêtage des données de l''''expérimentation RSA'


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Table permettant le suivi des visites et visiteurs uniques sur le TB 406 - Requetage FT.
Il était nécessaire de créer un nouvelle table fin d'avoir aussi les visites.

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

