### PR TITLE
chore:add a new CI rule:notion links are needed

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-**Carte Notion : **
+**Carte Notion : ** (non nécessaire si `label=hotfix`)
 
 ### Pourquoi ?
 
@@ -6,6 +6,7 @@ Indiquer le problème que nous sommes en train de résoudre et les objectifs mé
 
 ### Checks
 
+- [ ] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
 - [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
 - [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
 - [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

--- a/.github/workflows/require-notion-link.yml
+++ b/.github/workflows/require-notion-link.yml
@@ -1,0 +1,22 @@
+name: Require Notion Link
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, labeled, unlabeled]
+
+jobs:
+  require-notion-link:
+    runs-on: ubuntu-latest
+    permissions: {}
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'dependencies') &&
+      !contains(github.event.pull_request.labels.*.name, 'hotfix')
+    steps:
+      - name: Verify Notion link in PR description
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if ! echo "$PR_BODY" | grep --quiet "notion.so"; then
+            echo "PR description must contain a Notion link (notion.so)"
+            exit 1
+          fi


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

J'ai rajouté un workflow a la CI qui fera en sorte qu'on arrête d'oublier de mettre les cartes notion dans les descriptions de ces dernières

### Checks

- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

