### PR TITLE
Amélioration de l'origine des candidatures + ajout de l'info d'archivage d'une candidature

### DIFF
--- a/dbt/models/marts/daily/candidatures_acceptees_employeurs_orienteurs.sql
+++ b/dbt/models/marts/daily/candidatures_acceptees_employeurs_orienteurs.sql
@@ -1,0 +1,15 @@
+select
+    cddr.id,
+    cddr.id_candidat,
+    cca.id_candidat as id_candidat_bis,
+    cddr.id_structure,
+    cddr.origine_id_structure,
+    cddr.origine,
+    cddr.type_structure,
+    cddr.nom_structure,
+    cddr."état"
+from {{ ref('stg_candidatures') }} as cddr
+left join {{ ref('stg_candidats_candidatures_acceptees') }} as cca
+    on cddr.id_candidat = cca.id_candidat and cddr.origine_id_structure = cca.id_structure
+-- On veut uniquement voir les candidatures qui ont pour origine un employeur orienteur et qui ont été acceptées suite à cette orientation
+where cddr.origine = 'Employeur orienteur' and cddr."état" = 'Candidature acceptée' and cca.id_candidat is not null

--- a/dbt/models/marts/daily/candidatures_inconnues_employeurs_orienteurs.sql
+++ b/dbt/models/marts/daily/candidatures_inconnues_employeurs_orienteurs.sql
@@ -1,0 +1,15 @@
+select
+    cddr.id,
+    cddr.id_candidat,
+    cca.id_candidat as id_candidat_bis,
+    cddr.id_structure,
+    cddr.origine_id_structure,
+    cddr.origine,
+    cddr.type_structure,
+    cddr.nom_structure,
+    cddr."état"
+from {{ ref('stg_candidatures') }} as cddr
+left join {{ ref('stg_candidats_candidatures_employeurs_orienteurs') }} as cca
+    on cddr.id_candidat = cca.id_candidat and cddr.origine_id_structure = cca.id_structure
+-- On veut uniquement voir les candidatures qui ont pour origine un employeur orienteur
+where cddr.origine = 'Employeur orienteur'

--- a/dbt/models/marts/daily/candidatures_refusees_employeurs_orienteurs.sql
+++ b/dbt/models/marts/daily/candidatures_refusees_employeurs_orienteurs.sql
@@ -1,0 +1,16 @@
+select
+    cddr.id,
+    cddr.id_candidat,
+    cca.id_candidat as id_candidat_bis,
+    cddr.id_structure,
+    cddr.origine_id_structure,
+    cddr.origine,
+    cddr.type_structure,
+    cddr.nom_structure,
+    cddr."état"
+from {{ ref('stg_candidatures') }} as cddr
+-- On regarde les candidatures refusées par l'origine_id_structure
+left join {{ ref('stg_candidats_candidatures_refusees') }} as cca
+    on cddr.id_candidat = cca.id_candidat and cddr.origine_id_structure = cca.id_structure
+-- On veut uniquement voir les candidatures qui ont pour origine un employeur orienteur et qui ont été acceptées suite à cette orientation
+where cddr.origine = 'Employeur orienteur' and cddr."état" = 'Candidature acceptée' and cca.id_candidat is not null

--- a/dbt/models/marts/daily/properties.yml
+++ b/dbt/models/marts/daily/properties.yml
@@ -199,3 +199,12 @@ models:
           description: 1 si le candidat a eu une candidature acceptée dans les 6 derniers mois, 0 sinon
         - name: a_eu_embauche
           description: 1 si le candidat a eu une embauche dans les 6 derniers mois, 0 sinon
+  - name: candidatures_acceptees_employeurs_orienteurs
+    description: >
+      Table permettant le suivi des SIAE qui ont orienté un candidat ayant déjà travaillé chez elles vers d'autres SIAE.
+  - name: candidatures_refusees_employeurs_orienteurs
+    description: >
+      Table permettant le suivi des SIAE qui ont orienté un candidat dont la candidature avait été refusée au sein de la SIAE, vers d'autres SIAE.
+  - name: candidatures_iconnues_employeurs_orienteurs
+    description: >
+      Table permettant le suivi des SIAE qui ont orienté un candidat n'ayant jamais postulé chez elles, vers d'autres SIAE.

--- a/dbt/models/staging/properties.yml
+++ b/dbt/models/staging/properties.yml
@@ -175,3 +175,15 @@ models:
     description: >
       Vue permettant d'isoler les dates de derniere sortie et candidature afin de permettre l'identification des salaries des emplois en decrochage.
       Cette 2nde table permet d'éviter les doublons causés par le fait l'id salarie de l'asp n'est pas unique.
+  - name: stg_candidat_candidature_acceptee
+    description: >
+      vue permettant d'isoler les candidats + structures où la candidature qui a pour origine "Employeur" a été acceptée.
+      Cette vue permet de créer la table (candidatures_acceptees_employeurs_orienteurs) suivant les employeurs orienteurs qui transfèrent les candidatures d'anciens salariés.
+  - name: stg_candidat_candidature_refusee
+    description: >
+      vue permettant d'isoler les candidats + structures où la candidature qui a pour origine "Employeur" a été refusée.
+      Cette vue permet de créer la table (candidatures_refusees_employeurs_orienteurs) suivant les employeurs orienteurs qui transfèrent les candidatures refusées.
+  - name: stg_candidat_candidature_inconnue
+    description: >
+      vue permettant d'isoler les candidats + structures dont les candidatures ont pour origine "Employeur".
+      Cette vue permet de créer la table (candidatures_inconnues_employeurs_orienteurs) suivant les employeurs orienteurs qui transfèrent les candidatures de candidats n'étant jamais passé chez eux.

--- a/dbt/models/staging/stg_candidats_candidatures_acceptees.sql
+++ b/dbt/models/staging/stg_candidats_candidatures_acceptees.sql
@@ -1,0 +1,5 @@
+select
+    id_candidat,
+    id_structure
+from {{ ref('stg_candidatures') }}
+where origine = 'Employeur' and "état" = 'Candidature acceptée'

--- a/dbt/models/staging/stg_candidats_candidatures_employeurs_orienteurs.sql
+++ b/dbt/models/staging/stg_candidats_candidatures_employeurs_orienteurs.sql
@@ -1,0 +1,5 @@
+select
+    id_candidat,
+    id_structure
+from {{ ref('stg_candidatures') }}
+where origine = 'Employeur'

--- a/dbt/models/staging/stg_candidats_candidatures_refusees.sql
+++ b/dbt/models/staging/stg_candidats_candidatures_refusees.sql
@@ -1,0 +1,5 @@
+select
+    id_candidat,
+    id_structure
+from {{ ref('stg_candidatures') }}
+where origine = 'Employeur' and "état" = 'Candidature refusée'

--- a/dbt/models/staging/stg_candidatures.sql
+++ b/dbt/models/staging/stg_candidatures.sql
@@ -23,7 +23,7 @@ select
     end                                                    as motif_de_refus,
     case
         when candidatures.origine_id_structure != candidatures.id_structure
-            then 'Employeur (transfert candidature)'
+            then 'Employeur orienteur'
         else candidatures.origine
     end                                                    as origine,
     case


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Depuis quelques semaines les employeurs peuvent transférer leurs candidatures à d'autres employeurs. La colonne origine a été modifiée afin de prendre cela en compte.

De plus, une colonne informant si la candidature a été archivée ou non sur les emplois de l'inclusion a été ajoutée.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

