### PR TITLE
Ajout des informations financières par AF + test ETP conventionnés

### DIFF
--- a/dbt/macros/columns_null_check.sql
+++ b/dbt/macros/columns_null_check.sql
@@ -1,0 +1,6 @@
+{% macro sum_nullable_columns(columns) %}
+    {% for column in columns %}
+        coalesce({{ column }}, 0)
+        {% if not loop.last %} + {% endif %}
+    {% endfor %}
+{% endmacro %}

--- a/dbt/models/_sources.yml
+++ b/dbt/models/_sources.yml
@@ -21,6 +21,7 @@ sources:
       - name: fluxIAE_RefFormeContrat
       - name: fluxIAE_Salarie
       - name: fluxIAE_Structure
+      - name: fluxIAE_MarchesPublics
 
   - name: emplois
     schema: public

--- a/dbt/models/indexed/fluxIAE_MarchesPublics_v2.sql
+++ b/dbt/models/indexed/fluxIAE_MarchesPublics_v2.sql
@@ -1,0 +1,27 @@
+{{ config(
+    materialized = 'table',
+    indexes=[
+      {'columns': ['mpu_af_id'], 'type' : 'btree', 'unique' : False},
+    ]
+ ) }}
+
+select distinct --sometimes there are duplicates, we want to avoid this
+    mpu_af_id,
+    mpu_sct_mt_recet_nettoyage,
+    mpu_sct_mt_recet_serv_pers,
+    mpu_sct_mt_recet_btp,
+    mpu_sct_mt_recet_agri,
+    mpu_sct_mt_recet_recycl,
+    mpu_sct_mt_recet_transp,
+    mpu_sct_mt_recet_autres
+from
+    {{ source('fluxIAE', 'fluxIAE_MarchesPublics') }}
+where {{ sum_nullable_columns([
+    'mpu_sct_mt_recet_nettoyage',
+    'mpu_sct_mt_recet_serv_pers',
+    'mpu_sct_mt_recet_btp',
+    'mpu_sct_mt_recet_agri',
+    'mpu_sct_mt_recet_recycl',
+    'mpu_sct_mt_recet_transp',
+    'mpu_sct_mt_recet_autres'
+]) }} != 0

--- a/dbt/models/indexed/properties.yml
+++ b/dbt/models/indexed/properties.yml
@@ -32,3 +32,7 @@ models:
   - name: corresp_af_contrats
     description: >
       Table permettant de récupérer les annexes financières associées aux contrats.
+  - name: fluxIAE_MarchesPublics_v2
+    description: >
+      Table introduite afin d'ajouter des index à la table fluxIAE_MarchesPublics.
+      On ne prend pas en compte les 10 entrées dans cette table qui sont dupliquées, et on ignore les lignes où aucune valeur de recette n'est remplie (aucune valeur différente de null ou zéro).

--- a/dbt/models/marts/weekly/suivi_complet_etps_conventionnes.py
+++ b/dbt/models/marts/weekly/suivi_complet_etps_conventionnes.py
@@ -115,6 +115,19 @@ def join_etp_null_and_realized(df_replicate, df_etp_null):
 
 def model(dbt, session):
     df = dbt.ref("suivi_etp_conventionnes_v2")
+    # We don't need these columns
+    df.drop(
+        columns=[
+            "mpu_sct_mt_recet_nettoyage",
+            "mpu_sct_mt_recet_serv_pers",
+            "mpu_sct_mt_recet_btp",
+            "mpu_sct_mt_recet_agri",
+            "mpu_sct_mt_recet_recycl",
+            "mpu_sct_mt_recet_transp",
+            "mpu_sct_mt_recet_autres",
+        ],
+        inplace=True,
+    )
     df["af_date_debut_effet_v2"] = pd.to_datetime(df["af_date_debut_effet_v2"])
     df["af_date_fin_effet_v2"] = pd.to_datetime(df["af_date_fin_effet_v2"])
     df_replicate = explode_by_month(df)

