### PR TITLE
Retrait des doublons de la table structures de l'ASP

### DIFF
--- a/dbt/models/indexed/fluxIAE_Structure_v2.sql
+++ b/dbt/models/indexed/fluxIAE_Structure_v2.sql
@@ -5,7 +5,7 @@
     ]
  ) }}
 
-select
+select distinct -- parfois l'ASP introduit des doublons, ici les élimine
     -- l'ASP préconise l'utilisation de l'adresse administrative pour récupérer la commune de la structure
     {{ pilo_star(source('fluxIAE', 'fluxIAE_Structure')) }},
     app_geo.nom_epci                                                  as nom_epci_structure,

--- a/dbt/tests/properties.yml
+++ b/dbt/tests/properties.yml
@@ -46,4 +46,6 @@ tests:
   - name: test_stg_accompagnement_pro
     description: >
         Test permettant de vérifier qu'il n'y a pas de doublons pour acc_id, type_acc_pro
-
+  - name: test_doublons_structures_fluxIAE
+    description: >
+        Test permettant de vérifier qu'il n'y a pas de doublons dans les structures du fluxIAE

--- a/dbt/tests/test_doublons_structures_fluxIAE.sql
+++ b/dbt/tests/test_doublons_structures_fluxIAE.sql
@@ -1,0 +1,15 @@
+with nb_structures as (
+    select
+        (
+            select count(*)
+            from {{ source('fluxIAE',"fluxIAE_Structure") }}
+        ) as structure_all,
+        (
+            select count(distinct structure_id_siae)
+            from {{ source('fluxIAE',"fluxIAE_Structure") }}
+        ) as structure_distinct
+)
+
+select *
+from nb_structures
+where structure_all != structure_distinct


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

L'ASP a tendance a faire des erreurs et dupliquer des lignes en particulier dans la table structures (2eme fois que ça arrive en 2 mois), ici on retire les doublons de la table structures de l'ASP

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

