### PR TITLE
Ajout du suivi du TB privé 496

### DIFF
--- a/dbt/seeds/pilotage_interne/metabase_dashboards.csv
+++ b/dbt/seeds/pilotage_interne/metabase_dashboards.csv
@@ -47,3 +47,4 @@ id_tb,nom_tb,public,type
 465,tb 465 - SIAE- Données IAE : Suivi des effectifs annuels et mensuels en ETP,SIAE,TB privé
 485,tb 485 - DDETS/DREETS/CD - Données conventionnement - Maille structure,DDETS/DREETS/CD, TB privé
 488,tb 488 - PH - Etat des candidatures orientées,PH,TB privé
+496,tb 496 - FT - Etat des candidatures orientées,FT,TB privé


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Ajout du suivi du TB privé 496, PR a fusionner quand la PR associée côté emplois sera passée

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

