### PR TITLE
Récupération de la part CD/Etat via les données de la DGEFP

### DIFF
--- a/dags/data_consistency.py
+++ b/dags/data_consistency.py
@@ -1,5 +1,6 @@
 import airflow
-from airflow.operators import bash, empty
+from airflow.models.param import Param
+from airflow.operators import bash, empty, python
 
 from dags.common import db, dbt, default_dag_args
 
@@ -8,6 +9,7 @@ dag_args = default_dag_args() | {"default_args": dbt.get_default_args()}
 
 with airflow.DAG(
     dag_id="data_consistency",
+    params={"all_tests": Param(False, type="boolean")},
     **dag_args,
 ) as dag:
     start = empty.EmptyOperator(task_id="start")
@@ -21,9 +23,18 @@ with airflow.DAG(
         append_env=True,
     )
 
+    def params_check(params=None, **kwargs):
+        is_all_tests = params.get("all_tests")
+        if is_all_tests:
+            kwargs["ti"].xcom_push("dbt_test_args", "")
+        else:
+            kwargs["ti"].xcom_push("dbt_test_args", "--exclude test_etp_dgefp_pilo")
+
+    params_check = python.PythonOperator(task_id="params_check", provide_context=True, python_callable=params_check)
+
     dbt_test = bash.BashOperator(
         task_id="dbt_test",
-        bash_command="dbt test",
+        bash_command="dbt test {{ ti.xcom_pull(task_ids='params_check', key='dbt_test_args') }}",
         env=env_vars,
         append_env=True,
     )

--- a/dags/dgefp_get_etp.py
+++ b/dags/dgefp_get_etp.py
@@ -1,0 +1,59 @@
+from io import StringIO
+
+from airflow import DAG
+from airflow.decorators import task
+from airflow.operators import empty
+
+from dags.common import db, default_dag_args, ftp, slack
+
+
+with DAG(
+    "dgefp_etp",
+    schedule_interval=None,
+    **default_dag_args(),
+) as dag:
+    start = empty.EmptyOperator(task_id="start")
+    end = slack.success_notifying_task()
+
+    @task(task_id="store_etp")
+    def store_etp(**kwargs):
+
+        import ftputil
+        import pandas as pd
+
+        host, user, password = ftp.bucket_connection()
+        FILE_PREFIX = "iae_v1_0_suivi_hebdomadaire_"
+
+        with ftputil.FTPHost(host, user, password) as host_ft:
+            etp_file = None
+            for filename in host_ft.listdir("dgefp"):
+                if filename.startswith(FILE_PREFIX) and filename.endswith(".csv"):
+                    # Get file modification time and add to list
+                    etp_file = filename
+
+            if not etp_file:
+                raise Exception("No matching files found in the FTP directory")
+
+            # get the most recent file
+            DGEFP_RAW_DATA = f"dgefp/{etp_file}"
+
+            print(f"Loading most recent file: {etp_file}")
+
+            # Need to do this because setting the encoding on the pd.read_csv did not work
+            with host_ft.open(DGEFP_RAW_DATA, "rb") as etp_loaded_data:
+                content = etp_loaded_data.read()
+                text_content = content.decode("latin1")
+                df = pd.read_csv(StringIO(text_content), sep=";")
+
+                for col in df.columns[9:17]:
+                    if df[col].isnull().any() or (df[col] == "").any():
+                        print(f"Column {col} has missing or invalid values")
+                        df[col] = df[col].replace("", "NaN")
+                    else:
+                        df[col] = df[col].str.replace(",", ".").astype(float)
+
+        df.to_sql("dgefp_donnees_etp", con=db.connection_engine(), if_exists="replace", index=False)
+
+    store_etp = store_etp()
+
+    (start >> store_etp >> end)

--- a/dags/properties.yml
+++ b/dags/properties.yml
@@ -17,3 +17,7 @@ models:
     description: >
       Ce DAG permet de récupérer de manière quotidienne les données de contacts & commandes sur le airtable de monrecap.
       A travers un google sheet (tally) nous récupérons les réponses au baromètre. Ces 3 tables permettent la réalisation de la page statistiques de mon recap !
+- name: dgefp_get_etp
+    description: >
+      Ce DAG permet de récupérer le .csv de la DGEFP contenant la part CD/Etat pour chaque annexe financiere.
+      Le .csv doit être téléchargé sur POP puis déposé manuellement dans le ftp c2-bucket.

--- a/dbt/models/_sources.yml
+++ b/dbt/models/_sources.yml
@@ -127,3 +127,10 @@ sources:
       - name: barometre_v0
       - name: Contacts_v0
       - name: Commandes_v0
