### PR TITLE
adapt code to prod data schema

### DIFF
--- a/dags/common/immersion_facilitee/models.py
+++ b/dags/common/immersion_facilitee/models.py
@@ -35,7 +35,7 @@ class Conventions(ImmersionFaciliteeBase):
     id = Column(UUID(as_uuid=True), primary_key=True)
 
     status = Column(String)
-    statusJustification = Column(String)
+    statusJustification = Column(String, nullable=True)
     agencyId = Column(String)
     dateSubmission = Column(DateTime)
     dateStart = Column(DateTime)
@@ -56,10 +56,6 @@ class Conventions(ImmersionFaciliteeBase):
     agencyDepartment = Column(String)
     agencyKind = Column(String)
     agencySiret = Column(String, check_siret("agencySiret"))
-    agencyRefersToId = Column(String)
-    agencyRefersToName = Column(String)
-    agencyRefersToKind = Column(String)
-    updatedAt = Column(DateTime)
     beneficiaryPIIHashes = Column(ARRAY(String))
 
     def __repr__(self) -> str:


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Le schéma de données de la prod d'if était un peu different de celui du staging. Et afin de plus facilement gérer l'ajout de champs au schéma et de rendre le code plus sûr. J'ai changé unwanted_columns avec wanted_cols 
### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

