### PR TITLE
modified pass_agrements_valides to avoid duplicates

### DIFF
--- a/dbt/models/ephemeral/eph_suspensions_pass_en_cours.sql
+++ b/dbt/models/ephemeral/eph_suspensions_pass_en_cours.sql
@@ -1,0 +1,3 @@
+select *
+from {{ ref('suspensions_pass') }}
+where suspension_en_cours = 'Oui'

--- a/dbt/models/ephemeral/properties.yml
+++ b/dbt/models/ephemeral/properties.yml
@@ -34,6 +34,9 @@ models:
   - name: eph_series_mois
     description: >
       Vue créée pour récupérer le dernier jour des mois de l'année en cours et des trois années précédentes
+  - name: eph_suspensions_pass_en_cours
+    description: >
+      Vue créée pour récupérer les suspensions de pass en cours et pas l'historique complet
   - name: eph_heures_travail_contrat
     description: >
       Table ephemeral permettant de calculer le nombre d'heures travaillées par contrat

--- a/dbt/models/marts/daily/pass_agrements_valides.sql
+++ b/dbt/models/marts/daily/pass_agrements_valides.sql
@@ -1,16 +1,21 @@
 select
     {{ pilo_star(source('emplois', 'pass_agréments'), relation_alias="pa") }},
     struct.bassin_d_emploi as bassin_emploi_structure,
+    suspensions.motif_suspension,
     case
         when
             pa.date_fin >= current_date then 'pass valide'
         else 'pass non valide'
     end                    as validite_pass,
-    suspensions.suspension_en_cours,
-    suspensions.motif_suspension
+    case
+        when
+            suspensions."id_pass_agrément" is null then 'Non'
+        else 'Oui'
+    end                    as suspension_en_cours
 from
     {{ source('emplois', 'pass_agréments') }} as pa
 left join {{ ref('stg_structures') }} as struct
-    on struct.id = pa.id_structure
-left join {{ ref('suspensions_pass') }} as suspensions
-    on suspensions."id_pass_agrément" = pa.id
+    on pa.id_structure = struct.id
+left join {{ ref('eph_suspensions_pass_en_cours') }} as suspensions
+    on pa.id = suspensions."id_pass_agrément"
+where pa.type != 'Agrément PE'

--- a/dbt/models/marts/daily/properties.yml
+++ b/dbt/models/marts/daily/properties.yml
@@ -52,6 +52,19 @@ models:
   - name: pass_agrements_valides
     description: >
       Table permettant de savoir si un pass agrément ou IAE est valide et/ou suspendu.
+    columns:
+      - name: id
+        description: >
+          Identifiant du pass agrément
+        tests:
+          - not_null
+          - unique
+      - name: hash_numéro_pass_iae
+        description: >
+          Hash du numéro de pass IAE, utile pour éviter de stocker le numéro de pass en clair.
+        tests:
+          - not_null
+          - unique
   - name: suspensions_pass
     description: >
       Table permettant de connaître les pass agrément ou IAE suspendus.

--- a/dbt/tests/test_suspensions_pass.sql
+++ b/dbt/tests/test_suspensions_pass.sql
@@ -1,0 +1,11 @@
+with suspensions_en_cours as (
+    select
+        count(*)                            as nombre_lignes,
+        count(distinct "id_pass_agrément") as nb_pass_suspension_en_cours
+    from {{ ref('suspensions_pass') }}
+    where suspension_en_cours = 'Oui'
+)
+
+select *
+from suspensions_en_cours
+where nombre_lignes != nb_pass_suspension_en_cours


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/gip-inclusion/doublons-pass_agr-ments_valide-2255f321b60480da920efa9c13412c3f
### Pourquoi ?

Parce que il y avait des doublons d'id et de hash_pass_agrément numéro ce qui ne devait pas être le cas.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

