### PR TITLE
Ajout du mois dans l'extraction des emplois

### DIFF
--- a/dbt/models/marts/weekly/marche_suivi_structure.sql
+++ b/dbt/models/marts/weekly/marche_suivi_structure.sql
@@ -1,6 +1,7 @@
 select
     etp_r.identifiant_salarie,
     etp_r.id_annexe_financiere,
+    etp_r.emi_sme_mois,
     etp_r.emi_sme_annee,
     etp_r.nombre_etp_consommes_reels_annuels,
     etp_r.nombre_etp_consommes_reels_mensuels,
@@ -52,4 +53,5 @@ group by
     salarie.salarie_rci_libelle,
     etp_r.id_annexe_financiere,
     etp_r.emi_sme_annee,
+    etp_r.emi_sme_mois,
     salarie.salarie_annee_naissance


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Ajout du mois dans l'extraction des emplois

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

