### PR TITLE
Configuration _direnv_ personnelle

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,5 @@
 dotenv .env-base
 dotenv
+if test -f .envrc.local; then
+    . .envrc.local
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ logs/
 **/__pycache__
 
 .env
+.envrc.local
 dbt/packages/
 airflow/
 .latest.dump


### PR DESCRIPTION
### Pourquoi ?

Permettre l'utilisation de configuration _direnv_ personnelle, par exemple l'activation automatique d'un _virtualenv_.
