### PR TITLE
Ajout libellés aux tables accompagnement

### DIFF
--- a/dbt/models/marts/weekly/accompagnement_freins.sql
+++ b/dbt/models/marts/weekly/accompagnement_freins.sql
@@ -1,5 +1,6 @@
 select
     {{ pilo_star(ref('stg_accompagnement_freins'), relation_alias="t_acc") }},
+    acc_freins_libelle.type_frein_libelle,
     {{ pilo_star(ref('stg_info_per_annexe_financiere')) }},
     t_struct.structure_id_siae                      as structure_id,
     t_struct.structure_denomination,
@@ -11,3 +12,4 @@ select
 from {{ ref('stg_accompagnement_freins') }} as t_acc
 left join {{ ref('stg_info_per_annexe_financiere') }} as t_afi on t_acc.acc_afi_id = t_afi.af_id_annexe_financiere
 left join {{ ref('fluxIAE_Structure_v2') }} as t_struct on t_afi.af_id_structure = t_struct.structure_id_siae
+left join {{ ref('acc_freins_libelle') }} on t_acc.type_frein = acc_freins_libelle.type_frein

--- a/dbt/models/marts/weekly/accompagnement_pro.sql
+++ b/dbt/models/marts/weekly/accompagnement_pro.sql
@@ -1,7 +1,8 @@
 -- en date 20/03 28 fois on arrive pas à joindre l'annexe financiere et par consequence la structure
 --
 select
-    {{ pilo_star(ref('stg_accompagnement_pro')) }},
+    {{ pilo_star(ref('stg_accompagnement_pro'), relation_alias="t_acc_pro" ) }},
+    acc_pro_libelle.libelle,
     {{ pilo_star(ref('stg_info_per_annexe_financiere')) }},
     t_struct.structure_id_siae                      as structure_id,
     t_struct.structure_denomination,
@@ -13,3 +14,4 @@ select
 from {{ ref('stg_accompagnement_pro') }} as t_acc_pro
 left join {{ ref('stg_info_per_annexe_financiere') }} as t_afi on t_acc_pro.acc_afi_id = t_afi.af_id_annexe_financiere
 left join {{ ref('fluxIAE_Structure_v2') }} as t_struct on t_afi.af_id_structure = t_struct.structure_id_siae
+left join {{ ref('acc_pro_libelle') }} on t_acc_pro.type_acc_pro = acc_pro_libelle.type_acc_pro

--- a/dbt/seeds/acc_freins_libelle.csv
+++ b/dbt/seeds/acc_freins_libelle.csv
@@ -1,0 +1,9 @@
+type_frein,type_frein_libelle
+illetrisme,"Illetrisme / analphabétisme / Français langues étrangères"
+demarch,"Démarches administratives et accès aux droits"
+heberg,"Hébergement / Logement"
+mobilite,"Manque de mobilité"
+sante,"Santé (addiction, souffrance et handicap psy, autres)"
+justice,"Justice"
+surendet,"Surendettement et finances"
+manque_dispo,"Manque de disponibilité"

--- a/dbt/seeds/acc_pro_libelle.csv
+++ b/dbt/seeds/acc_pro_libelle.csv
@@ -1,0 +1,3 @@
+type_acc_pro,libelle
+presta_tech,"Techniques en recherche emploi"
+benef_projet_pro,"Aide définition du projet professionnel"

--- a/dbt/seeds/properties.yml
+++ b/dbt/seeds/properties.yml
@@ -78,3 +78,9 @@ seeds:
   - name: type_parcours_xp_ft
     description: >
       Correspondance entre les sigles du type de parcours, provenant du fichier brut expérimentation FT, et le type de parcours en toutes lettres
+  - name: acc_freins_libelle
+    description: >
+      Correspondance entre les sigles des freins à l'emploi, issues des titres des colonnes fluxIAE_accompagnement, et le libellé en toutes lettres présents dans la documentation sur les tables
+  - name: acc_pro_libelle
+    description: >
+      Correspondance entre les sigles des accompagnments professionels, issues des titres des colonnes fluxIAE_accompagnement, et le libellé en toutes lettres présents dans la documentation sur les tables


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Dans les tables accompagnement_pro et accompagnement_freins le noms des colonnes ont été utilisés pour décrire le type de frein ou le type d'accompagnement, on veut ici y ajouter le libellé présent dans la doc de ces tables.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

