### PR TITLE
Fix URL for dbt-postgres repository in requirements

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,7 +5,7 @@ apache-airflow[amazon,sentry,slack]==2.9.3  # https://github.com/apache/airflow
 # DBT
 # ------------------------------------------------------------------------------
 dbt-core==1.5.*  # https://github.com/dbt-labs/dbt-core
-dbt-postgres  # https://github.com/dbt-labs/postgres
+dbt-postgres  # https://github.com/dbt-labs/dbt-postgres
 dbt-fal  # https://github.com/fal-ai/dbt-fal
 
 # Data management (scripts, DAG, ...)


### PR DESCRIPTION
### Pourquoi ?

Le lien vers le repo de `dbt-postgres` qu'on utilise n'est pas celui de leur [page PyPi](https://pypi.org/project/dbt-postgres/)

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

