### PR TITLE
SQLFluff : Corrections diverse de la configuration

### DIFF
--- a/.sqlfluffignore
+++ b/.sqlfluffignore
@@ -1,2 +1,3 @@
 dbt/target/
 dbt/packages/
+dbt/macros/

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,7 @@ update:
 .PHONY: fix quality test clean
 
 MONITORED_DIRS := dags dbt tests
-# FIXME(vperron): In the long run we should include "references.consistent,references.from,references.qualification" rules.
-SQLFLUFF_OPTIONS := \
-	--exclude-rules ambiguous.distinct,layout.long_lines,references.consistent,references.from,references.qualification,references.special_chars,convention.left_join \
-	--disable-progress-bar --nocolor
+SQLFLUFF_OPTIONS := --disable-progress-bar --nocolor
 
 # if `sqlfluff fix` does not work, use `sqlfluff parse` to investigate.
 fix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,6 @@ capitalisation_policy = "lower"
 [tool.sqlfluff.rules.references.special_chars]
 additional_allowed_characters = "àéè '-"
 
-[tool.sqlfluff.templater.jinja]
-apply_dbt_builtins = true
-load_macros_from_path = "dbt/packages"
-
 [tool.pytest.ini_options]
 addopts = "--ignore=dbt/packages"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ line_length = 119
 
 [tool.sqlfluff.core]
 dialect = "postgres"
-exclude_rules = "ambiguous.distinct,layout.long_lines"
+# FIXME: In the long run we should include "references.consistent,references.from,references.qualification" rules.
+exclude_rules = "ambiguous.distinct,layout.long_lines,references.special_chars,convention.left_join,references.consistent,references.from,references.qualification"
 templater = "dbt"
 max_line_length = 119
 


### PR DESCRIPTION
### Pourquoi ?

Quelque corrections _drive by_ suite à ma tentative d'investigation de pourquoi la CI détecte des erreurs non détectées en local.