### PR TITLE
metabase: add dept column to enable carto

### DIFF
--- a/dbt/models/marts/daily/candidatures_dihal.sql
+++ b/dbt/models/marts/daily/candidatures_dihal.sql
@@ -1,4 +1,4 @@
 select
-    {{ pilo_star(ref('candidatures_echelle_locale')) }}
+    {{ pilo_star(ref('candidatures_echelle_locale'), relation_alias='cel') }}
 from {{ ref('candidatures_echelle_locale') }}
 where "type_org_prescripteur" in ('CHRS', 'CHU', 'RS_FJT', 'OIL')

--- a/dbt/models/marts/daily/candidatures_echelle_locale.sql
+++ b/dbt/models/marts/daily/candidatures_echelle_locale.sql
@@ -32,10 +32,13 @@ select
     candidats.eligibilite_dispositif,
     candidats.eligible_cej,
     candidats.eligible_cdi_inclusion,
-    candidats.date_inscription                          as date_inscription_candidat
+    candidats.date_inscription                          as date_inscription_candidat,
+    orga."département"                                  as "département_orga"
 from
     {{ ref('stg_candidatures') }} as candidatures
 left join {{ ref('candidats') }} as candidats
     on candidats.id = candidatures.id_candidat
+left join {{ ref('organisations') }} as orga
+    on orga.id = candidatures.id_org_prescripteur
 left join {{ source('emplois','c1_ref_type_prescripteur') }} as org
     on org.code = candidatures.type_org_prescripteur


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/gip-inclusion/Repr-senter-le-graphique-diff-remment-pour-faciliter-sa-lecture-1c1480629af341a2a8a1624112a7455c?pvs=4

### Pourquoi ?

Permettre de réaliser une cartographie des SIAE ayant accepté des candidatures en fonction du département du prescripteur.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

