### PR TITLE
add fluxIAE_Accompagnement to dag

### DIFF
--- a/dags/populate_metabase_fluxiae.py
+++ b/dags/populate_metabase_fluxiae.py
@@ -81,6 +81,7 @@ with airflow.DAG(
 
         populate_fluxiae_referentials()
 
+        populate_fluxiae_view(vue_name="fluxIAE_Accompagnement")
         populate_fluxiae_view(vue_name="fluxIAE_AnnexeFinanciere")
         populate_fluxiae_view(vue_name="fluxIAE_AnnexeFinanciereACI")
         populate_fluxiae_view(vue_name="fluxIAE_Convention")


### PR DESCRIPTION
**Carte Notion : **
https://www.notion.so/gip-inclusion/Cr-er-des-indicateurs-sur-le-suivi-des-freins-de-l-ASP-1975f321b60480eca748d318c2a6492e
### Pourquoi ?

Pour récupérer fluxIAE_accompagnement à partir des emplois 

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

