### PR TITLE
Dag pour refresh les oneshot

### DIFF
--- a/dags/dbt_oneshot.py
+++ b/dags/dbt_oneshot.py
@@ -1,0 +1,59 @@
+import airflow
+from airflow.operators import bash, empty, trigger_dagrun
+
+from dags.common import db, dbt, default_dag_args, slack
+
+
+dag_args = default_dag_args() | {"default_args": dbt.get_default_args()}
+
+with airflow.DAG(
+    dag_id="dbt_oneshot",
+    schedule_interval=None,
+    **dag_args,
+) as dag:
+    start = empty.EmptyOperator(task_id="start")
+
+    end = slack.success_notifying_task()
+
+    env_vars = db.connection_envvars()
+
+    dbt_debug = bash.BashOperator(
+        task_id="dbt_debug",
+        bash_command="dbt debug",
+        env=env_vars,
+        append_env=True,
+    )
+
+    dbt_deps = bash.BashOperator(
+        task_id="dbt_deps",
+        bash_command="dbt deps",
+        env=env_vars,
+        append_env=True,
+    )
+
+    dbt_seed = bash.BashOperator(
+        task_id="dbt_seed",
+        bash_command="dbt seed --full-refresh",
+        env=env_vars,
+        append_env=True,
+    )
+
+    dbt_run = bash.BashOperator(
+        task_id="dbt_run",
+        bash_command="dbt run --select marts.oneshot",
+        env=env_vars,
+        append_env=True,
+    )
+
+    dbt_clean = bash.BashOperator(
+        task_id="dbt_clean",
+        bash_command="dbt clean",
+        env=env_vars,
+        append_env=True,
+    )
+
+    dag_data_consistency = trigger_dagrun.TriggerDagRunOperator(
+        trigger_dag_id="data_consistency", task_id="trigger_data_consistency"
+    )
+
+    (start >> dbt_debug >> dbt_deps >> dbt_seed >> dbt_run >> dbt_clean >> dag_data_consistency >> end)

--- a/dbt/models/marts/oneshot/candidatures_ddets50.sql
+++ b/dbt/models/marts/oneshot/candidatures_ddets50.sql
@@ -13,6 +13,5 @@ select
 from {{ ref('candidatures_echelle_locale') }} as cel
 left join {{ ref('stg_candidats_candidatures') }} as cc on cel.id = cc.id_candidature
 where
-    date_part('year', cel.date_candidature) = 2024
-    and date_part('month', cel.date_candidature) <= 6
+    cel.date_candidature between '2023-01-01' and '2024-06-30'
     and cel.dept_org = '50 - Manche'


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Création d'un dag pour pouvoir refresh les fichiers 'oneshot' sans refresh le reste

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

