### PR TITLE
[Mon recap] Fix d'un test obsolète

### DIFF
--- a/dbt/models/_sources.yml
+++ b/dbt/models/_sources.yml
@@ -127,7 +127,6 @@ sources:
     description: >
       Données de Mon Récap
     tables:
-      - name: barometre_v0
       - name: Contacts_v0
       - name: Commandes_v0
       - name: contacts_non_commandeurs_v0

--- a/dbt/models/monrecap/marts/properties.yml
+++ b/dbt/models/monrecap/marts/properties.yml
@@ -18,4 +18,4 @@ models:
       Table du barometre de mon recap. Nous créons cette table à partir d'une version v0 afin de faire des modifications eventuelle en sql et non en python
     tests:
       - dbt_utils.equal_rowcount:
-          compare_model: source('monrecap','barometre_v0')
+          compare_model: source('monrecap','raw_barometre')


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

la table barometre_v0 a été remplacée par raw_barometre. On corrige l'oubli de changement de nom dans un test + on retire barometre_v0 comme source.

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

