### PR TITLE
Modification du test utilisateurs et clarification de la doc

### DIFF
--- a/dbt/models/marts/daily/properties.yml
+++ b/dbt/models/marts/daily/properties.yml
@@ -119,9 +119,8 @@ models:
   - name: utilisateurs
     description: >
         Table contenant les utilisateurs des emplois ainsi que l'id de la structure/orga/institution à laquelle ils sont rattachés.
-    tests:
-      - dbt_utils.equal_rowcount:
-          compare_model: source('emplois', 'utilisateurs_v0')
+        Attention dans cette table les utilisateurs apparaîssent autant de fois qu'ils ont de collaborations.
+        Pour obtenir le nombre d'utilisateurs réels il faut passer par un distinct sur l'id ou l'email.
   - name: utilisateurs_jamais_venus
     description: >
       Table permettant de récupérer les mails des utilisateurs des emplois ne s'étant jamais connecté sur les tb prives.

--- a/dbt/tests/test_utilisateurs.sql
+++ b/dbt/tests/test_utilisateurs.sql
@@ -1,0 +1,15 @@
+with nb_utilisateurs as (
+    select
+        (
+            select count(distinct id)
+            from utilisateurs
+        ) as utilisateurs,
+        (
+            select count(*)
+            from utilisateurs_v0
+        ) as utilisateurs_v0
+)
+
+select *
+from nb_utilisateurs
+where utilisateurs != utilisateurs_v0


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

La table utilisateur contient une ligne par utilisateur et structure, contient donc des doublons d'utilisateurs. Le test simple rowcount ne passait donc pas. J'ai mis à jour le test et clarifié la doc pour que l'usage de la table soit bien clair.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

