### PR TITLE
Ajout d'informations sur les candidatures des candidats de la file active pour permettre le filtrage sur les TB privés

### DIFF
--- a/dbt/models/staging/stg_candidats_candidatures.sql
+++ b/dbt/models/staging/stg_candidats_candidatures.sql
@@ -10,12 +10,19 @@ select
     cd.type_structure,
     cd.categorie_structure,
     cd.id_structure,
+    cd.nom_structure,
     cd.origine,
     cd."origine_détaillée",
     cd.type_prescripteur,
     cd."nom_prénom_conseiller",
     cd.nom_org_prescripteur,
-    cd.id_org_prescripteur
+    cd.id_org_prescripteur,
+    cd.dept_org,
+    cd."région_org",
+    cd.bassin_emploi_prescripteur,
+    cd."nom_département_structure",
+    cd.reprise_de_stock_ai,
+    cd.epci
 from {{ ref('candidats') }} as c
 left join {{ ref('candidatures_echelle_locale') }} as cd
     on c.id = cd.id_candidat


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/gip-inclusion/Candidats-bloqu-s-Int-grer-2-nouveaux-indicateurs-dans-le-TB-des-prescripteurs-1ac5f321b60480a5b0e1d6051c216773?pvs=4

### Pourquoi ?

Pour permettre le même filtrage que tous les autres indicateurs, il manquait certaines variables.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

