### PR TITLE
[mon recap] Prise en compte de la limite de lignes/requete

### DIFF
--- a/dags/common/airtable.py
+++ b/dags/common/airtable.py
@@ -14,10 +14,17 @@ def connection_airtable(table_name):
 def fetch_airtable_data(url, headers):
     records = []
     params = {}
-    response = requests.get(url=url, params=params, headers=headers)
-    if response.status_code != 200:
-        raise Exception(f"Failed to fetch data: {response.status_code}, {response.text}")
-    data = response.json()
-    records.extend(data["records"])
+    while True:
+        response = requests.get(url=url, params=params, headers=headers)
+        if response.status_code != 200:
+            raise Exception(f"Failed to fetch data: {response.status_code}, {response.text}")
+        data = response.json()
+        records.extend(data["records"])
+        # Airtable is limited to 100 rows per request
+        # the if combined with 'while true' will add rows until there are no more rows to loop in
+        if "offset" in data:
+            params["offset"] = data["offset"]
+        else:
+            break
     df = pd.DataFrame([record["fields"] for record in records])
     return df


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Airflow est limité à 100 lignes par requete, j'ai rajouté une petite condition pour prendre ça en compte :) 

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

