### PR TITLE
Table taux_refus_siae : renommer et ajouter des agrégations

### DIFF
--- a/dbt/models/marts/daily/properties.yml
+++ b/dbt/models/marts/daily/properties.yml
@@ -154,6 +154,10 @@ models:
     description: >
         Table permettant de suivre les utilisateurs qui restent actifs d'une période à une autre.
         Les périodes peuvent être un mois ou un trimestre.
+  - name: taux_refus_siae
+    description: >
+        Donne le nombre de candidatures emises et refusées (avec et sans autoprescription) pour permettre le calcul des taux de refus par SIAE.
+        Agrégation par date_candidature, origine (détaillée), territoires, etc, pour permettre d'y associer les filtres sur metabase.
   - name: nombre_candidatures_par_structure
     description: >
       Table faisant appel a plusieurs ephemeral tables (anciennement des CTEs) afin de pouvoir montrer différentes informations sans être limité par les filtres de Metabase.

--- a/dbt/models/marts/daily/taux_refus_siae.sql
+++ b/dbt/models/marts/daily/taux_refus_siae.sql
@@ -17,11 +17,17 @@ select
     /* Nombre de candidatures acceptées initiées par l'employeur de type SIAE */
     etp_conventionnes.nombre_etp_conventionnes,
     /* Nombre de candidatures initiées par l'employeur de type SIAE */
+    cel.date_candidature,
     cel.type_structure,
     cel."nom_département_structure",
     cel."région_structure",
     cel.epci,
     cel.bassin_emploi_structure,
+    cel.type_prescripteur,
+    cel.origine,
+    cel."origine_détaillée",
+    cel.tranche_age,
+    cel.genre_candidat,
     count(distinct cel.id)
     filter (
         where
@@ -74,9 +80,16 @@ where
     and cel.date_candidature >= date_trunc('month', cast((cast(now() as timestamp) + (interval '-12 month')) as timestamp))
     and cel.type_structure in ('EI', 'ETTI', 'AI', 'ACI', 'EITI')
 group by
+    etp_conventionnes.nombre_etp_conventionnes,
+    cel.date_candidature,
     cel.type_structure,
+    cel.categorie_structure,
     cel."nom_département_structure",
     cel."région_structure",
-    etp_conventionnes.nombre_etp_conventionnes,
     cel.epci,
-    cel.bassin_emploi_structure
+    cel.bassin_emploi_structure,
+    cel.type_prescripteur,
+    cel.origine,
+    cel."origine_détaillée",
+    cel.tranche_age,
+    cel.genre_candidat

--- a/dbt/models/marts/daily/taux_refus_siae.sql
+++ b/dbt/models/marts/daily/taux_refus_siae.sql
@@ -1,21 +1,4 @@
-/* L'objectif est de suivre le taux de refus par type de structure */
-with etp_conventionnes as (
-    select
-        type_siae,
-        nom_departement_af,
-        nom_region_af,
-        sum("nombre_etp_conventionnés") as nombre_etp_conventionnes
-    from {{ ref('nombre_etp_conventionnes') }}
-    where annee_af = date_part('year', current_date)
-    group by
-        type_siae,
-        nom_departement_af,
-        nom_region_af
-)
-
 select
-    /* Nombre de candidatures acceptées initiées par l'employeur de type SIAE */
-    etp_conventionnes.nombre_etp_conventionnes,
     /* Nombre de candidatures initiées par l'employeur de type SIAE */
     cel.date_candidature,
     cel.type_structure,
@@ -67,12 +50,6 @@ left join
     {{ source('emplois', 'fiches_de_poste') }} as fdp on fdpc.id_fiche_de_poste = fdp.id
 left join
     {{ ref('structures') }} as structures on structures.id = cel.id_structure
-left join
-    etp_conventionnes
-    on
-        etp_conventionnes.type_siae = cel.type_structure
-        and etp_conventionnes.nom_departement_af = cel."nom_département_structure"
-        and etp_conventionnes.nom_region_af = cel."région_structure"
 where
     cel.injection_ai = 0
     and fdp.recrutement_ouvert = 1
@@ -80,7 +57,6 @@ where
     and cel.date_candidature >= date_trunc('month', cast((cast(now() as timestamp) + (interval '-12 month')) as timestamp))
     and cel.type_structure in ('EI', 'ETTI', 'AI', 'ACI', 'EITI')
 group by
-    etp_conventionnes.nombre_etp_conventionnes,
     cel.date_candidature,
     cel.type_structure,
     cel.categorie_structure,


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/gip-inclusion/Filtre-et-variable-Indicateur-taux-de-refus-du-TB116-r-alis-sur-une-table-qui-ne-permet-pas-d-ut-07b73cc17542471b8b52a970aadb0afb?pvs=4

### Pourquoi ?

Renommer : pour qu'on ait des `taux` partout et pas de `tx` ;p un seul indicateur calculé sur cette table, donc c'est pas chiant de le refaire (sinon j'aurais pas fait)
Agréger : pour permettre de brancher les filtres sur le tb116 (cf carte)

J'en profite pour déplacer le modèle dans marts.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

