### PR TITLE
Ignore order column in dbt snapshot 

### DIFF
--- a/dbt/snapshots/candidats_recherche_active_snapshot.sql
+++ b/dbt/snapshots/candidats_recherche_active_snapshot.sql
@@ -10,5 +10,7 @@
         )
     }}
 
-    select * from {{ ref('candidats_recherche_active') }}
+    select
+        {{ pilo_star(ref('candidats_recherche_active'), except=['delai_derniere_candidature_interval_order']) }}
+    from {{ ref('candidats_recherche_active') }}
 {% endsnapshot %}


### PR DESCRIPTION
### Pourquoi ?

Résoudre le bug soulevé ici : https://gip-inclusion.slack.com/archives/C050D9JNJ9Z/p1736175364160319

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

