### PR TITLE
Tests tables candidats/candidatures recherche active

### DIFF
--- a/dbt/tests/properties.yml
+++ b/dbt/tests/properties.yml
@@ -19,3 +19,9 @@ tests:
    - name: test_potentiel_structures
     description: >
       Permet de vérifier que le nb de structures comptées dans le potentiel correspond bien au nombre de structures mères de la table structure
+   - name: test_candidats_recherche_active
+    description: >
+      Permet de vérifier qu'il n'y a pas de doublons ou lignes absentes dans la table candidats recherche active.
+   - name: test_candidatures_candidats_recherche_active
+    description: >
+      Permet de vérifier qu'il n'y a pas de doublons ou lignes absentes dans la table candidatures candidats recherche active.

--- a/dbt/tests/test_candidats_recherche_active.sql
+++ b/dbt/tests/test_candidats_recherche_active.sql
@@ -1,0 +1,17 @@
+with nb_candidats_recherche_active as (
+    select
+        (
+            select count(distinct id)
+            from stg_candidats_candidatures
+            where date_candidature >= current_date - interval '6 months'
+        ) as cdd_stg,
+        (
+            select count(*)
+            from candidats_recherche_active
+            where date_derniere_candidature >= current_date - interval '6 months'
+        ) as cdd_candidats_recherche_active
+)
+
+select *
+from nb_candidats_recherche_active
+where cdd_stg != cdd_candidats_recherche_active

--- a/dbt/tests/test_candidatures_candidats_recherche_active.sql
+++ b/dbt/tests/test_candidatures_candidats_recherche_active.sql
@@ -1,0 +1,17 @@
+with nb_candidatures as (
+    select
+        (
+            select count(*)
+            from candidatures_echelle_locale
+            where date_candidature >= current_date - interval '6 months'
+        ) as candidatures_cel,
+        (
+            select count(*)
+            from candidatures_candidats_recherche_active
+            where date_candidature >= current_date - interval '6 months'
+        ) as candidatures_cra
+)
+
+select *
+from nb_candidatures
+where candidatures_cel != candidatures_cra


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Tests tables candidats/candidatures recherche active. La solution était de rajouter le même filtre temporel à la deuxième condition car parfois les dates ne matchaient pas (lié à des soucis de maj effectuées en meme temps que le test)

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

