### PR TITLE
Corrections des erreurs récentes

### DIFF
--- a/dags/common/db.py
+++ b/dags/common/db.py
@@ -121,9 +121,11 @@ def drop_view(view_name):
 def create_schema(schema_name):
     # TODO: Use an Airflow Connection
     with connection_engine().connect() as connection:
-        connection.execute(CreateSchema(schema_name))
+        if not connection.dialect.has_schema(connection, schema_name):
+            connection.execute(CreateSchema(schema_name))
 
 
 @sqlalchemy.event.listens_for(sqlalchemy.Table, "before_create")
 def create_schema_if_not_exists(target, connection, **_):
-    connection.execute(CreateSchema(target.schema))
+    if not connection.dialect.has_schema(connection, target.schema):
+        connection.execute(CreateSchema(target.schema))

--- a/dags/data_inclusion.py
+++ b/dags/data_inclusion.py
@@ -58,6 +58,7 @@ with DAG("data_inclusion", schedule="@daily", **dag_args) as dag:
                 "labels_nationaux": postgresql.ARRAY(sqlalchemy.types.Text),
                 "labels_autres": postgresql.ARRAY(sqlalchemy.types.Text),
                 "thematiques": postgresql.ARRAY(sqlalchemy.types.Text),
+                "doublons": postgresql.ARRAY(sqlalchemy.types.JSON),
             },
         )
         logger.info("%r rows created", row_created)

--- a/dags/monrecap.py
+++ b/dags/monrecap.py
@@ -143,8 +143,7 @@ with DAG("mon_recap", schedule="@daily", **dag_args) as dag:
 
     (
         create_schema(DB_SCHEMA).as_setup()
-        >> monrecap_airtable()
-        >> monrecap_gsheet()
+        >> [monrecap_airtable(), monrecap_gsheet()]
         >> dbt_deps
         >> dbt_seed
         >> dbt_monrecap

--- a/dags/monrecap.py
+++ b/dags/monrecap.py
@@ -1,5 +1,6 @@
 import re
 
+import pandas as pd
 import sqlalchemy.types as types
 from airflow import DAG
 from airflow.decorators import task
@@ -73,7 +74,7 @@ with DAG("mon_recap", schedule="@daily", **dag_args) as dag:
             dtype_mapping = {}
             for col in table_data.columns:
                 # Check if column contains dict or list values
-                sample_values = table_data[col].dropna().head(10)
+                sample_values = pd.concat([table_data[col].dropna().head(1000), table_data[col].dropna().tail(1000)])
                 if any(isinstance(val, dict | list) for val in sample_values):
                     dtype_mapping[col] = types.JSON
 


### PR DESCRIPTION
### Pourquoi ?

- Les DAG `mon_recap`, `data_inclusion` et `esat`  échouaient car leur schema existait déjà. Commit 1 => Lié a mon refactor sur les DAG
- Les DAG `data_inclusion` et `monrecap` échouaient car des données récupérées sont des `dict` et il manquais le _dtype_. Commit 2 et 4 => Probablement lié a la MAJ des dépendances, les `dict` ne sont plus adapté comme avant il semblerais.
- Le DAG `esat` échouait a cause de la redéclaration du model SQLAlchemy. Commit 3 => Lier a mon refactor sur les DAG
- Le DAG `populate_metabase_fluxiae` échouaient car un `\n` c'est retrouvé dans la colonne de l'email du salarié donc on se retrouve avec une ligne coupée en deux et donc pas avec le bon nombre de lignes dans chacune de ces lignes mais panda s'en tamponne jusqu'à devoir convertir un _None_ en _int_... => C'est une erreur du coté de l'ASP

### Checks

- [x] J'ai lancé les DAG
