### PR TITLE
[monrecap] Fix doublons region dans la table barometre

### DIFF
--- a/dbt/models/monrecap/staging/stg_departement_derniere_commandes.sql
+++ b/dbt/models/monrecap/staging/stg_departement_derniere_commandes.sql
@@ -1,12 +1,17 @@
+with departement_table as (
+    select
+        cmd."Email"                  as email_commande,
+        max(cmd."Nom Departement")   as nom_departement,
+        max(cmd."Submitted at")      as "Submitted at",
+        max(cmd."Nombre de Carnets") as "Nombre de Carnets"
+    from {{ source('monrecap','Commandes_v0') }} as cmd
+    group by
+        cmd."Email"
+)
+
 select
-    cmd."Email"                  as email_commande,
-    reg.region,
-    max(cmd."Nom Departement")   as nom_departement,
-    max(cmd."Submitted at")      as "Submitted at",
-    max(cmd."Nombre de Carnets") as "Nombre de Carnets"
-from {{ source('monrecap','Commandes_v0') }} as cmd
-left join {{ ref('dep_reg_ref_emplois') }} as reg
-    on cmd."Nom Departement" = reg.departement
-group by
-    cmd."Email",
+    dpt.*,
     reg.region
+from departement_table as dpt
+left join {{ ref('dep_reg_ref_emplois') }} as reg
+    on dpt.nom_departement = reg.departement


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Fix doublons region dans la table barometre

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

