### PR TITLE
add new ids to track for the same dashboard name

### DIFF
--- a/dbt/seeds/pilotage_interne/metabase_dashboards.csv
+++ b/dbt/seeds/pilotage_interne/metabase_dashboards.csv
@@ -51,4 +51,6 @@ id_tb,nom_tb,public,type
 545,tb 545 - PH/FT/CD - Suivi des bénéficiaires taux d’encadrement et présence en emploi,PH,TB privé
 550,tb 550 - SIAE - Suivi des bénéficiaires taux d’encadrement et présence en emploi,SIAE,TB privé
 566,tb 440 - SIAE - Données conventionnement - Maille structure,SIAE,TB privé
+573,tb 160 - Facilitation de l'embauche DREETS/DDETS,DREETS/DDETS,TB privé
+577,tb 289 - Suivi des prescriptions des PH DDETS/DREETS,DDETS/DREETS, TB privé
 578,tb 485 - DDETS/DREETS/CD - Données conventionnement - Maille structure,DDETS/DREETS/CD, TB privé


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Suivi des deux nouvelles version du TDB prescriptions et du TDB facilitation embauche On a changé l'id du TB mais gardé le même nom de TB de façon que le tracking (fait à partir du nom TDB) reste valable. Les v1 des deux TBs seront archivées, on aura une trace du passée comme ça.

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

