### PR TITLE
Ajout du nombre de candidatures provenant d'une autoprescription 

### DIFF
--- a/dbt/models/ephemeral/eph_nbr_candidatures.sql
+++ b/dbt/models/ephemeral/eph_nbr_candidatures.sql
@@ -11,9 +11,10 @@ select
     c."nom_département_structure",
     c."région_structure",
     c.nom_org_prescripteur,
-    count(c."état") as nombre_de_candidatures
+    count(c."état")                                                                   as nombre_de_candidatures,
+    count(case when type_de_candidature = 'Autoprescription' then id_candidature end) as nombre_autoprescription
 from
-    {{ ref('candidatures_echelle_locale') }} as c
+    {{ ref('stg_candidatures_autoprescription') }} as c
 where
     c.type_structure in (
         'AI', 'ACI', 'EI', 'EITI', 'ETTI'

--- a/dbt/models/marts/daily/nombre_candidatures_par_structure.sql
+++ b/dbt/models/marts/daily/nombre_candidatures_par_structure.sql
@@ -4,10 +4,11 @@ selon l'état de la candidature, la structure, le type de structure, l'orgine de
 select
     c."état",
     c.date_candidature,
-    c.nombre_de_candidatures,
-    prop_cddr.total_candidatures,
-    ttes_ccdr.somme_candidatures,
-    ttes_ccdr_ph.somme_candidatures_ph,
+    c.nombre_de_candidatures, -- nombre de candidatures pour cette structure, état, date, origine et prescripteur donné
+    prop_cddr.total_candidatures, -- nombre total de candidatures pour cette structure et cet état
+    ttes_ccdr.somme_candidatures, -- nombre total de candidatures pour cette structure
+    ttes_ccdr_ph.somme_candidatures_ph, -- nombre de candidatures pour cette structure et ce prescripteur
+    c.nombre_autoprescription, -- nombre de candidatures en autoprescription pour cet état et cette structure
     c.nom_structure,
     c.type_structure,
     c.origine,
@@ -22,7 +23,7 @@ select
     s.siret,
     s.nom_epci_structure,
     /* calcul de la proportion de candidatures en % */
-    c.nombre_de_candidatures / prop_cddr.total_candidatures as taux_de_candidatures
+    c.nombre_de_candidatures / prop_cddr.total_candidatures as taux_de_candidatures -- taux de candidatures à l'état pour la structure
 from
     {{ ref('eph_nbr_candidatures') }} as c
 left join {{ ref('eph_prop_cddr') }} as prop_cddr

--- a/dbt/models/staging/properties.yml
+++ b/dbt/models/staging/properties.yml
@@ -12,7 +12,7 @@ models:
       Elle a été introduite pour agréger les données de candidatures en fonction de leur appartenance géographique.
   - name: stg_candidatures_autoprescription
     description: >
-      Ce modèle permet de sélectionner les candidatures provenant d'une auto prescription.
+      Ce modèle permet d'identifier les candidatures provenant d'une auto prescription.
       Nous parlons d'auto prescription lorsque l'auteur du diagnostic et l'origine de la candidature proviennent du même employeur.
   - name: stg_structures
     description: >

--- a/dbt/models/staging/stg_candidatures_autoprescription.sql
+++ b/dbt/models/staging/stg_candidatures_autoprescription.sql
@@ -17,6 +17,8 @@ select
     c.type_auteur_diagnostic,
     c.sous_type_auteur_diagnostic,
     c.nom_auteur_diagnostic,
+    cd.nom_org_prescripteur,
+    cd.injection_ai,
     cd."état",
     cd.id_structure,
     cd.origine,


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/gip-inclusion/Cr-er-indicateur-s-dans-TB346-permettant-de-reconstituer-ensemble-des-candidatures-trait-es-par-les-1c15f321b60480999702e36524c619f0?pvs=4

### Pourquoi ?

Pour ajouter cette donnée à la nouvelle table du tb 346.
J'ai ajouté des commentaires dans le code car j'ai GALERE à comprendre (je trouve le nom des variables très peu explicites), et je crains de redevoir passer du temps à comprendre un jour si je ne mettais pas ces commentaires.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

