### PR TITLE
Ajout du NIR pour le calcul des bénéficiaires

### DIFF
--- a/dbt/models/marts/weekly/etp_par_salarie.sql
+++ b/dbt/models/marts/weekly/etp_par_salarie.sql
@@ -1,5 +1,6 @@
 select
     {{ pilo_star(ref('suivi_etp_realises_v2'), relation_alias='etp_r') }},
+    salarie.hash_nir,
     etp_c."effectif_mensuel_conventionné",
     etp_c."effectif_annuel_conventionné",
     (etp_r.nombre_etp_consommes_reels_annuels * etp_r.af_montant_unitaire_annuel_valeur) as montant_utilise,


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Ajout du NIR dans la table etp_par_salarie afin de calculer le nombre de bénéficiaires de l'IAE

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

