### PR TITLE
DAG : Suppression des tâches `dbt clean`

### DIFF
--- a/dags/dbt_daily.py
+++ b/dags/dbt_daily.py
@@ -60,15 +60,8 @@ with airflow.DAG(
         append_env=True,
     )
 
-    dbt_clean = bash.BashOperator(
-        task_id="dbt_clean",
-        bash_command="dbt clean",
-        env=env_vars,
-        append_env=True,
-    )
-
     dag_data_consistency = trigger_dagrun.TriggerDagRunOperator(
         trigger_dag_id="data_consistency", task_id="trigger_data_consistency"
     )
 
-    (start >> dbt_debug >> dbt_deps >> dbt_seed >> dbt_run >> dbt_clean >> dag_data_consistency >> end)
+    (start >> dbt_debug >> dbt_deps >> dbt_seed >> dbt_run >> dag_data_consistency >> end)

--- a/dags/dbt_france_travail.py
+++ b/dags/dbt_france_travail.py
@@ -60,11 +60,4 @@ with airflow.DAG(
         append_env=True,
     )
 
-    dbt_clean = bash.BashOperator(
-        task_id="dbt_clean",
-        bash_command="dbt clean",
-        env=env_vars,
-        append_env=True,
-    )
-
-    (start >> dbt_debug >> dbt_deps >> dbt_seed >> dbt_run >> dbt_clean >> end)
+    (start >> dbt_debug >> dbt_deps >> dbt_seed >> dbt_run >> end)

--- a/dags/dbt_oneshot.py
+++ b/dags/dbt_oneshot.py
@@ -45,15 +45,8 @@ with airflow.DAG(
         append_env=True,
     )
 
-    dbt_clean = bash.BashOperator(
-        task_id="dbt_clean",
-        bash_command="dbt clean",
-        env=env_vars,
-        append_env=True,
-    )
-
     dag_data_consistency = trigger_dagrun.TriggerDagRunOperator(
         trigger_dag_id="data_consistency", task_id="trigger_data_consistency"
     )
 
-    (start >> dbt_debug >> dbt_deps >> dbt_seed >> dbt_run >> dbt_clean >> dag_data_consistency >> end)
+    (start >> dbt_debug >> dbt_deps >> dbt_seed >> dbt_run >> dag_data_consistency >> end)

--- a/dags/dbt_snapshot.py
+++ b/dags/dbt_snapshot.py
@@ -42,15 +42,8 @@ with airflow.DAG(
         append_env=True,
     )
 
-    dbt_clean = bash.BashOperator(
-        task_id="dbt_clean",
-        bash_command="dbt clean",
-        env=env_vars,
-        append_env=True,
-    )
-
     dag_data_consistency = trigger_dagrun.TriggerDagRunOperator(
         trigger_dag_id="data_consistency", task_id="trigger_data_consistency"
     )
 
-    (start >> dbt_debug >> dbt_deps >> dbt_snapshot >> dbt_clean >> dag_data_consistency >> end)
+    (start >> dbt_debug >> dbt_deps >> dbt_snapshot >> dag_data_consistency >> end)

--- a/dags/dbt_weekly.py
+++ b/dags/dbt_weekly.py
@@ -58,15 +58,8 @@ with airflow.DAG(
         append_env=True,
     )
 
-    dbt_clean = bash.BashOperator(
-        task_id="dbt_clean",
-        bash_command="dbt clean",
-        env=env_vars,
-        append_env=True,
-    )
-
     dag_data_consistency = trigger_dagrun.TriggerDagRunOperator(
         trigger_dag_id="data_consistency", task_id="trigger_data_consistency"
     )
 
-    (start >> dbt_debug >> dbt_deps >> dbt_seed >> dbt_run >> dbt_clean >> dag_data_consistency >> end)
+    (start >> dbt_debug >> dbt_deps >> dbt_seed >> dbt_run >> dag_data_consistency >> end)


### PR DESCRIPTION
### Pourquoi ?

Quand plusieurs DAG _dbt_ sont lancés en même temps, le `dbt clean` de l'un fait échouer la commande `dbt` de l'autre car les dépendances ne sont plus là, idéalement il faudrait avoir des environnements séparés entre chaque DAG mais c'est beaucoup plus complexe donc pour le moment on va tester en ne faisant plus de `dbt clean`.

A priori on devrais être bon en prod (cf. explication de mon commit), il reste possible d'avoir des comportements bizarre en dev mais je ne pense pas.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)

