### PR TITLE
Création d'une table contenant les contrats cvg et phc pour convergence

### DIFF
--- a/dbt/models/_sources.yml
+++ b/dbt/models/_sources.yml
@@ -18,6 +18,7 @@ sources:
       - name: fluxIAE_RefMontantIae
       - name: fluxIAE_RefMotifSort
       - name: fluxIAE_RefNiveauFormation
+      - name: fluxIAE_RefFormeContrat
       - name: fluxIAE_Salarie
       - name: fluxIAE_Structure
 

--- a/dbt/models/marts/weekly/contrats_cvg_phc.sql
+++ b/dbt/models/marts/weekly/contrats_cvg_phc.sql
@@ -1,0 +1,19 @@
+select
+    cm.contrat_id_structure,
+    struct.structure_denomination,
+    rfc.rfc_lib_forme_contrat                                          as type_contrat,
+    extract(year from to_date(cm.contrat_date_embauche, 'DD/MM/YYYY')) as annee_embauche,
+    count(cm.contrat_id_ctr)                                           as nb_contrats
+from {{ source("fluxIAE", "fluxIAE_ContratMission") }} as cm
+left join {{ source("fluxIAE", "fluxIAE_RefFormeContrat") }} as rfc
+    on cm."contrat_format_contrat_code" = rfc."rfc_code_forme_contrat"
+left join {{ source("fluxIAE", "fluxIAE_Structure") }} as struct
+    on cm.contrat_id_structure = struct.structure_id_siae
+where
+    rfc_lib_forme_contrat = 'CDDI PHC'
+    or rfc_lib_forme_contrat = 'CDDI CVG'
+group by
+    cm.contrat_id_structure,
+    struct.structure_denomination,
+    rfc.rfc_lib_forme_contrat,
+    extract(year from to_date(cm.contrat_date_embauche, 'DD/MM/YYYY'))

--- a/dbt/models/marts/weekly/properties.yml
+++ b/dbt/models/marts/weekly/properties.yml
@@ -1,6 +1,9 @@
 version: 2
 
 models:
+  - name: contrats_cvg_phc
+    description: >
+      Table créée pour que convergence puisse visualiser le nombre de contrats de type cvg phc par structure et par année.
   - name: suivi_etp_realises_v2
     description: >
       Table créée pour suivre le nombre d'etp réalisés. Cette table, permet, à travers le calcul du nombre d'heures x la valeur d'un etp de retrouver le nombre d'etp réalisés par mois et par personne physique.


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/gip-inclusion/Table-CVG-PHC-c8aabe83eff841e8bf3b8e2fd7337e30?pvs=4

### Pourquoi ?

Nous avons fait cette table en 2022 pour Convergence. En 2024 ils ont a nouveau besoin de cette table. L'idée ici est de généraliser et l'ajouter à un TB pour qu'ils puisse eux même exporter les structures qu'ils doivent fournir à la DGEFP en filtrant sur metabase.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

