### PR TITLE
Tech : Utiliser PostgreSQL 17 comme en production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       cancel-in-progress: true
     services:
       postgres:
-        image: postgis/postgis:14-master
+        image: postgres:17
         env:
           POSTGRES_PASSWORD: password
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   postgres:
     container_name: pilotage_postgres
-    image: postgres:15
+    image: postgres:17
     # Disable some safety switches for a faster postgres: https://www.postgresql.org/docs/current/non-durability.html
     command: -c fsync=off -c full_page_writes=off -c synchronous_commit=off
     environment:


### PR DESCRIPTION
### Pourquoi ?

La production a été migrée en PG 17
