### PR TITLE
Ajout des types de contrats sur les tables contrats et candidatures.

### DIFF
--- a/dbt/models/_sources.yml
+++ b/dbt/models/_sources.yml
@@ -56,6 +56,9 @@ sources:
       - name: demandes_de_prolongation
       - name: prolongations
       - name: structures_v0
+      - name: c1_ref_type_contrat
+        description: >
+          Table de correspondance entre le code d'un type de contrat et son label affiché sur les emplois.
       - name: c1_ref_type_prescripteur
       - name: c1_ref_motif_de_refus
         description: >

--- a/dbt/models/marts/weekly/contrats_aci.sql
+++ b/dbt/models/marts/weekly/contrats_aci.sql
@@ -2,32 +2,35 @@ select
     ctr.contrat_id_structure,
     ctr.contrat_id_pph,
     salarie.hash_nir,
-    max(structs.code_dept_structure)        as departement_structure,
-    max(structs.nom_departement_structure)  as nom_departement_structure,
-    max(structs.nom_region_structure)       as nom_region_structure,
-    max(motif_sortie)                       as motif_sortie,
+    count(distinct ctr.type_contrat)                                    as types_contrats_distincts,
+    array_agg(ctr.type_contrat order by ctr.contrat_date_embauche)      as types_contrats,
+    (array_agg(ctr.type_contrat order by ctr.contrat_date_embauche))[1] as type_contrat_embauche,
+    max(structs.code_dept_structure)                                    as departement_structure,
+    max(structs.nom_departement_structure)                              as nom_departement_structure,
+    max(structs.nom_region_structure)                                   as nom_region_structure,
+    max(motif_sortie)                                                   as motif_sortie,
     case
         when max(motif_sortie) is null then 'Non'
         else 'Oui'
-    end                                     as salarie_sorti,
-    array_agg(ctr.contrat_id_ctr)           as id_contrats,
-    max(contrat_mesure_disp_code)           as type_aci,
-    min(ctr.contrat_date_embauche)          as date_embauche_premier_contrat,
-    max(ctr.contrat_date_fin_contrat)       as date_fin_dernier_contrat,
-    max(ctr.contrat_date_sortie_definitive) as date_sortie_definitive_dernier_contrat,
+    end                                                                 as salarie_sorti,
+    array_agg(ctr.contrat_id_ctr order by ctr.contrat_date_embauche)    as id_contrats,
+    max(contrat_mesure_disp_code)                                       as type_aci,
+    min(ctr.contrat_date_embauche)                                      as date_embauche_premier_contrat,
+    max(ctr.contrat_date_fin_contrat)                                   as date_fin_dernier_contrat,
+    max(ctr.contrat_date_sortie_definitive)                             as date_sortie_definitive_dernier_contrat,
     case
         when max(ctr.contrat_date_sortie_definitive) is not null then {{ duration_in_days('min(ctr.contrat_date_embauche)', 'max(ctr.contrat_date_sortie_definitive)') }}
         else {{ duration_in_days('min(ctr.contrat_date_embauche)', 'max(ctr.contrat_date_fin_contrat)') }}
-    end                                     as duree_contrat_jours,
+    end                                                                 as duree_contrat_jours,
     case
         when max(ctr.contrat_date_sortie_definitive) is not null then {{ duration_in_months('min(ctr.contrat_date_embauche)', 'max(ctr.contrat_date_sortie_definitive)') }}
         else {{ duration_in_months('min(ctr.contrat_date_embauche)', 'max(ctr.contrat_date_fin_contrat)') }}
-    end                                     as duree_contrat_mois,
-    sum(ctr.contrat_duree_contrat)          as duree_contrat_asp_mois,
+    end                                                                 as duree_contrat_mois,
+    sum(ctr.contrat_duree_contrat)                                      as duree_contrat_asp_mois,
     case
         when cgv_structs.siret is not null then 'Oui'
         else 'Non'
-    end                                     as structure_convergence
+    end                                                                 as structure_convergence
 from {{ ref('stg_contrats') }} as ctr
 left join {{ ref("fluxIAE_Structure_v2") }} as structs
     on ctr.contrat_id_structure = structs.structure_id_siae

