### PR TITLE
Patch pour corriger le dbt daily qui plante

### DIFF
--- a/dbt/models/marts/oneshot/ft_candidats_nord.sql
+++ b/dbt/models/marts/oneshot/ft_candidats_nord.sql
@@ -1,6 +1,0 @@
-select
-    {{ pilo_star(source('oneshot', 'ft_iae_nord')) }},
-    {{ pilo_star(ref('candidats')) }}
-from {{ source('oneshot', 'ft_iae_nord') }} as ft
-left join {{ ref('candidats') }} as c
-    on ft.nir_hash = c.hash_nir

--- a/dbt/models/marts/oneshot/ft_candidatures_nord.sql
+++ b/dbt/models/marts/oneshot/ft_candidatures_nord.sql
@@ -1,8 +1,0 @@
-select
-    {{ pilo_star(source('oneshot', 'ft_iae_nord'), relation_alias='ft') }},
-    {{ pilo_star(ref('candidatures_echelle_locale'), relation_alias='cd') }}
-from {{ source('oneshot', 'ft_iae_nord') }} as ft
-left join {{ ref('candidats') }} as c
-    on ft.nir_hash = c.hash_nir
-left join {{ ref('candidatures_echelle_locale') }} as cd
-    on c.id = cd.id_candidat

--- a/dbt/models/staging/stg_candidats_asp_derniere_sortie.sql
+++ b/dbt/models/staging/stg_candidats_asp_derniere_sortie.sql
@@ -1,11 +1,11 @@
 select
-    pass."hash_numéro_pass_iae"                      as pass_iae,
-    c.id                                             as id_salarie_emplois,
-    salarie.salarie_id                               as id_salarie_asp,
-    sortie.rcs_libelle                               as cause_sortie,
-    sortie.rms_libelle                               as motif_sortie,
-    max(sortie.contrat_date_sortie_definitive::date) as date_derniere_sortie,
-    max(cddr.date_candidature)                       as date_derniere_candidature
+    pass."hash_numéro_pass_iae"                                       as pass_iae,
+    c.id                                                              as id_salarie_emplois,
+    salarie.salarie_id                                                as id_salarie_asp,
+    sortie.rcs_libelle                                                as cause_sortie,
+    sortie.rms_libelle                                                as motif_sortie,
+    to_date(max(sortie.contrat_date_sortie_definitive), 'DD/MM/YYYY') as date_derniere_sortie,
+    max(cddr.date_candidature)                                        as date_derniere_candidature
 from {{ source('fluxIAE','fluxIAE_Salarie') }} as salarie
 -- pour récupérer le nir pour ensuite pouvoir filtrer les candidats non ft
 left join {{ ref('pass_agrements_valides') }} as pass


### PR DESCRIPTION
**Carte Notion : **

- Suppression des scripts ft (sont corrigés dans une autre PR)
- Modification du format de date qui fait planter `candidats_derniere_embauche`

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

