### PR TITLE
add prescriptor to dihal candidatures

### DIFF
--- a/dbt/models/marts/daily/candidatures_dihal.sql
+++ b/dbt/models/marts/daily/candidatures_dihal.sql
@@ -1,4 +1,4 @@
 select
     {{ pilo_star(ref('candidatures_echelle_locale'), relation_alias='cel') }}
 from {{ ref('candidatures_echelle_locale') }} as cel
-where cel.type_org_prescripteur in ('CHRS', 'CHU', 'RS_FJT', 'OIL')
+where cel.type_org_prescripteur in ('CHRS', 'CHU', 'RS_FJT', 'OIL', 'CADA', 'HUDA', 'CPH')


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/gip-inclusion/Elargir-le-p-rim-tre-du-TB-AHI-en-int-grant-les-donn-es-des-nouveaux-prescripteurs-des-h-bergement--1c85f321b604805dbb5aeefd9e43ddd3?source=copy_link

### Pourquoi ?

On veut ajouter dans le TDB AHI les prescriptions issues de trois nouveaux prescripteurs

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

