### PR TITLE
Ajout d'informations sur les pass agrément

### DIFF
--- a/dbt/models/_sources.yml
+++ b/dbt/models/_sources.yml
@@ -41,6 +41,7 @@ sources:
       - name: c1_private_dashboard_visits_v0
         description: >
           Propose une ligne par visite enregistrée sur un tableau de bord privé du Pilotage de l'Inclusion.
+      - name: c1_ref_motif_suspension
       - name: candidats_v0
       - name: candidatures
       - name: cap_campagnes
@@ -58,6 +59,7 @@ sources:
       - name: organisations_v0
       - name: pass_agréments
       - name: structures
+      - name: suspensions_v0
       - name: utilisateurs_v0
       - name: demandes_de_prolongation
       - name: prolongations

--- a/dbt/models/marts/daily/pass_agrements_valides.sql
+++ b/dbt/models/marts/daily/pass_agrements_valides.sql
@@ -1,9 +1,16 @@
 select
     {{ pilo_star(source('emplois', 'pass_agréments'), relation_alias="pa") }},
+    struct.bassin_d_emploi as bassin_emploi_structure,
     case
         when
             pa.date_fin >= current_date then 'pass valide'
         else 'pass non valide'
-    end as validite_pass
+    end                    as validite_pass,
+    suspensions.suspension_en_cours,
+    suspensions.motif_suspension
 from
     {{ source('emplois', 'pass_agréments') }} as pa
+left join {{ ref('stg_structures') }} as struct
+    on struct.id = pa.id_structure
+left join {{ ref('suspensions_pass') }} as suspensions
+    on suspensions."id_pass_agrément" = pa.id

--- a/dbt/models/marts/daily/properties.yml
+++ b/dbt/models/marts/daily/properties.yml
@@ -51,10 +51,14 @@ models:
       Table introduite pour obtenir la liste des réseaux et les structures attachées à ces derniers.
   - name: pass_agrements_valides
     description: >
-      A la demande du C1, cette table a été créée pour suivre le nombre de pass IAE valides. Ici un pass est considéré valide quand sa date de fin n'a pas expiré.
-      Afin d'informer si le pass est valide ou pas une colonne validite_pass remplie, avec les strings 'pass valide/pass non valide', a été créée.
-      L'information contenue dans cette colonne n'est pas sous forme 1/0 afin d'anticiper une potentielle demande métier où cette colonne servirait de filtre.
-      Cette colonne aurait pu être rajoutée dans {{source, pass_agréments}} mais un marts a été préféré à un ajout de colonne pour des raisons d'autonomie du côté des data analyst.
+      Table permettant de savoir si un pass agrément ou IAE est valide et/ou suspendu.
+  - name: suspensions_pass
+    description: >
+      Table permettant de connaître les pass agrément ou IAE suspendus.
+      Ajoute à la source suspensions_v0 l'état de suspension et le motif de suspension en toutes lettres.
+    tests:
+      - dbt_utils.equal_rowcount:
+          compare_model: source('emplois', 'suspensions_v0')
   - name: candidats_derniere_embauche
     description: >
       Table créée pour récupérer la dernière embauche (si elle existe) d'un candidat.

--- a/dbt/models/marts/daily/suspensions_pass.sql
+++ b/dbt/models/marts/daily/suspensions_pass.sql
@@ -1,0 +1,11 @@
+select
+    suspension."id_pass_agrément",
+    suspension."date_début",
+    suspension.date_fin,
+    rms.label as motif_suspension,
+    case
+        when suspension.en_cours = 1 then 'Oui' else 'Non'
+    end       as suspension_en_cours
+from {{ source("emplois", "suspensions_v0") }} as suspension
+left join {{ source("emplois", "c1_ref_motif_suspension") }} as rms
+    on suspension.motif = rms.code


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/gip-inclusion/Cr-er-des-indicateurs-sur-les-pass-actifs-et-suspendus-1fb5f321b60480a3a649ed6be60b1e4d?pvs=4

### Pourquoi ?

- Permettre de filtrer par bassin d'emploi de la structure
- Permettre d'identifier les pass suspendus à l'instant T


### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

