### PR TITLE
Résolution d'un bug sur le tb 289

### DIFF
--- a/dbt/models/staging/stg_organisations.sql
+++ b/dbt/models/staging/stg_organisations.sql
@@ -7,10 +7,11 @@ select
     organisations."nom_département",
     organisations.siret                                                               as siret_org_prescripteur,
     organisations."nom_département"                                                   as dept_org,
+    -- les deux colonnes suivantes sont en doublons le temps de vérifier les branchements de filtre sur metabase
     organisations."région"                                                            as "région_org",
+    organisations."région",
     /*bien mettre nom département et pas département */
     appartenance_geo_communes.nom_departement                                         as "nom_département_insee",
-    appartenance_geo_communes.nom_region                                              as "région",
     appartenance_geo_communes.nom_zone_emploi                                         as zone_emploi,
     appartenance_geo_communes.nom_epci                                                as epci,
     organisations_libelles.label                                                      as type_complet,


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Problème : 
- la colonne région était calculée via les données insee, donc certaines manquent et c'est ce qui causait le bug
- la colonne région org est bien la région de l'orga via les emploi, c'est sur cette col qu'on veut filtrer
- le filtre a cependant été branché sur "région" et pas "région_org"
- pour éviter de modifier tous les branchements, je modifie la colonne région
- je laisse la colonne région_org pour le moment même si cela fait doublon, car je crains qu'un autre tb soit branché sur cette colonne et je ne veux pas tout casser

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

