### PR TITLE
[fluxIAE] Retrait d'un NTT induisant une duplication d'un salarie

### DIFF
--- a/dbt/models/indexed/fluxIAE_Salarie_v2.sql
+++ b/dbt/models/indexed/fluxIAE_Salarie_v2.sql
@@ -17,3 +17,5 @@ select distinct
     end as tranche_age
 from
     {{ source('fluxIAE', 'fluxIAE_Salarie') }}
+-- an employee of an SIAE has a NIR & and NTT, we remove the NTT.
+where hash_nir != '936aa21c8553ab199f68a47ac9fbf4cee9241c48a46a037264223c84b5f64cac'

--- a/dbt/models/staging/stg_uniques_salarie_id.sql
+++ b/dbt/models/staging/stg_uniques_salarie_id.sql
@@ -1,5 +1,5 @@
 select
     hash_nir,
     salarie_id
-from {{ source("fluxIAE","fluxIAE_Salarie") }}
+from {{ ref("fluxIAE_Salarie_v2") }}
 group by hash_nir, salarie_id


### PR DESCRIPTION
**Carte Notion : ** (non nécessaire si `label=hotfix`)

### Pourquoi ?

Un meme id_salarie a un NTT et un NIR, nous avons décidé de retirer le NTT car peu pertinent et créé un doublon.

### Checks

- [ ] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

