### PR TITLE
Airflow : Désactivation du méchanisme de rattrapage

### DIFF
--- a/.env-base
+++ b/.env-base
@@ -7,6 +7,7 @@ AIRFLOW__CORE__PARALLELISM=6  # No more than the number of production CPUs
 AIRFLOW__DATABASE__LOAD_DEFAULT_CONNECTIONS=False
 AIRFLOW__METRICS__TIMER_UNIT_CONSISTENCY=True  # Not used but this will prevent warnings and this is the default in Airflow 3.0
 # We don't use or need data interval, and this will be the default in Airflow 3.0
+AIRFLOW__SCHEDULER__CATCHUP_BY_DEFAULT=False
 AIRFLOW__SCHEDULER__CREATE_CRON_DATA_INTERVALS=False
 AIRFLOW__SCHEDULER__CREATE_DELTA_DATA_INTERVALS=False
 # cf https://github.com/apache/airflow/issues/17536#issuecomment-900343494


### PR DESCRIPTION
### Pourquoi ?

Pour éviter que les DAG ne soient lancé plusieurs fois d’affilé quand un _run_ est manqué, ce n'est pas utile pour nous car on utilise pas les _data interval_.