### PR TITLE
[DSN] Retrait de caractères dans le nom de fichier final

### DIFF
--- a/dags/stats_dsn.py
+++ b/dags/stats_dsn.py
@@ -276,7 +276,7 @@ with DAG(
         processed_df = processed_df[FILE_BASE_COLUMNS + FILE_EXTRA_COLUMNS]
         check_dataframe_columns_exists(processed_df, FILE_BASE_COLUMNS + FILE_EXTRA_COLUMNS)
 
-        base_name = f"GIPP3242.PIQDISB3.P{datetime.date.today():%y0%m%d}.MESUREIMPACT.INCLUSION"
+        base_name = f"GIPP3242.PIQDISB3.P{datetime.date.today():%y0%m%d}"
         archive_name, file_name = f"{base_name}.7z", f"{base_name}.txt"
 
         file_content = get_file_content(


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Suite à une demande du GIP MDS, retrait de caractères dans le nom de fichier exporté sur le sftp pour la DSN

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

