### PR TITLE
github : Ne plus forcer la présence de label pour les PR `dependencies`

### DIFF
--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   require-label:
+    if: >  # The ">" is a hack to prevent the "tag suffix cannot contain flow indicator characters" error...
+        !contains(github.event.pull_request.labels.*.name, 'dependencies')
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -15,7 +17,7 @@ jobs:
         with:
           mode: exactly
           count: 1
-          labels: "changelog:.*|dependencies"
+          labels: "changelog:.*"
           use_regex: true
       - name: Verify datasource label
         uses: mheap/github-action-required-labels@388fd6af37b34cdfe5a23b37060e763217e58b03 # v5.5.0


### PR DESCRIPTION
### Pourquoi ?

Afin de pouvoir fusionner les PR ouvertes automatiquement par dependabot sans avoir à ajouter un label `datasource:*`.
