### PR TITLE
Modification de la definition de groupe_contrat dans le modèle stg_contrats

### DIFF
--- a/dbt/models/ephemeral/eph_stg_contrats.sql
+++ b/dbt/models/ephemeral/eph_stg_contrats.sql
@@ -4,7 +4,7 @@ select
     structs.nom_departement_structure,
     structs.code_dept_structure,
     first_value(ctr.contrat_id_ctr) over (
-        partition by ctr.contrat_id_pph, groupe_contrat
+        partition by ctr.contrat_id_pph, groupe_contrat, contrat_mesure_disp_code
         order by ctr.contrat_date_embauche
     ) as contrat_parent_id
 from {{ ref('stg_contrats') }} as ctr

--- a/dbt/models/staging/properties.yml
+++ b/dbt/models/staging/properties.yml
@@ -153,6 +153,9 @@ models:
         tests:
           - unique
           - not_null
+      - name: groupe_contrat
+        description: >
+          Identifiant unique (lorsqu'on groupe par contrat_id_pph, et contrat_mesure_disp_code) du groupe de contrat. Il est utilisé pour regrouper les reconductions d'un même contrat.
   - name: stg_contrats_parent
     description: >
       Permet de récupérer les contrats parents (contrats initiaux) à partir des contrats.

--- a/dbt/models/staging/stg_contrats.sql
+++ b/dbt/models/staging/stg_contrats.sql
@@ -16,7 +16,7 @@ select distinct
         when ctr.contrat_type_contrat = 0 then 1
         else 0
     end) over (
-        partition by ctr.contrat_id_pph
+        partition by ctr.contrat_id_pph, ctr.contrat_mesure_disp_code
         order by ctr.contrat_date_embauche
     )                                                         as groupe_contrat
 from {{ ref('fluxIAE_EtatMensuelIndiv_v2') }} as emi

--- a/dbt/tests/properties.yml
+++ b/dbt/tests/properties.yml
@@ -49,3 +49,6 @@ tests:
   - name: test_doublons_structures_fluxIAE
     description: >
         Test permettant de vérifier qu'il n'y a pas de doublons dans les structures du fluxIAE
+  - name: test_stg_contrats_parent
+    description: >
+        Test permettant de vérifier qu'il n'y a pas plus de 10 contrat_parent_id pas unique dans stg_contrats_parent

--- a/dbt/tests/test_stg_contrats_parent.sql
+++ b/dbt/tests/test_stg_contrats_parent.sql
@@ -1,0 +1,11 @@
+with multiple_contrat_parent_id as (
+    select
+        contrat_parent_id,
+        count(*) as count
+    from {{ ref('stg_contrats_parent') }}
+    having count(*) > 1
+)
+
+select count(*)
+from multiple_contrat_parent_id
+where count(*) > 10


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/gip-inclusion/Modifier-stg_contrats-pour-prendre-en-compte-que-on-peut-avoir-plusieurs-contrats-au-m-me-temps-1d05f321b604800086bffd8b4a8b31bb?pvs=4

### Pourquoi ?
Modifier stg_contrat pour prendre en compte que l’on peut avoir plusieurs contrats au même temps ayant un type de dispositif différent, aujourd'hui ces contrats sont mis dans le même “groupe” et ça génère des doublons dans la table stg_parent_contrat.

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

