### PR TITLE
Ajout du numéro d'AF comme suffixe au nom de la structure

### DIFF
--- a/dbt/models/staging/stg_consommation_etp.sql
+++ b/dbt/models/staging/stg_consommation_etp.sql
@@ -13,6 +13,7 @@ select
     etp.type_structure,
     etp.structure_denomination,
     etp.structure_denomination_unique,
+    etp.structure_denomination_af,
     etp.code_departement_af,
     etp.nom_departement_af,
     etp.nom_region_af,
@@ -115,6 +116,7 @@ group by
     etp.structure_id_siae,
     etp.structure_denomination,
     etp.structure_denomination_unique,
+    etp.structure_denomination_af,
     etp.code_departement_af,
     etp.nom_departement_af,
     etp.nom_region_af

--- a/dbt/models/staging/stg_etp_conventionnes.sql
+++ b/dbt/models/staging/stg_etp_conventionnes.sql
@@ -1,5 +1,5 @@
 select distinct
-    af.af_id_annexe_financiere                   as id_annexe_financiere,
+    af.af_id_annexe_financiere                                                       as id_annexe_financiere,
     af.af_numero_convention,
     af.af_numero_annexe_financiere,
     af.af_date_debut_effet_v2,
@@ -14,7 +14,7 @@ select distinct
     Thus, the artificial addition of an extra month to round the operation is needed */
     af.af_mesure_dispositif_code,
     af.af_numero_avenant_modification,
-    af.af_etp_postes_insertion                   as "effectif_mensuel_conventionné",
+    af.af_etp_postes_insertion                                                       as "effectif_mensuel_conventionné",
     af.af_montant_total_annuel,
     af.af_montant_unitaire_annuel_valeur,
     af.af_mt_cofinance,
@@ -25,29 +25,31 @@ select distinct
     mp.mpu_sct_mt_recet_recycl,
     mp.mpu_sct_mt_recet_transp,
     mp.mpu_sct_mt_recet_autres,
-    evo_rsa.montant                              as montant_rsa,
+    evo_rsa.montant                                                                  as montant_rsa,
     ref_asp.type_structure,
     ref_asp.type_structure_emplois,
     structure.structure_id_siae,
     structure.structure_denomination,
     structure.structure_denomination_unique,
-    structure.structure_adresse_admin_commune    as commune_structure,
-    structure.structure_adresse_admin_code_insee as code_insee_structure,
-    structure.structure_siret_actualise          as siret_structure,
+    structure.structure_adresse_admin_commune                                        as commune_structure,
+    structure.structure_adresse_admin_code_insee                                     as code_insee_structure,
+    structure.structure_siret_actualise                                              as siret_structure,
     structure.nom_departement_structure,
     structure.nom_region_structure,
-    af.num_dep_af                                as code_departement_af,
+    af.num_dep_af                                                                    as code_departement_af,
     af.nom_departement_af,
     af.nom_region_af,
-    date_part('year', af.af_date_debut_effet_v2) as annee_af,
+    concat_ws('-', structure.structure_denomination, af.af_numero_annexe_financiere)
+    as structure_denomination_af,
+    date_part('year', af.af_date_debut_effet_v2)                                     as annee_af,
     (
         date_part('year', af.af_date_fin_effet_v2) - date_part('year', af.af_date_debut_effet_v2)
-    )                                            as year_diff,
+    )                                                                                as year_diff,
     (
         date_part('year', af.af_date_fin_effet_v2) - date_part('year', af.af_date_debut_effet_v2)
     ) * 12 + (
         date_part('month', af.af_date_fin_effet_v2) - date_part('month', af.af_date_debut_effet_v2)
-    ) + 1                                        as duree_annexe,
+    ) + 1                                                                            as duree_annexe,
     (
         af.af_etp_postes_insertion * (
             (
@@ -56,7 +58,7 @@ select distinct
                 date_part('month', af.af_date_fin_effet_v2) - date_part('month', af.af_date_debut_effet_v2)
             ) + 1
         ) / 12
-    )                                            as "effectif_annuel_conventionné"
+    )                                                                                as "effectif_annuel_conventionné"
 from
     {{ ref('stg_dates_annexe_financiere') }} as constantes
 cross join


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Afin de régler des problèmes de visualisation sur le TB ETP, liés au fait qu'une structure avec le meme nom + SIRET peut avoir plusieurs AF qui lui sont associées nous avons décidé d'ajouter le numéro d'AF comme suffixe au nom de la structure.

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

