### PR TITLE
Ajout d'une colonne contenant le nom + SIRET d'une siae

### DIFF
--- a/dbt/models/indexed/fluxIAE_Structure_v2.sql
+++ b/dbt/models/indexed/fluxIAE_Structure_v2.sql
@@ -8,10 +8,11 @@
 select
     /* l'ASP préconise l'utilisation de l'adresse administrative pour récupérer la commune de la structure */
     {{ pilo_star(source('fluxIAE', 'fluxIAE_Structure')) }},
-    app_geo.nom_epci                as nom_epci_structure,
-    app_geo.nom_region              as nom_region_structure,
-    app_geo.code_dept               as code_dept_structure,
-    app_geo.nom_departement_complet as nom_departement_structure
+    app_geo.nom_epci                                                  as nom_epci_structure,
+    app_geo.nom_region                                                as nom_region_structure,
+    app_geo.code_dept                                                 as code_dept_structure,
+    app_geo.nom_departement_complet                                   as nom_departement_structure,
+    concat_ws('-', structure_denomination, structure_siret_actualise) as structure_denomination_unique
 from
     {{ source('fluxIAE', 'fluxIAE_Structure') }} as structure
 left join {{ ref('stg_insee_appartenance_geo_communes') }} as app_geo

--- a/dbt/models/marts/weekly/suivi_complet_etps_conventionnes.py
+++ b/dbt/models/marts/weekly/suivi_complet_etps_conventionnes.py
@@ -72,6 +72,7 @@ def get_zero_etp(df):
                             "type_structure_emplois",
                             "structure_id_siae",
                             "structure_denomination",
+                            "structure_denomination_unique",
                             "type_structure",
                             "year_diff",
                             "af_montant_total_annuel",

--- a/dbt/models/staging/stg_etp_conventionnes.sql
+++ b/dbt/models/staging/stg_etp_conventionnes.sql
@@ -23,6 +23,7 @@ select distinct
     ref_asp.type_structure_emplois,
     structure.structure_id_siae,
     structure.structure_denomination,
+    structure.structure_denomination_unique,
     structure.structure_adresse_admin_commune    as commune_structure,
     structure.structure_adresse_admin_code_insee as code_insee_structure,
     structure.structure_siret_actualise          as siret_structure,


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Certaines SIAE ont le même nom alors que ce ne sont pas les mêmes structures, ajout d'une colonne Nom + ID afin de pouvoir montrer des données non agrégées sur nos TBs.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

