### PR TITLE
 Ajout de la colonne genre et tranche d'âge sur certaines tables

### DIFF
--- a/dbt/models/marts/daily/taux_transformation_prescripteurs.sql
+++ b/dbt/models/marts/daily/taux_transformation_prescripteurs.sql
@@ -13,6 +13,8 @@ with candidats_p as (
         cdd.id                                as id_candidat,
         cdd.actif,
         cdd.age,
+        cdd.tranche_age,
+        cdd.sexe_selon_nir,
         cdd.date_diagnostic,
         cdd."département"                     as departement_candidat,
         cdd."nom_département"                 as nom_departement_candidat,

--- a/dbt/models/staging/stg_candidatures_autoprescription.sql
+++ b/dbt/models/staging/stg_candidatures_autoprescription.sql
@@ -3,6 +3,8 @@ select
     cd.id                                  as id_candidature,
     c.hash_nir,
     c.age,
+    c.tranche_age,
+    c.sexe_selon_nir,
     c."département",
     c."nom_département",
     c."région",


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Pour permettre l'ajout des filtres sur le tb 32, 136,

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

