### PR TITLE
Ajout de l'arrondissement du prescripteur

### DIFF
--- a/dbt/models/marts/daily/suivi_candidatures_prescripteurs_habilites.sql
+++ b/dbt/models/marts/daily/suivi_candidatures_prescripteurs_habilites.sql
@@ -1,11 +1,12 @@
 select
     {{ pilo_star(ref('candidatures_echelle_locale'), relation_alias='candidatures') }},
-    organisations."département"     as "département_prescripteur",
-    organisations."nom_département" as "nom_département_prescripteur",
-    organisations."région"          as "région_prescripteur",
-    organisations.epci              as epci_prescripteur,
-    organisations.zone_emploi       as zone_emploi_prescripteur,
-    organisations.type_complet      as libelle_complet
+    organisations."département"      as "département_prescripteur",
+    organisations."nom_département"  as "nom_département_prescripteur",
+    organisations."région"           as "région_prescripteur",
+    organisations.nom_arrondissement as nom_arrondissement_prescripteur,
+    organisations.epci               as epci_prescripteur,
+    organisations.zone_emploi        as zone_emploi_prescripteur,
+    organisations.type_complet       as libelle_complet
 from
     {{ ref('candidatures_echelle_locale') }} as candidatures
 left join {{ ref('organisations') }} as organisations

--- a/dbt/models/marts/daily/taux_transformation_prescripteurs.sql
+++ b/dbt/models/marts/daily/taux_transformation_prescripteurs.sql
@@ -45,17 +45,18 @@ with candidats_p as (
 select
     /* On selectionne les colonnes finales qui nous intéressent */
     c.*,
-    organisations_libelles.label as type_auteur_diagnostic_detaille,
+    organisations_libelles.label     as type_auteur_diagnostic_detaille,
     prescripteurs.type_prescripteur,
-    prescripteurs.zone_emploi    as bassin_emploi_prescripteur,
-    prescripteurs.epci           as epci_prescripteur,
-    prescripteurs.dept_org       as "nom_département_prescripteur",
-    prescripteurs."région_org"   as "nom_région_prescripteur",
+    prescripteurs.nom_arrondissement as nom_arrondissement_prescripteur,
+    prescripteurs.zone_emploi        as bassin_emploi_prescripteur,
+    prescripteurs.epci               as epci_prescripteur,
+    prescripteurs.dept_org           as "nom_département_prescripteur",
+    prescripteurs."région_org"       as "nom_région_prescripteur",
     case
         /* ajout d'une colonne permettant de calculer le taux de candidats acceptées
             tout en faisant une jointure avec la table candidatures */
         when c.total_embauches > 0 then concat(cast(c.id_candidat as varchar), '_accepté')
-    end                          as "candidature_acceptée"
+    end                              as "candidature_acceptée"
 from
     candidats_p as c
 left join {{ ref('stg_organisations') }} as prescripteurs

--- a/dbt/models/staging/stg_organisations.sql
+++ b/dbt/models/staging/stg_organisations.sql
@@ -12,6 +12,7 @@ select
     organisations."région",
     /*bien mettre nom département et pas département */
     appartenance_geo_communes.nom_departement                                         as "nom_département_insee",
+    appartenance_geo_communes.nom_arrondissement,
     appartenance_geo_communes.nom_zone_emploi                                         as zone_emploi,
     appartenance_geo_communes.nom_epci                                                as epci,
     organisations_libelles.label                                                      as type_complet,


### PR DESCRIPTION
**Carte Notion : **
https://www.notion.so/gip-inclusion/Suivi-des-cartes-2c660074779f41658b95bac202e38a08?p=1425f321b6048078b7b4fbbf1b756f05&pm=c

### Pourquoi ?

A la demande des SD, ajout de l'arrondissement du prescripteur afin de rajouter un filtre sur le TB 289 

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

