### PR TITLE
[flux IAE] Retrait de la colonne nir_chiffré

### DIFF
--- a/dbt/models/indexed/fluxIAE_Salarie_v2.sql
+++ b/dbt/models/indexed/fluxIAE_Salarie_v2.sql
@@ -6,7 +6,7 @@
  ) }}
 
 select distinct
-    {{ pilo_star(source('fluxIAE', 'fluxIAE_Salarie'), except=["hash_numéro_pass_iae"]) }},
+    {{ pilo_star(source('fluxIAE', 'fluxIAE_Salarie'), except=["hash_numéro_pass_iae", "nir_chiffré"]) }},
     case
         when date_part('year', current_date) - date_part('year', to_date(salarie_annee_naissance::TEXT, 'YYYY')) <= 26 then 'Jeune (- de 26 ans)'
         when


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

La colonne nir_chiffré créait des doublons dans la table fluxIAE_salarie_v2. Induisant des erreurs en cascade.
Retrait de cette colonne non utilisée par le pilotage.

### Checks

- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

