### PR TITLE
github: Mise à jour de la version des actions pour `ci.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,9 @@ jobs:
           CREATE DATABASE airflow;
         SQL
         docker kill --signal=SIGHUP ${{ job.services.postgres.id }}
-    - uses: actions/checkout@v3.5.0
+    - uses: actions/checkout@v4.1.6
     - name: 🐍 Install Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5.1.0
       with:
         python-version: "3.10"
         cache: pip


### PR DESCRIPTION

### Pourquoi ?

> Node.js 16 actions are deprecated. Please update the following actions
> to use Node.js 20: actions/checkout@v3.5.0, actions/setup-python@v4.
> For more information see:
> https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
