### PR TITLE
DAG : Suppression de la logique de cache pour `ft_information_territoire`

### DIFF
--- a/dags/ft_information_territoire.py
+++ b/dags/ft_information_territoire.py
@@ -1,6 +1,7 @@
 import logging
 
 from airflow import DAG
+from airflow.decorators import task
 from airflow.operators import python
 
 from dags.common import default_dag_args, slack
@@ -14,6 +15,7 @@ logger = logging.getLogger(__name__)
 # we cannot reliably schedule this DAG, so we run it regularly.
 with DAG(**default_dag_args(), dag_id="ft_information_territoire", schedule_interval="@weekly") as dag:
 
+    @task(task_id="registered_jobseeker_stats_by_territory")
     def registered_jobseeker_stats_by_territory(**kwargs):
         # Import data from the API for each territory targeted.
         access_token = ft_api_helpers.request_access_token(format_for_header=True)
@@ -23,12 +25,8 @@ with DAG(**default_dag_args(), dag_id="ft_information_territoire", schedule_inte
 
         logger.info("Import complete.")
 
-    end = slack.success_notifying_task()
-
     (
-        python.PythonOperator(task_id="create_schema_and_tables", python_callable=models.create_tables)
-        >> python.PythonOperator(
-            task_id="registered_jobseeker_stats_by_territory", python_callable=registered_jobseeker_stats_by_territory
-        )
-        >> end
+        python.PythonOperator(task_id="create_schema_and_tables", python_callable=models.create_tables).as_setup()
+        >> registered_jobseeker_stats_by_territory()
+        >> slack.success_notifying_task()
     )

--- a/dags/ft_information_territoire.py
+++ b/dags/ft_information_territoire.py
@@ -30,6 +30,5 @@ with DAG(**default_dag_args(), dag_id="ft_information_territoire", schedule_inte
         >> python.PythonOperator(
             task_id="registered_jobseeker_stats_by_territory", python_callable=registered_jobseeker_stats_by_territory
         )
-        >> python.PythonOperator(task_id="verify_periods", python_callable=ft_api_helpers.raise_for_missing_periods)
         >> end
     )


### PR DESCRIPTION
### Pourquoi ?

Les _run_ en prod échoue sur la tâche `verify_periods` mais pas en local même après repris le contenu de `FT_INFORMATION_TERRITOIRE_PERIOD_LOG`, ce qui n'est pas déconnant car nous n'avons pas les mêmes données et que la dite tâche regarde elle en BDD.
Cela va augmenter le temps d’exécution mais il n'est que hebdomadaire et ça me semble mieux philosophiquement de se dire qu'on fait juste des miroir des données externes importées, la correction des erreurs pouvant être faite dans un modèle DBT.
