### PR TITLE
[monrecap] retrait contacts commandeurs de la table non commandeurs

### DIFF
--- a/dbt/models/monrecap/staging/stg_contacts_non_commandeurs.sql
+++ b/dbt/models/monrecap/staging/stg_contacts_non_commandeurs.sql
@@ -66,3 +66,6 @@ left join {{ ref('stg_commandes_max') }} as cmd
     on cnm.submission_id = cmd."Submission ID"
 left join {{ ref('stg_departement_derniere_commandes') }} as dpt
     on cnm."Commandeur référent" = dpt.email_commande
+-- A contact who did not place an order cannot have the filed email and commandeur referent completed
+-- this condition removes the persons that placed an order and made a mistake while filling the form
+where cnm."EMAIL" != cnm."Commandeur référent"


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Certains contacts sont commandeurs mais se déclarent comme non commandeurs, nous les retirons donc de la table non commandeurs.
Lorsqu'un contact est non commandeur il ne peut pas avoir son mail dans email et contact référent

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

