### PR TITLE
Tech : Ne plus générer un hash pour les valeurs évaluées à `False`

### DIFF
--- a/dags/common/anonymize_sensible_data.py
+++ b/dags/common/anonymize_sensible_data.py
@@ -13,7 +13,7 @@ class NormalizationKind(enum.Enum):
 
 
 def hash_content(content: str) -> str:
-    return hashlib.sha256(f'{content}{os.getenv("HASH_SALT")}'.encode()).hexdigest()
+    return hashlib.sha256(f'{content}{os.getenv("HASH_SALT")}'.encode()).hexdigest() if content else ""
 
 
 def normalize_sensible_data(*args: tuple[str | datetime.date, NormalizationKind]) -> str:

--- a/tests/test_common_anonymize_sensible_data.py
+++ b/tests/test_common_anonymize_sensible_data.py
@@ -13,8 +13,8 @@ from dags.common.anonymize_sensible_data import NormalizationKind, hash_content,
         (None, "8e728c4578281ea0b6a7817e50a0f6d50c995c27f02dd359d67427ac3d86e019"),
     ],
 )
-def test_hash_content(mocker, value, expected):
-    mocker.patch.dict("os.environ", {"HASH_SALT": "foobar2000"})
+def test_hash_content(monkeypatch, value, expected):
+    monkeypatch.setenv("HASH_SALT", "foobar2000")
 
     assert hash_content(value) == expected
 

--- a/tests/test_common_anonymize_sensible_data.py
+++ b/tests/test_common_anonymize_sensible_data.py
@@ -9,8 +9,8 @@ from dags.common.anonymize_sensible_data import NormalizationKind, hash_content,
     "value, expected",
     [
         ("XXXXX2012369", "7cc9da292b108e91aa40f7287b990daeca22b296e68ee5e0457a89c97a282c27"),
-        ("", "6cc868860cee823f0ffe0b3498bb4ebda51baa1b7858e2022f6590b0bd86c31c"),
-        (None, "8e728c4578281ea0b6a7817e50a0f6d50c995c27f02dd359d67427ac3d86e019"),
+        ("", ""),
+        (None, ""),
     ],
 )
 def test_hash_content(monkeypatch, value, expected):

--- a/tests/test_common_db.py
+++ b/tests/test_common_db.py
@@ -1,22 +1,15 @@
-from unittest import mock
-
 from dags.common import db
 
 
-@mock.patch.dict(
-    "os.environ",
-    {
-        "AIRFLOW_VAR_PGHOST": "host",
-        "AIRFLOW_VAR_PGPORT": "port",
-        "AIRFLOW_VAR_PGDATABASE": "db",
-        "AIRFLOW_VAR_PGUSER": "user",
-        "AIRFLOW_VAR_PGPASSWORD": "password",
-    },
-)
-def test_connection_envvars():
-    envvars = db.connection_envvars()
-    assert envvars["PGDATABASE"] == "db"
-    assert envvars["PGHOST"] == "host"
-    assert envvars["PGPASSWORD"] == "password"
-    assert envvars["PGPORT"] == "port"
-    assert envvars["PGUSER"] == "user"
+def test_connection_envvars(monkeypatch):
+    expected = {
+        "PGHOST": "host",
+        "PGPORT": "port",
+        "PGDATABASE": "db",
+        "PGUSER": "user",
+        "PGPASSWORD": "password",
+    }
+    for name, value in expected.items():
+        monkeypatch.setenv(f"AIRFLOW_VAR_{name}", value)
+
+    assert db.connection_envvars() == expected

--- a/tests/test_dags.py
+++ b/tests/test_dags.py
@@ -1,23 +1,14 @@
 import json
-from unittest import mock
+import pathlib
 
 from airflow.models import DagBag
 
 
-# keep track of all the necessary variables for any DAGs to run.
-# this is good to avoid losing the grip on what is necessary to
-# our production flows. Any added variable not listed in the dev
-# file will make the tests fail.
-def get_dag_variables():
-    with open("dag-variables.json", "r", encoding="utf-8") as json_file:
-        return json.load(json_file)
+def test_dags_generic(monkeypatch, subtests):
+    # Keep track of all the necessary variables to parse the DAGs.
+    for var in json.load(pathlib.Path("dag-variables.json").open("r")):
+        monkeypatch.setenv(f"AIRFLOW_VAR_{var}", "dummy")
 
-
-@mock.patch.dict(
-    "os.environ",
-    {f"AIRFLOW_VAR_{var}": "dummy" for var in get_dag_variables()},
-)
-def test_dags_generic(subtests):
     dagbag = DagBag()
     for dag_id in dagbag.dag_ids:
         with subtests.test(msg="DAG generic checks", dag_id=dag_id):


### PR DESCRIPTION
### Pourquoi ?

- Ces valeurs ne nous sont pas utiles.
- Ça donner des résultats faux si jamais on venais à joindre sur ces hash.
- Ça nous évite de devoir ignorer ces valeurs dans nos scripts. 
- Ça simplifie la découverte du sel utilisé d'avoir une valeur connue.