### PR TITLE
Changement nom colonne mon recap

### DIFF
--- a/dbt/models/monrecap/staging/stg_contacts_commandeurs.sql
+++ b/dbt/models/monrecap/staging/stg_contacts_commandeurs.sql
@@ -48,7 +48,7 @@ select
     cmd."declaratif autre outil",
     cmd."declaratif plusieurs freins",
     cmd."declaratif quels freins",
-    cmd.label,
+    cmd."Votre structure appartient à une structure, un réseau ou un l",
     dpt.nom_departement,
     contacts."Commande passée",
     contacts."Nombre de carnets commandés Total",

--- a/dbt/models/monrecap/staging/stg_contacts_non_commandeurs.sql
+++ b/dbt/models/monrecap/staging/stg_contacts_non_commandeurs.sql
@@ -48,7 +48,7 @@ select
     cmd."declaratif autre outil",
     cmd."declaratif plusieurs freins",
     cmd."declaratif quels freins",
-    cmd.label,
+    cmd."Votre structure appartient à une structure, un réseau ou un l",
     dpt.nom_departement,
     null::BOOLEAN                                                       as "Commande passée",
     null::INT                                                           as "Nombre de carnets commandés Total",


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Changement nom colonne mon recap. Le nom a changé côté airtable il faut donc le changer sur notre script

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

