### PR TITLE
Ajout le nom du prescripteur aux candidatures des candidats en recherche active

### DIFF
--- a/dbt/models/staging/stg_candidats_candidatures.sql
+++ b/dbt/models/staging/stg_candidats_candidatures.sql
@@ -13,7 +13,9 @@ select
     cd.origine,
     cd."origine_détaillée",
     cd.type_prescripteur,
-    cd."nom_prénom_conseiller"
+    cd."nom_prénom_conseiller",
+    cd.nom_org_prescripteur,
+    cd.id_org_prescripteur
 from {{ ref('candidats') }} as c
 left join {{ ref('candidatures_echelle_locale') }} as cd
     on c.id = cd.id_candidat


### PR DESCRIPTION
**Carte Notion : **  
https://www.notion.so/gip-inclusion/File-active-Connaitre-le-nombre-de-candidats-bloqu-s-par-prescripteur-13e5f321b60480ea97b7d0ffb6f7ccbd?pvs=4
https://gip-inclusion.slack.com/archives/C04SAGUGJFJ/p1740586558335389

### Pourquoi ?

Affiner les indicateurs actuellement calculés par typologie de prescripteur.

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

