### PR TITLE
[Mon Recap] Automatisation de la récupération des stats de mon recap

### DIFF
--- a/dags/common/airtable.py
+++ b/dags/common/airtable.py
@@ -1,0 +1,23 @@
+import pandas as pd
+import requests
+from airflow.models import Variable
+
+
+def connection_airtable(table_name):
+    api_token = Variable.get("TOKEN_API_AIRTABLE_MON_RECAP")
+    base_id = Variable.get("BASE_ID_AIRTABLE_MON_RECAP")
+    url = f"https://api.airtable.com/v0/{base_id}/{table_name}"
+    headers = {"Authorization": f"Bearer {api_token}"}
+    return url, headers
+
+
+def fetch_airtable_data(url, headers):
+    records = []
+    params = {}
+    response = requests.get(url=url, params=params, headers=headers)
+    if response.status_code != 200:
+        raise Exception(f"Failed to fetch data: {response.status_code}, {response.text}")
+    data = response.json()
+    records.extend(data["records"])
+    df = pd.DataFrame([record["fields"] for record in records])
+    return df

--- a/dags/common/db_monrecap.py
+++ b/dags/common/db_monrecap.py
@@ -1,0 +1,12 @@
+from airflow.models import Variable
+from sqlalchemy import create_engine
+
+
+def connection_engine_monrecap():
+    database = Variable.get("PGDATABASE_C6")
+    host = Variable.get("PGHOST_C6")
+    password = Variable.get("PGPASSWORD_C6")
+    port = Variable.get("PGPORT_C6")
+    user = Variable.get("PGUSER_C6")
+    url = f"postgresql://{user}:{password}@{host}:{port}/{database}"
+    return create_engine(url)

--- a/dags/monrecap.py
+++ b/dags/monrecap.py
@@ -1,0 +1,40 @@
+from airflow import DAG
+from airflow.decorators import task
+from airflow.models import Variable
+from airflow.operators import empty
+
+from dags.common import airtable, db_monrecap, default_dag_args, slack
+
+
+with DAG(
+    "mon_recap",
+    schedule_interval="@daily",
+    **default_dag_args(),
+) as dag:
+    start = empty.EmptyOperator(task_id="start")
+
+    end = slack.success_notifying_task()
+
+    @task(task_id="monrecap_airtable")
+    def monrecap_airtable(**kwargs):
+        tables = ["Commandes", "Contacts"]
+        for table_name in tables:
+            url, headers = airtable.connection_airtable(table_name)
+            df = airtable.fetch_airtable_data(url, headers)
+            df.to_sql(table_name, con=db_monrecap.connection_engine_monrecap(), if_exists="replace", index=False)
+
+    monrecap_airtable = monrecap_airtable()
+
+    @task(task_id="monrecap_gsheet")
+    def monrecap_gsheet(**kwargs):
+        import pandas as pd
+
+        sheet_url = Variable.get("BAROMETRE_MON_RECAP")
+        print(f"reading barometre monrecap at {sheet_url=}")
+        df_baro = pd.read_csv(sheet_url)
+        df_baro.to_sql("barometre", con=db_monrecap.connection_engine_monrecap(), if_exists="replace", index=False)
+
+    monrecap_gsheet = monrecap_gsheet()
+
+
+(start >> monrecap_airtable >> monrecap_gsheet >> end)

--- a/dags/properties.yml
+++ b/dags/properties.yml
@@ -13,3 +13,7 @@ models:
     description: >
       Ce DAG permet de récupérer (de manière hebdomadaire) pour chaque campagne matomo du c0 et chaque produit du gip les visiteurs et leurs actions.
       Mise à disposition de cette table sur metabase pour les statistiques internes du c0.
+- name: monrecap
+    description: >
+      Ce DAG permet de récupérer de manière quotidienne les données de contacts & commandes sur le airtable de monrecap.
+      A travers un google sheet (tally) nous récupérons les réponses au baromètre. Ces 3 tables permettent la réalisation de la page statistiques de mon recap !


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Automatisation de la récupération des stats de mon recap. Suite à une discussion avec Victor & Jérémy notre airflow et le meilleur moyen de faire ça.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