--- a/dbt/models/staging/stg_etp_conventionnes.sql
+++ b/dbt/models/staging/stg_etp_conventionnes.sql
@@ -18,6 +18,13 @@ select distinct
     af.af_montant_total_annuel,
     af.af_montant_unitaire_annuel_valeur,
     af.af_mt_cofinance,
+    mp.mpu_sct_mt_recet_nettoyage,
+    mp.mpu_sct_mt_recet_serv_pers,
+    mp.mpu_sct_mt_recet_btp,
+    mp.mpu_sct_mt_recet_agri,
+    mp.mpu_sct_mt_recet_recycl,
+    mp.mpu_sct_mt_recet_transp,
+    mp.mpu_sct_mt_recet_autres,
     evo_rsa.montant                              as montant_rsa,
     ref_asp.type_structure,
     ref_asp.type_structure_emplois,
@@ -61,6 +68,9 @@ left join
 left join {{ ref('ref_mesure_dispositif_asp') }} as ref_asp
     on
         af.af_mesure_dispositif_code = ref_asp.af_mesure_dispositif_code
+left join {{ ref('fluxIAE_MarchesPublics_v2') }} as mp
+    on
+        af.af_id_annexe_financiere = mp.mpu_af_id
 left join
     {{ ref('evolution_rsa') }} as evo_rsa
     -- to get the rsa amount at the year of the af

--- a/dbt/tests/properties.yml
+++ b/dbt/tests/properties.yml
@@ -25,3 +25,11 @@ tests:
    - name: test_candidatures_candidats_recherche_active
     description: >
       Permet de vérifier qu'il n'y a pas de doublons ou lignes absentes dans la table candidatures candidats recherche active.
+   - name: test_etp_conventionnes
+    description: >
+      Permet de vérifier que l'on a le bon nombre d'ETP conventionnes
+   - name: test_fluxIAE_MarchesPublics
+    description: >
+        Test permettant de vérifier que l'on a le même montant de recettes entre le fichier fluxIAE_MarchesPublics et fluxIAE_MarchesPublics_v2
+
+

--- a/dbt/tests/test_etp_conventionnes.sql
+++ b/dbt/tests/test_etp_conventionnes.sql
@@ -1,0 +1,30 @@
+with etp_sum as (
+    select
+        (
+            --there some unique ids that are duplicated, we need to get rid of them
+            select sum(af_etp_postes_insertion) from (
+                select distinct on (af.af_id_annexe_financiere) af.af_etp_postes_insertion
+                from {{ ref('stg_dates_annexe_financiere') }} as constantes
+                cross join {{ ref('fluxIAE_AnnexeFinanciere_v2') }} as af
+                where
+                    date_part('year', af.af_date_debut_effet_v2) = constantes.annee_en_cours
+                    and af.af_etat_annexe_financiere_code in (
+                        'VALIDE',
+                        'PROVISOIRE',
+                        'CLOTURE'
+                    )
+                    and af.af_mesure_dispositif_code not like '%FDI%'
+            ) as tmp
+        ) as theirs,
+        (
+            select sum(etp."effectif_mensuel_conventionné")
+            from {{ ref('stg_dates_annexe_financiere') }} as constantes
+            cross join {{ ref("suivi_etp_conventionnes_v2") }} as etp
+            where
+                etp.annee_af = constantes.annee_en_cours
+        ) as ours
+)
+
+select *
+from etp_sum
+where round(theirs) != round(ours)

--- a/dbt/tests/test_fluxIAE_MarchesPublics.sql
+++ b/dbt/tests/test_fluxIAE_MarchesPublics.sql
@@ -1,0 +1,15 @@
+with mp as (
+    select
+        (
+            select sum(mpu_sct_mt_recet_nettoyage)
+            from {{ source('fluxIAE', 'fluxIAE_MarchesPublics') }}
+        ) as theirs,
+        (
+            select sum(mpu_sct_mt_recet_nettoyage)
+            from {{ ref("fluxIAE_MarchesPublics_v2") }}
+        ) as ours
+)
+
+select *
+from mp
+where round(theirs) != round(ours)


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Afin de répondre à une demande de FT et du marché, nous ajoutons les informations financières par AF (recettes par AF) + ajout d'un test pour les ETP conventionnés (much needed)

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

