### PR TITLE
Ajout de l'EPCI structures sur 2 tables pour le TB 346

### DIFF
--- a/dbt/models/marts/daily/nombre_candidatures_par_structure.sql
+++ b/dbt/models/marts/daily/nombre_candidatures_par_structure.sql
@@ -20,6 +20,7 @@ select
     c.injection_ai,
     s.ville,
     s.siret,
+    s.nom_epci_structure,
     /* calcul de la proportion de candidatures en % */
     c.nombre_de_candidatures / prop_cddr.total_candidatures as taux_de_candidatures
 from

--- a/dbt/models/staging/stg_candidatures_autoprescription.sql
+++ b/dbt/models/staging/stg_candidatures_autoprescription.sql
@@ -27,6 +27,7 @@ select
     cd."département_structure",
     cd."nom_département_structure",
     cd."région_structure",
+    cd.nom_epci_structure,
     cd.bassin_emploi_prescripteur,
     cd.bassin_emploi_structure,
     date_part('year', c.date_diagnostic)   as "année_diagnostic",


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Ajout de l'EPCI structures sur 2 tables pour le TB 346

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

