### PR TITLE
Ajout département_orga à table stg_candidats_candidatures

### DIFF
--- a/dbt/models/staging/stg_candidats_candidatures.sql
+++ b/dbt/models/staging/stg_candidats_candidatures.sql
@@ -22,7 +22,8 @@ select
     cd.bassin_emploi_prescripteur,
     cd."nom_département_structure",
     cd.reprise_de_stock_ai,
-    cd.epci
+    cd.epci,
+    cd."département_orga"
 from {{ ref('candidats') }} as c
 left join {{ ref('candidatures_echelle_locale') }} as cd
     on c.id = cd.id_candidat


### PR DESCRIPTION
**Carte Notion : **
https://www.notion.so/gip-inclusion/Tester-le-Changement-d-input-des-d-partements-et-r-gions-sur-les-TBs-FT-2105f321b60480f38cf6f4d076ec576c?v=5783842cc96b4bdbb6884e08a661ce24&source=copy_link
### Pourquoi ?

Parce que j'ai besoin du code du département sur la table candidatures_candidats_recherche_active pour pouvoir faire filtrer aux emplois la question de la TDB sur le code département et pas le nom

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

