### PR TITLE
Simplification des libelle des motifs de refus

### DIFF
--- a/dbt/macros/translate_tables.sql
+++ b/dbt/macros/translate_tables.sql
@@ -1,0 +1,23 @@
+{% macro translate_motif_refus(field) -%}
+case {{ field }}
+    when 'other' then 'Autre motif saisi sur les emplois de l''inclusion'
+    when 'hired_elsewhere' then 'Candidat indisponible (en emploi)'
+    when 'training' then 'Candidat indisponible (en formation)'
+    when 'unavailable' then 'Candidat indisponible ou non intéressé par le poste'
+    when 'did_not_come_to_interview' then 'Candidat ne s’étant pas présenté à l’entretien'
+    when 'non_eligible' then 'Candidat non éligible'
+    when 'not_interested' then 'Candidat non intéressé'
+    when 'did_not_come' then 'Candidat non joignable'
+    when 'not_mobile' then 'Candidat non mobile'
+    when 'duplicate' then 'Candidature en doublon'
+    when 'poorly_informed' then 'Candidature pas assez renseignée'
+    when 'eligibility_doubt' then 'Doute sur l''éligibilité du candidat'
+    when 'prevent_objectives' then 'Embauche incompatible avec les objectifs du dialogue de gestion'
+    when 'approval_expiration_too_close' then 'La date de fin du pass est trop proche'
+    when 'deactivation' then 'La structure n''est plus conventionnée'
+    when 'lacking_skills' then 'Compétences insuffisantes pour le poste'
+    when 'no_position' then 'Pas de recrutement en cours'
+    when 'incompatible' then 'Freins à l''emploi incompatible avec le poste proposé'
+    else {{ field }}
+end
+{%- endmacro -%}

--- a/dbt/models/_sources.yml
+++ b/dbt/models/_sources.yml
@@ -57,6 +57,10 @@ sources:
       - name: prolongations
       - name: structures_v0
       - name: c1_ref_type_prescripteur
+      - name: c1_ref_motif_de_refus
+        description: >
+          Table de correspondance entre le code d'un motif de refus et son label affiché sur les emplois.
+          Sert de base pour la table motif de refus qui contient le label affiché sur le pilotage.
 
   - name: oneshot
     schema: public

--- a/dbt/models/marts/daily/candidatures_echelle_locale.sql
+++ b/dbt/models/marts/daily/candidatures_echelle_locale.sql
@@ -1,5 +1,7 @@
 select
-    {{ pilo_star(ref('stg_candidatures'), except=['origine_détaillée'], relation_alias='candidatures') }},
+    {{ pilo_star(ref('stg_candidatures'), except=['origine_détaillée', 'motif_de_refus'], relation_alias='candidatures') }},
+    {{ translate_motif_refus('candidatures.motif_de_refus') }}
+    as motif_de_refus,
     case
         when candidatures.injection_ai = 0 then 'Non'
         else 'Oui'

--- a/dbt/seeds/properties.yml
+++ b/dbt/seeds/properties.yml
@@ -84,4 +84,3 @@ seeds:
     config:
         column_types:
             siret: varchar(30)
-


### PR DESCRIPTION
**Carte Notion : **  https://www.notion.so/gip-inclusion/Motif-de-refus-Autre-Trouver-une-solution-qui-permettrait-de-distinguer-les-motifs-de-refus-Autre-42d49154c9694899ac1b13c22d4da0cc?pvs=4

### Pourquoi ?
Nous permettre de gérer plus facilement les libelle des motifs de refus sur le pilotage.
à faire passer avec cette PR : https://github.com/gip-inclusion/les-emplois/pull/4273
(je n'ai pas pu tester pour le moment l'autre PR n'étant pas passée)

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