--- a/dbt/models/staging/stg_candidatures.sql
+++ b/dbt/models/staging/stg_candidatures.sql
@@ -1,8 +1,9 @@
 select
     {{ pilo_star(source('emplois', 'candidatures'),
-        except=["date_mise_à_jour_metabase", "état", "motif_de_refus", "origine", "origine_détaillée", "candidature_archivee"], relation_alias='candidatures') }},
+        except=["date_mise_à_jour_metabase", "état", "motif_de_refus", "origine", "origine_détaillée", "candidature_archivee", "type_contrat"], relation_alias='candidatures') }},
     {{ pilo_star(ref('stg_organisations'),
         except=["id", "date_mise_à_jour_metabase", "ville", "code_commune", "type", "date_inscription", "total_candidatures", "total_membres", "total_embauches", "date_dernière_candidature"], relation_alias='org_prescripteur') }},
+    c_type.label                                           as type_contrat_candidature,
     struct.bassin_d_emploi                                 as bassin_emploi_structure,
     org_prescripteur.zone_emploi                           as bassin_emploi_prescripteur,
     org_prescripteur.type                                  as type_org_prescripteur,
@@ -40,6 +41,8 @@ select
     extract(year from candidatures.date_candidature)       as annee_candidature
 from
     {{ source('emplois', 'candidatures') }} as candidatures
+left join {{ source('emplois', 'c1_ref_type_contrat') }} as c_type
+    on candidatures.type_contrat = c_type.code
 left join {{ ref('stg_structures') }} as struct
     on candidatures.id_structure = struct.id
 left join {{ ref('stg_organisations') }} as org_prescripteur

--- a/dbt/models/staging/stg_contrats.sql
+++ b/dbt/models/staging/stg_contrats.sql
@@ -6,7 +6,8 @@ select distinct
     ctr.contrat_duree_contrat,
     ctr.contrat_date_embauche,
     ctr.contrat_date_fin_contrat,
-    ctr.contrat_type_contrat,
+    ctr.contrat_type_contrat                                                       as num_reconduction,
+    rfc.rfc_lib_forme_contrat                                                      as type_contrat,
     motif_sortie.rms_libelle                                                       as motif_sortie,
     sum(emi.emi_nb_heures_travail)                                                 as contrat_nb_heures,
     to_date(ctr.contrat_date_sortie_definitive, 'DD/MM/YYYY')                      as contrat_date_sortie_definitive,
@@ -17,6 +18,8 @@ select distinct
 from {{ ref('fluxIAE_EtatMensuelIndiv_v2') }} as emi
 left join {{ ref('fluxIAE_ContratMission_v2') }} as ctr
     on ctr.contrat_id_ctr = emi.emi_ctr_id
+left join {{ source("fluxIAE", "fluxIAE_RefFormeContrat") }} as rfc
+    on ctr."contrat_format_contrat_code" = rfc."rfc_code_forme_contrat"
 left join {{ ref('fluxIAE_RefMotifSort_v2') }} as motif_sortie
     on emi.emi_motif_sortie_id = motif_sortie.rms_id
 group by
@@ -28,6 +31,7 @@ group by
     ctr.contrat_date_embauche,
     ctr.contrat_date_fin_contrat,
     ctr.contrat_type_contrat,
+    rfc.rfc_lib_forme_contrat,
     ctr.contrat_date_sortie_definitive,
     motif_sortie.rms_libelle
 -- because we consider only contracts starting in 2021

--- a/dbt/models/staging/stg_recrutements.sql
+++ b/dbt/models/staging/stg_recrutements.sql
@@ -5,7 +5,7 @@ select
     min(contrat_date_embauche)          as date_recrutement,
     max(contrat_date_fin_contrat)       as date_fin_recrutement,
     max(contrat_date_sortie_definitive) as date_sortie_definitive,
-    max(contrat_type_contrat)           as nb_reconductions
+    max(num_reconduction)               as nb_reconductions
 from {{ ref('stg_contrats') }}
 group by
     contrat_id_pph,


### PR DESCRIPTION
**Carte Notion : ** 

### Pourquoi ?

Permettre de filtre par type de contrat pour convergence.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

