### PR TITLE
modèle `nb_utilisateurs_potentiels` : Correction de possible `KeyError`

### DIFF
--- a/dbt/models/marts/daily/nb_utilisateurs_potentiels.py
+++ b/dbt/models/marts/daily/nb_utilisateurs_potentiels.py
@@ -36,16 +36,18 @@ def model(dbt, session):
             # organisations
             if not region_orga.empty:
                 dept_orga = subdf_by_value_if_exists(region_orga, region_orga.dept_org, dept)
-                for orga_type in dept_orga["type"].unique():
-                    potential = len(dept_orga[dept_orga.type == orga_type])
-                    potential_records.append([region, num_dept, dept, "prescripteur", orga_type, potential])
+                if not dept_orga.empty:
+                    for orga_type in dept_orga["type"].unique():
+                        potential = len(dept_orga[dept_orga.type == orga_type])
+                        potential_records.append([region, num_dept, dept, "prescripteur", orga_type, potential])
 
             # structures
             if not region_struct.empty:
                 dept_struct = subdf_by_value_if_exists(region_struct, region_struct.nom_département, dept)
-                for struct_type in dept_struct["type"].unique():
-                    potential = len(dept_struct[dept_struct.type == struct_type])
-                    potential_records.append([region, num_dept, dept, "siae", struct_type, potential])
+                if not dept_struct.empty:
+                    for struct_type in dept_struct["type"].unique():
+                        potential = len(dept_struct[dept_struct.type == struct_type])
+                        potential_records.append([region, num_dept, dept, "siae", struct_type, potential])
 
     return pd.DataFrame.from_records(
         potential_records,


### PR DESCRIPTION
### Pourquoi ?

_CPT_

Le script cassait pour "975 - Saint-Pierre-et-Miquelon" qui n'avais pas d'orga donc `dept_orga["type"]` :boom:.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

