### PR TITLE
Resolution d'une erreur de doublons dans la table stg_contrats (merci Giulia !)

### DIFF
--- a/dbt/models/staging/stg_contrats.sql
+++ b/dbt/models/staging/stg_contrats.sql
@@ -19,7 +19,7 @@ from {{ ref('fluxIAE_EtatMensuelIndiv_v2') }} as emi
 left join {{ ref('fluxIAE_ContratMission_v2') }} as ctr
     on emi.emi_ctr_id = ctr.contrat_id_ctr
 left join {{ source("fluxIAE", "fluxIAE_RefFormeContrat") }} as rfc
-    on ctr.contrat_format_contrat_code = rfc.rfc_code_forme_contrat
+    on ctr.contrat_format_contrat_code = rfc.rfc_id
 left join {{ ref('fluxIAE_RefMotifSort_v2') }} as motif_sortie
     on emi.emi_motif_sortie_id = motif_sortie.rms_id
 group by

--- a/dbt/tests/properties.yml
+++ b/dbt/tests/properties.yml
@@ -36,5 +36,7 @@ tests:
         Test permettant de vérifier que nos données d'ETP sont raccord avec celle de la DGEFP.
         Les données de la DGEFP étant importées à la main, ce test doit être lancé manuellement.
         L'execution de ce test se fait, après import des données DGEGP, à l'aide d'un "all_tests" du dag data_consistency via l'interface graphique d'airflow.
-
+   - name: test_contrats
+     description: >
+        Test permettant de s'assurer que les contrats calculés dans stg_contrats correspondent à ceux de la table source fluxIAE_contratMission.
 

--- a/dbt/tests/test_contrats.sql
+++ b/dbt/tests/test_contrats.sql
@@ -1,0 +1,17 @@
+with nb_contrat as (
+    select
+        (
+            select count(distinct contrat_id_ctr)
+            from stg_contrats
+            where extract(year from contrat_date_embauche) >= 2021 and num_reconduction = 0
+        ) as contrats_stg,
+        (
+            select count(distinct contrat_id_ctr)
+            from {{ ref('fluxIAE_ContratMission_v2') }}
+            where extract(year from contrat_date_embauche) >= 2021 and contrat_type_contrat = 0
+        ) as contrats
+)
+
+select *
+from nb_contrat
+where contrats_stg != contrats


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

La jointure sur la table `fluxIAE_RefFormeContrat`n'était pas réalisée avec le bon id ce qui causait des duplicats.
Aucun impact sur les indicateurs, ceux-ci étant réalisés avec un distinct sur les contrats, mais potentiellement pour les travaux autour des parcours. Ajout d'un test pour s'assurer de la consistance.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

