### PR TITLE
github: Ajout de l'Action "Block Fixup Commit Merge"

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,12 @@
+name: Git Checks
+
+on: [pull_request]
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4.1.6
+    - name: Block Fixup Commit Merge
+      uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
### Pourquoi ?

Pour ne pas fusionner par erreurs des commits créés avec `git commit --fixup` ou `git commit --squash`.

La page de l'action liste tout un tas de liens à propos de ces options et de leur _workflow_ avec `rebase`, je conseille donc leur lecture : https://github.com/marketplace/actions/block-fixup-commit-merge
