### PR TITLE
Ajout du nom prénom du conseiller aux candidats file active

### DIFF
--- a/dbt/models/marts/daily/candidats_recherche_active.sql
+++ b/dbt/models/marts/daily/candidats_recherche_active.sql
@@ -17,6 +17,7 @@ select
     cc."région",
     cc."nom_département",
     cc."département",
+    cc."nom_prénom_conseiller",
     coalesce(sum(case when cc.type_prescripteur = 'SPE' then 1 else 0 end) > 0)                              as candidatures_spe,
     coalesce(sum(case when cc.type_structure in ('ACI', 'AI', 'EI', 'EITI', 'ETTI') then 1 else 0 end) > 0)  as candidat_iae,
     min(cc.date_premiere_candidature)                                                                        as date_premiere_candidature,
@@ -53,6 +54,7 @@ group by
     cc."région",
     cc."nom_département",
     cc."département",
+    cc."nom_prénom_conseiller",
     cc.diagnostic_valide,
     cc.type_auteur_diagnostic,
     cc.sous_type_auteur_diagnostic

--- a/dbt/models/staging/stg_candidats_candidatures.sql
+++ b/dbt/models/staging/stg_candidats_candidatures.sql
@@ -12,7 +12,8 @@ select
     cd.id_structure,
     cd.origine,
     cd."origine_détaillée",
-    cd.type_prescripteur
+    cd.type_prescripteur,
+    cd."nom_prénom_conseiller"
 from {{ ref('candidats') }} as c
 left join {{ ref('candidatures_echelle_locale') }} as cd
     on c.id = cd.id_candidat


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/gip-inclusion/usagers-bloqu-s-Rajouter-dans-la-table-usager-bloqu-candidat-en-recherche-active-nom-conseiller--1735f321b6048006b4b7da241d31b6c5?pvs=4

### Pourquoi ?

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

