### PR TITLE
Envoyer une notification slack que si la connection est configurée dans Airflow

### DIFF
--- a/dags/common/slack.py
+++ b/dags/common/slack.py
@@ -1,18 +1,31 @@
+import logging
+
 from airflow.decorators import task
+from airflow.models import Connection
 from airflow.operators.python import get_current_context
 from airflow.providers.slack.hooks.slack_webhook import SlackWebhookHook
 from airflow.utils import timezone
+from airflow.utils.session import create_session
 
+
+logger = logging.getLogger(__name__)
 
 # FIXME(vperron): this webhook should absolutely be installed through the entrypoint
 # and not declared manually in the interface.
 SLACK_CONN_ID = "slack_webhook"
 
 
+def _call_webhook(text):
+    with create_session() as session:
+        if session.query(Connection).filter(Connection.conn_id == SLACK_CONN_ID).count():
+            return SlackWebhookHook(slack_webhook_conn_id=SLACK_CONN_ID).send_text(text)
+        else:
+            logger.info("Connection %s is not configured, slack notifications are noop.", SLACK_CONN_ID)
+
+
 def task_fail_alert(context):
-    hook = SlackWebhookHook(slack_webhook_conn_id=SLACK_CONN_ID)
     ti = context.get("task_instance")
-    return hook.send_text(
+    return _call_webhook(
         """
     :airflow: :red_circle: Airflow task failed ! *dag*={dag} *task*={task} <{log_url}|online logs>
     """.format(
@@ -24,9 +37,8 @@ def task_fail_alert(context):
 
 
 def task_success_alert(context):
-    hook = SlackWebhookHook(slack_webhook_conn_id=SLACK_CONN_ID)
     dr = context.get("dag_run")
-    return hook.send_text(
+    return _call_webhook(
         """
     :airflow: :white_check_mark: Airflow DAG success. *dag*={dag} *duration_seconds*={duration}
     """.format(


### PR DESCRIPTION
### Pourquoi ?

Afin de pouvoir lancer les DAG en local et :
- Ne pas faire de notification
- Ne pas avoir d'erreur car la connection n'est pas configurée

### Checks

- [x] J'ai lancé le DAG en local. Ah bah non on peux pas ! Ou peut-être que si :eyes:.