### PR TITLE
Docker : Montage du dossier `dbt` dans le container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,10 @@ services:
     volumes:
       - ./custom-dev-entrypoint.sh:/entrypoint.sh
       - ./dags:/opt/airflow/dags
+      - ./dbt:/opt/airflow/dbt
+      - dbt_data:/opt/airflow/dbt/packages
 
 volumes:
   postgres_data:
   minio_data:
+  dbt_data:


### PR DESCRIPTION
### Pourquoi ?

Afin de pouvoir utiliser la version locale des fichiers modèles DBT quand on lance les DAG

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
