### PR TITLE
Modèles : Simplification pour `les_emplois_contrats`

### DIFF
--- a/dbt/models/marts/weekly/les_emplois_contrats.sql
+++ b/dbt/models/marts/weekly/les_emplois_contrats.sql
@@ -1,26 +1,18 @@
 select
-    candidats.id             as candidat_id,
-    salarie.hash_nir,
-    ctr.contrat_id_structure as id_structure,
-    structs.structure_denomination,
-    structs.structure_siret_actualise,
-    type_structure.type_structure_emplois,
-    salarie.salarie_id,
+    candidats.id as emplois_candidat_id,
+    ctr.contrat_id_structure,
+    ctr.contrat_mesure_disp_code,
     ctr.contrat_id_ctr,
-    ctr.contrat_date_sortie_definitive,
+    ctr.contrat_parent_id,
     ctr.contrat_date_embauche,
     ctr.contrat_date_fin_contrat,
+    ctr.contrat_date_sortie_definitive,
     case
-        when ctr.contrat_type_contrat = 0 then 'contrat_initiale'
-        when ctr.contrat_type_contrat > 0 then 'renouvellement'
-    end                      as type_contrat
-from {{ ref("fluxIAE_ContratMission_v2") }} as ctr
-left join {{ ref('ref_mesure_dispositif_asp') }} as type_structure
-    on ctr.contrat_mesure_disp_code = type_structure.af_mesure_dispositif_code
-left join {{ ref("fluxIAE_Structure_v2") }} as structs
-    on ctr.contrat_id_structure = structs.structure_id_siae
-left join {{ ref("stg_uniques_salarie_id") }} as salarie
+        when ctr.num_reconduction = 0 then 'initial'
+        when ctr.num_reconduction > 0 then 'renouvellement'
+    end          as type_contrat
+from {{ ref("stg_contrats") }} as ctr
+inner join {{ ref("stg_uniques_salarie_id") }} as salarie
     on ctr.contrat_id_pph = salarie.salarie_id
-left join {{ source('emplois', 'candidats_v0') }} as candidats
+inner join {{ source('emplois', 'candidats_v0') }} as candidats
     on salarie.hash_nir = candidats.hash_nir
-where candidats.id is not null

--- a/dbt/models/marts/weekly/properties.yml
+++ b/dbt/models/marts/weekly/properties.yml
@@ -49,23 +49,26 @@ models:
     description: >
       Table à destination des emplois afin qu'ils puissent remonter les infos sur les contrats des candidats.
     columns:
-      - name: id_structure
+      - name: emplois_candidat_id
         tests:
           - not_null
-      - name: type_structure_emplois
+      - name: contrat_id_structure
         tests:
           - not_null
-      - name: salarie_id
+      - name: contrat_mesure_disp_code
         tests:
           - not_null
       - name: contrat_id_ctr
         tests:
           - not_null
           - unique
-      - name: type_contrat
+      - name: contrat_parent_id
         tests:
           - not_null
-      - name: candidat_id
+      - name: contrat_date_embauche
+        tests:
+          - not_null
+      - name: type_contrat
         tests:
           - not_null
   - name: formations


### PR DESCRIPTION
### Pourquoi ?

J'ai commencé à exploiter ces données coté emplois et ai vu des améliorations possibles (cf. commit).

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

