### PR TITLE
github : Rendre obligatoire la présence d'au moins un label sur les PR

### DIFF
--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -1,0 +1,25 @@
+name: Label Checks
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  merge_group:
+
+jobs:
+  require-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify changelog label
+        uses: mheap/github-action-required-labels@5.5.0
+        with:
+          mode: exactly
+          count: 1
+          labels: "changelog:.*|dependencies"
+          use_regex: true
+      - name: Verify datasource label
+        uses: mheap/github-action-required-labels@5.5.0
+        with:
+          mode: exactly
+          count: 1
+          labels: "datasource:.*"
+          use_regex: true


### PR DESCRIPTION
### Pourquoi ?

Pour que les choses soient rangé au bon endroit afin de créer automatiquement le _changelog_.