### PR TITLE
Ajout d'un DAG pour récupérer les structures et services de data·inclusion

### DIFF
--- a/dags/common/db.py
+++ b/dags/common/db.py
@@ -75,3 +75,11 @@ def drop_view(view_name):
         drop_view_query = sql.SQL("DROP VIEW IF EXISTS {name};").format(name=sql.Identifier(view_name))
         cursor.execute(drop_view_query)
         conn.commit()
+
+
+def create_schema(schema_name):
+    from psycopg2 import sql
+
+    with MetabaseDBCursor() as (cursor, conn):
+        cursor.execute(sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(sql.Identifier(schema_name)))
+        conn.commit()

--- a/dags/data_inclusion.py
+++ b/dags/data_inclusion.py
@@ -1,0 +1,95 @@
+import logging
+
+import httpx
+import pandas as pd
+import sqlalchemy
+from airflow import DAG
+from airflow.decorators import task
+from airflow.models import Variable
+from airflow.operators import python
+from sqlalchemy.dialects import postgresql
+
+from dags.common import db, dbt, default_dag_args, slack
+
+
+DB_SCHEMA = "data_inclusion"
+
+logger = logging.getLogger(__name__)
+
+dag_args = default_dag_args() | {"default_args": dbt.get_default_args()}
+
+
+def api_client() -> httpx.Client:
+    return httpx.Client(
+        base_url=Variable.get("API_DATA_INCLUSION_BASE_URL"),
+        headers={"Authorization": "Bearer {}".format(Variable.get("API_DATA_INCLUSION_TOKEN"))},
+        timeout=httpx.Timeout(timeout=5, read=30),
+    )
+
+
+def get_all_items(path):
+    client = api_client()
+
+    page_to_fetch = 1
+    while True:
+        response = client.get(path, params={"size": 1000, "page": page_to_fetch})
+        response.raise_for_status()
+        data = response.json()
+        logger.info("Got %r items, metadata=%r", len(data["items"]), {k: v for k, v in data.items() if k != "items"})
+        yield from data["items"]
+        page_to_fetch = data["page"] + 1
+        if page_to_fetch > data["pages"]:
+            break
+
+
+with DAG("data_inclusion", schedule_interval=None, **dag_args) as dag:
+
+    @task(task_id="import_structures")
+    def import_structures(**kwargs):
+        df = pd.DataFrame(get_all_items("/api/v0/structures"))
+        df["date_maj"] = pd.to_datetime(df["date_maj"])
+        row_created = df.to_sql(
+            "structures_v0",
+            con=db.connection_engine(),
+            schema=DB_SCHEMA,
+            if_exists="replace",
+            index=False,
+            dtype={
+                "labels_nationaux": postgresql.ARRAY(sqlalchemy.types.Text),
+                "labels_autres": postgresql.ARRAY(sqlalchemy.types.Text),
+                "thematiques": postgresql.ARRAY(sqlalchemy.types.Text),
+            },
+        )
+        logger.info("%r rows created", row_created)
+
+    @task(task_id="import_services")
+    def import_services(**kwargs):
+        df = pd.DataFrame(get_all_items("/api/v0/services"))
+        df["date_creation"] = pd.to_datetime(df["date_creation"])
+        df["date_suspension"] = pd.to_datetime(df["date_suspension"])
+        df["date_maj"] = pd.to_datetime(df["date_maj"])
+        rows_created = df.to_sql(
+            "services_v0",
+            con=db.connection_engine(),
+            schema=DB_SCHEMA,
+            if_exists="replace",
+            index=False,
+            dtype={
+                "types": postgresql.ARRAY(sqlalchemy.types.Text),
+                "thematiques": postgresql.ARRAY(sqlalchemy.types.Text),
+                "frais": postgresql.ARRAY(sqlalchemy.types.Text),
+                "profils": postgresql.ARRAY(sqlalchemy.types.Text),
+                "pre_requis": postgresql.ARRAY(sqlalchemy.types.Text),
+                "justificatifs": postgresql.ARRAY(sqlalchemy.types.Text),
+                "modes_accueil": postgresql.ARRAY(sqlalchemy.types.Text),
+                "modes_orientation_beneficiaire": postgresql.ARRAY(sqlalchemy.types.Text),
+                "modes_orientation_accompagnateur": postgresql.ARRAY(sqlalchemy.types.Text),
+            },
+        )
+        logger.info("%r rows created", rows_created)
+
+    (
+        python.PythonOperator(task_id="create_schema", python_callable=db.create_schema, op_args=[DB_SCHEMA])
+        >> [import_structures(), import_services()]
+        >> slack.success_notifying_task()
+    )


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/gip-inclusion/2-Source-de-donn-es-Se-brancher-sur-DI-et-r-cup-rer-leur-donn-es-pour-le-cas-d-usage-tensions-sur-15e5f321b60480608cc2d936b28eb728?pvs=4

C'est pas la solution que je voulais faire, mais je pense qu'elle fera l'affaire pour le moment.

A l'origine je voulais installer `data-inclusion-schema` pour réutiliser les modèles _pydantic_ et créer le schéma de la table depuis celui-ci mais à cause de `dbt-fal` les versions de `data-inclusion-schema`, `pydantic` et `pydantic-core` installable sont trop veilles donc inutilisable...
Et cerise sur le gâteau la version de `httpx` ne nous permet pas de chaîner les appels après `raise_for_status()` : https://github.com/encode/httpx/commit/9415af643f23600403740baad0a466edc5cdbec1