### PR TITLE
Ajoute numéro département aux tables taux_trasformation et stg_organisations

### DIFF
--- a/dbt/models/marts/daily/taux_transformation_prescripteurs.sql
+++ b/dbt/models/marts/daily/taux_transformation_prescripteurs.sql
@@ -45,18 +45,19 @@ with candidats_p as (
 select
     /* On selectionne les colonnes finales qui nous intéressent */
     c.*,
-    organisations_libelles.label     as type_auteur_diagnostic_detaille,
+    organisations_libelles.label        as type_auteur_diagnostic_detaille,
     prescripteurs.type_prescripteur,
-    prescripteurs.nom_arrondissement as nom_arrondissement_prescripteur,
-    prescripteurs.zone_emploi        as bassin_emploi_prescripteur,
-    prescripteurs.epci               as epci_prescripteur,
-    prescripteurs.dept_org           as "nom_département_prescripteur",
-    prescripteurs."région_org"       as "nom_région_prescripteur",
+    prescripteurs.nom_arrondissement    as nom_arrondissement_prescripteur,
+    prescripteurs.zone_emploi           as bassin_emploi_prescripteur,
+    prescripteurs.epci                  as epci_prescripteur,
+    prescripteurs.dept_org              as "nom_département_prescripteur",
+    prescripteurs."région_org"          as "nom_région_prescripteur",
+    prescripteurs."num_département_org" as "num_département_prescripteur",
     case
         /* ajout d'une colonne permettant de calculer le taux de candidats acceptées
             tout en faisant une jointure avec la table candidatures */
         when c.total_embauches > 0 then concat(cast(c.id_candidat as varchar), '_accepté')
-    end                              as "candidature_acceptée"
+    end                                 as "candidature_acceptée"
 from
     candidats_p as c
 left join {{ ref('stg_organisations') }} as prescripteurs

--- a/dbt/models/staging/stg_organisations.sql
+++ b/dbt/models/staging/stg_organisations.sql
@@ -7,6 +7,7 @@ select
     organisations."nom_département",
     organisations.siret                                                               as siret_org_prescripteur,
     organisations."nom_département"                                                   as dept_org,
+    organisations."département"                                                       as "num_département_org",
     -- les deux colonnes suivantes sont en doublons le temps de vérifier les branchements de filtre sur metabase
     organisations."région"                                                            as "région_org",
     organisations."région",


### PR DESCRIPTION
**Carte Notion : **
https://www.notion.so/gip-inclusion/Tester-le-Changement-d-input-des-d-partements-et-r-gions-sur-les-TBs-FT-2105f321b60480f38cf6f4d076ec576c
### Pourquoi ?

Car on veut passer à parti des emplois le numéro de département et pas le nom pour raccourcir les url

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