+  - name: DGEFP
+    schema: public
+    description: >
+      Tables générées chaque semaine, manuellement via un DAG, après récupération des données auprès de la DGEFP
+    tables:
+      - name: dgefp_donnees_etp
+

--- a/dbt/models/marts/weekly/dgefp_etp_etat_cd.sql
+++ b/dbt/models/marts/weekly/dgefp_etp_etat_cd.sql
@@ -1,0 +1,47 @@
+select
+    af.af_numero_convention,
+    af.af_numero_annexe_financiere,
+    af.af_date_debut_effet_v2,
+    af.af_date_fin_effet_v2,
+    af.af_mesure_dispositif_code,
+    af.af_montant_total_annuel,
+    af.af_montant_unitaire_annuel_valeur,
+    af.af_mt_cofinance,
+    af.type_structure,
+    af.type_structure_emplois,
+    af.structure_id_siae,
+    af.structure_denomination,
+    af.structure_denomination_unique,
+    af.commune_structure,
+    af.code_insee_structure,
+    af.siret_structure,
+    af.nom_departement_structure,
+    af.nom_region_structure,
+    af.code_departement_af,
+    af.nom_departement_af,
+    af.nom_region_af,
+    af.annee_af,
+    af.year_diff,
+    af.duree_annexe,
+    af."effectif_annuel_conventionné",
+    af."Montant_total_aide",
+    af.part_conventionnement_cd,
+    af.etp_conventionnes_cd,
+    af.etp_conventionnes_etat,
+    dgefp."SIRET actualisé",
+    dgefp."Num Annexe",
+    dgefp."Type Aide",
+    dgefp."Financeur",
+    dgefp."ETP conventionnés",
+    dgefp."Montant conventionné",
+    dgefp."ETP déclarés",
+    dgefp."ETP réalisé plafonné au max des ETP conv",
+    dgefp."Réalisation en ETP en deçà ou au-delà du conventionnement"
+from {{ ref('suivi_etp_conventionnes_v2') }} as af
+left join {{ source('DGEFP','dgefp_donnees_etp') }} as dgefp
+    on
+        af.annee_af = dgefp."Année d'analyse"
+        and af.af_numero_annexe_financiere = dgefp."Num Annexe"
+where
+    "Type Aide" = 'Aide au poste'
+    and af.annee_af in (select distinct dgefp."Année d'analyse" from {{ source('DGEFP','dgefp_donnees_etp') }})

--- a/dbt/models/marts/weekly/properties.yml
+++ b/dbt/models/marts/weekly/properties.yml
@@ -128,3 +128,7 @@ models:
   - name: candidats_decrochage
     description: >
       Table permettant l'identification des candidats en decrochage, c'est a dire les candidats ayant effectué une candidature après une sortie non positive.
+  - name: dgefp_etp_etat_cd
+    description: >
+      Table permettant d'identifier d'associer les données de la DGEFP contenant la part CD et Etat aux informations de structure et d'annexe financiere du flux IAE.
+

--- a/dbt/tests/properties.yml
+++ b/dbt/tests/properties.yml
@@ -31,5 +31,10 @@ tests:
    - name: test_fluxIAE_MarchesPublics
     description: >
         Test permettant de vérifier que l'on a le même montant de recettes entre le fichier fluxIAE_MarchesPublics et fluxIAE_MarchesPublics_v2
+   - name: test_etp_dgefp_pilo
+    description: >
+        Test permettant de vérifier que nos données d'ETP sont raccord avec celle de la DGEFP.
+        Les données de la DGEFP étant importées à la main, ce test doit être lancé manuellement.
+        L'execution de ce test se fait, après import des données DGEGP, à l'aide d'un "all_tests" du dag data_consistency via l'interface graphique d'airflow.
 
 

--- a/dbt/tests/test_etp_dgefp_pilo.sql
+++ b/dbt/tests/test_etp_dgefp_pilo.sql
@@ -1,0 +1,16 @@
+with etp_conventionnes as (
+    select
+        (
+            select round(sum("effectif_annuel_conventionné"))
+            from {{ ref("suivi_etp_conventionnes_v2") }}
+        ) as count_us,
+        (
+            select round(sum("ETP conventionnés"))
+            from {{ source("DGEFP","dgefp_donnees_etp") }}
+            where "Type Aide" = 'Aide au poste'
+        ) as count_them
+)
+
+select *
+from etp_conventionnes
+where count_us != count_them


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/gip-inclusion/ETP-Part-CD-Etat-R-cup-rer-les-donn-es-de-la-DGEFP-et-faire-la-jointure-avec-nos-donn-es-1735f321b604802cbcdccbdd3f7dd621?pvs=4

### Pourquoi ?

Récupération de la part CD/Etat via les données de la DGEFP

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

