### PR TITLE
Correction des erreurs de consistance

### DIFF
--- a/dbt/models/marts/daily/nb_utilisateurs_potentiels.sql
+++ b/dbt/models/marts/daily/nb_utilisateurs_potentiels.sql
@@ -33,5 +33,5 @@ select
     s.type                                  as profil,
     count(*)                                as potentiel
 from {{ source('emplois', 'structures') }} as s
-where s."nom_département" is not null and s.active = 1 and type in ('ACI', 'AI', 'EI', 'EITI    ', 'ETTI')
+where s."nom_département" is not null and s.active = 1 and type in ('ACI', 'AI', 'EI', 'EITI', 'ETTI')
 group by s."région", s."nom_département", s.type

--- a/dbt/tests/test_potentiel_structures.sql
+++ b/dbt/tests/test_potentiel_structures.sql
@@ -3,7 +3,7 @@ with nb_structures_meres as (
         (
             select count(*)
             from structures
-            where source != 'Utilisateur (Antenne)' and "nom_département" is not null
+            where "nom_département" is not null and active = 1 and type in ('ACI', 'AI', 'EI', 'EITI', 'ETTI')
         ) as structures_meres,
         (
             select sum(potentiel)


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/gip-inclusion/Corriger-bug-consistency-1d55f321b604808a812ec24a73a5d32e?pvs=4

### Pourquoi ?

Le test n'avait pas été modifié lors de la modification de la définition du potentiel.
Des espaces involontaires avaient été insérés dans le filtre par type de structure.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

