### PR TITLE
DAG : Ajout d'une option pour copier le fichier envoyé chez nous

### DIFF
--- a/custom-dev-entrypoint.sh
+++ b/custom-dev-entrypoint.sh
@@ -21,5 +21,6 @@ airflow users create \
 # Create buckets. Use `|| true` because we get an error : 409 (BucketAlreadyOwnedByYou)
 s3cmd --host="http://minio:9000" --host-bucket="http://minio:9000" --no-ssl --access_key="minioadmin" --secret_key="minioadmin" mb s3://airflow || true
 s3cmd --host="http://minio:9000" --host-bucket="http://minio:9000" --no-ssl --access_key="minioadmin" --secret_key="minioadmin" mb s3://les-emplois || true
+s3cmd --host="http://minio:9000" --host-bucket="http://minio:9000" --no-ssl --access_key="minioadmin" --secret_key="minioadmin" mb s3://pilotage || true
 
 exec /entrypoint "standalone"

--- a/dag-variables.json
+++ b/dag-variables.json
@@ -2,6 +2,7 @@
     "DATASTORE_S3_ACCESS_KEY": "minioadmin",
     "DATASTORE_S3_EMPLOIS_BUCKET_NAME": "les-emplois",
     "DATASTORE_S3_ENDPOINT_URL": "http://minio:9000",
+    "DATASTORE_S3_PILOTAGE_BUCKET_NAME": "pilotage",
     "DATASTORE_S3_SECRET_KEY": "minioadmin",
     "PGDATABASE": "pilotage",
     "PGHOST": "postgres",


### PR DESCRIPTION
### Pourquoi ?

Car le GIP-MDS nous demande souvent une version anonymisée pour tester avant les échanges avec la CNAV.

Le code fonctionne mais pour le moment quand je test avec les creds de prods ça me met une erreur de permissions mais c'est OK quand j'utilise les miens :shrug:, vu que c'est une option c'est pas gênant de fusionner la PR et de ne l'utiliser qu'une fois le problème de permissions corrigé.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

