### PR TITLE
DAG : Amélioration des performances mémoires pour `populate_metabase_fluxiae`

### DIFF
--- a/dags/common/python.py
+++ b/dags/common/python.py
@@ -1,0 +1,21 @@
+import itertools
+import sys
+
+
+if sys.version_info >= (3, 12):
+    from itertools import batched
+else:
+
+    def batched(iterable, n, *, strict=False):
+        """Batch data from the iterable into tuples of length n. The last batch may be shorter than n.
+
+        Source: Python stdlib, added in version 3.12.
+        """
+        # batched('ABCDEFG', 3) → ABC DEF G
+        if n < 1:
+            raise ValueError("n must be at least one")
+        iterator = iter(iterable)
+        while batch := tuple(itertools.islice(iterator, n)):
+            if strict and len(batch) != n:
+                raise ValueError("batched(): incomplete batch")
+            yield batch


### PR DESCRIPTION
### Pourquoi ?

Sur ma machine pandas se retrouve a utiliser 7-8 Go de RAM pour le traitement du fichier `EtatMensuelIndiv` sauf qu'à un moment je pense qu'il duplique la _dataframe_ car ça fait un pic à 11+ Go de RAM, l'instance de prod à 16 GB de mémoire mais 20% sont utilisées de base par Airflow donc je suspecte le kernel d'activer le _OOM killer_.

Avec la nouvelle version du code, la mémoire utilisée reste constante et est linéaire en fonction de `chunk_size` (~100 Mo par 10_000 lignes) et pas de la taille du fichier.
J'ai testé plusieurs multiples de 10K pour `chunk_size`, 20_000 semble être un bon compromis car on n'explose pas la RAM et ça reste en plus la plus rapide des versions, tout du moins en local.

Schéma actuellement présent sur la DB de prod :
```sql
                    Table "public.fluxIAE_EtatMensuelIndiv"
           Column           |       Type       | Collation | Nullable | Default 
----------------------------+------------------+-----------+----------+---------
 emi_date_creation          | text             |           |          | 
 emi_date_modification      | text             |           |          | 
 emi_afi_id                 | bigint           |           |          | 
 emi_sme_mois               | bigint           |           |          | 
 emi_sme_annee              | bigint           |           |          | 
 emi_esm_etat_id            | bigint           |           |          | 
 emi_esm_etat_code          | text             |           |          | 
 emi_sme_version            | bigint           |           |          | 
 emi_date_validation        | text             |           |          | 
 emi_pph_id                 | bigint           |           |          | 
 emi_ctr_id                 | bigint           |           |          | 
 emi_nb_heures_travail      | bigint           |           |          | 
 emi_nb_mission             | double precision |           |          | 
 emi_nb_heures_facturees    | bigint           |           |          | 
 emi_mt_salaire_brut        | double precision |           |          | 
 emi_salarie_tjs_accomp     | boolean          |           |          | 
 emi_part_etp               | double precision |           |          | 
 emi_date_fin_reelle        | text             |           |          | 
 emi_motif_sortie_id        | double precision |           |          | 
 emi_motif_sortie_code      | double precision |           |          | 
 emi_dsm_id                 | bigint           |           |          | 
 emi_coefficient_degressive | double precision |           |          | 
 emi_dsm_ca_reel            | bigint           |           |          | 
 emi_dsm_ca_lisse           | bigint           |           |          | 
 emi_dsm_rdv_phy            | double precision |           |          | 
 emi_dsm_rdv_dis            | double precision |           |          | 
 emi_dsm_rdv_com            | double precision |           |          | 
 emi_dsm_rdv_soc            | double precision |           |          | 
 emi_dsm_acre               | boolean          |           |          | 
 emi_dsm_nb_rdv_mens_ti     | double precision |           |          | 
 emi_dsm_nb_mois            | double precision |           |          | 

```
Schéma avec la nouvelle version :
```sql
                    Table "public.fluxIAE_EtatMensuelIndiv"
           Column           |       Type       | Collation | Nullable | Default 
----------------------------+------------------+-----------+----------+---------
 emi_date_creation          | text             |           |          | 
 emi_date_modification      | text             |           |          | 
 emi_afi_id                 | bigint           |           |          | 
 emi_sme_mois               | bigint           |           |          | 
 emi_sme_annee              | bigint           |           |          | 
 emi_esm_etat_id            | bigint           |           |          | 
 emi_esm_etat_code          | text             |           |          | 
 emi_sme_version            | bigint           |           |          | 
 emi_date_validation        | text             |           |          | 
 emi_pph_id                 | bigint           |           |          | 
 emi_ctr_id                 | bigint           |           |          | 
 emi_nb_heures_travail      | bigint           |           |          | 
 emi_nb_mission             | double precision |           |          | 
 emi_nb_heures_facturees    | bigint           |           |          | 
 emi_mt_salaire_brut        | double precision |           |          | 
 emi_salarie_tjs_accomp     | boolean          |           |          | 
 emi_part_etp               | double precision |           |          | 
 emi_date_fin_reelle        | text             |           |          | 
 emi_motif_sortie_id        | double precision |           |          | 
 emi_motif_sortie_code      | double precision |           |          | 
 emi_dsm_id                 | bigint           |           |          | 
 emi_coefficient_degressive | double precision |           |          | 
 emi_dsm_ca_reel            | bigint           |           |          | 
 emi_dsm_ca_lisse           | bigint           |           |          | 
 emi_dsm_rdv_phy            | double precision |           |          | 
 emi_dsm_rdv_dis            | double precision |           |          | 
 emi_dsm_rdv_com            | double precision |           |          | 
 emi_dsm_rdv_soc            | double precision |           |          | 
 emi_dsm_acre               | boolean          |           |          | 
 emi_dsm_nb_rdv_mens_ti     | double precision |           |          | 
 emi_dsm_nb_mois            | double precision |           |          | 
```

---

Idéalement ce qui est dans `FLUX_IAE_MODELS` devrait être un modèle _SQLAlchemy_ mais le but est déjà de faire en sorte que le DAG fonctionne chaque semaine ;).

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
