### PR TITLE
replace stg_insee_appartenance_geo_communes with centralized dim commune

### DIFF
--- a/dbt/models/indexed/fluxIAE_Structure_v2.sql
+++ b/dbt/models/indexed/fluxIAE_Structure_v2.sql
@@ -8,13 +8,13 @@
 select distinct -- parfois l'ASP introduit des doublons, ici les élimine
     -- l'ASP préconise l'utilisation de l'adresse administrative pour récupérer la commune de la structure
     {{ pilo_star(source('fluxIAE', 'fluxIAE_Structure')) }},
-    app_geo.nom_epci                                                  as nom_epci_structure,
-    app_geo.nom_zone_emploi                                           as zone_emploi_structure,
-    app_geo.nom_region                                                as nom_region_structure,
-    app_geo.code_dept                                                 as code_dept_structure,
-    app_geo.nom_departement_complet                                   as nom_departement_structure,
+    dim_commune.nom_epci                                              as nom_epci_structure,
+    dim_commune.nom_zone_emploi                                       as zone_emploi_structure,
+    dim_commune.nom_region                                            as nom_region_structure,
+    dim_commune.code_departement_insee                                as code_dept_structure,
+    dim_commune.nom_departement_complet                               as nom_departement_structure,
     concat_ws('-', structure_denomination, structure_siret_actualise) as structure_denomination_unique
 from
     {{ source('fluxIAE', 'fluxIAE_Structure') }} as structure
-left join {{ ref('stg_insee_appartenance_geo_communes') }} as app_geo
-    on ltrim(structure.structure_adresse_admin_code_insee, '0') = app_geo.code_insee
+left join {{ ref('dim_commune') }}
+    on ltrim(structure.structure_adresse_admin_code_insee, '0') = dim_commune.code_commune_insee

--- a/dbt/models/marts/daily/structures.sql
+++ b/dbt/models/marts/daily/structures.sql
@@ -1,25 +1,25 @@
 select
     {{ pilo_star(source('emplois','structures_v0'), except=['source', 'ville'], relation_alias='struct') }},
-    insee.libelle_commune as ville,
-    insee.nom_zone_emploi as bassin_d_emploi,
-    grp_strct.groupe      as categorie_structure,
+    dim_commune.nom_commune     as ville,
+    dim_commune.nom_zone_emploi as bassin_d_emploi,
+    grp_strct.groupe            as categorie_structure,
     case
         when struct.source = 'Export ASP' then strct_asp.nom_epci_structure
-        else insee.nom_epci
-    end                   as nom_epci_structure,
+        else dim_commune.nom_epci
+    end                         as nom_epci_structure,
     case
         when struct.type = 'OPCS' and struct.source = 'Utilisateur (Antenne)' then 'Utilisateur (OPCS)'
         when struct.type = 'OPCS' and struct.source = 'Staff Itou' then 'Staff Itou (OPCS)'
         else struct.source
-    end                   as source
+    end                         as source
 from
     {{ source('emplois','structures_v0') }} as struct
 left join
     {{ ref('groupes_structures') }} as grp_strct
     on struct.type = grp_strct.structure
 left join
-    {{ ref('stg_insee_appartenance_geo_communes') }} as insee
-    on coalesce(ltrim(struct.code_commune, '0'), ltrim(struct.code_commune_c1, '0')) = insee.code_insee
+    {{ ref('dim_commune') }}
+    on coalesce(struct.code_commune, struct.code_commune_c1) = dim_commune.code_commune_insee
 left join
     {{ ref('fluxIAE_Structure_v2') }} as strct_asp
     on struct.id_asp = strct_asp.structure_id_siae

--- a/dbt/models/staging/stg_fdp.sql
+++ b/dbt/models/staging/stg_fdp.sql
@@ -10,8 +10,8 @@ select
     fdpc."nom_département_structure",
     fdpc."département_structure",
     fdpc."région_structure",
-    app_geo.nom_epci                                        as epci_structure,
-    app_geo.nom_zone_emploi                                 as bassin_emploi_structure,
+    dim_commune.nom_epci                                    as epci_structure,
+    dim_commune.nom_zone_emploi                             as bassin_emploi_structure,
     fdpc.nom_structure,
     fdpc."date_création_fdp",
     rome.domaine_professionnel,
@@ -54,8 +54,8 @@ left join {{ ref('code_rome_domaine_professionnel') }} as rome
     on fdpc.code_rome_fpd = rome.code_rome
 left join {{ ref('structures') }} as s
     on fdpc.id_structure = s.id
-left join {{ ref('stg_insee_appartenance_geo_communes') }} as app_geo
-    on s.code_commune = app_geo.code_insee
+left join {{ ref('dim_commune') }}
+    on s.code_commune = dim_commune.code_commune_insee
 group by
     fdpc.active,
     fdpc.id_fdp,
@@ -67,8 +67,8 @@ group by
     fdpc."nom_département_structure",
     fdpc."département_structure",
     fdpc."région_structure",
-    app_geo.nom_epci,
-    app_geo.nom_zone_emploi,
+    dim_commune.nom_epci,
+    dim_commune.nom_zone_emploi,
     fdpc.nom_structure,
     fdpc."date_création_fdp",
     rome.domaine_professionnel,

--- a/dbt/models/staging/stg_organisations.sql
+++ b/dbt/models/staging/stg_organisations.sql
@@ -5,41 +5,41 @@ select
     -- récupérer la ville insee si le croisement insee a bien pu se faire
     -- pour les 492 villes restantes, récupérer la ville des emplois
     organisations."nom_département",
-    organisations.siret                                                               as siret_org_prescripteur,
-    organisations."nom_département"                                                   as dept_org,
-    organisations."département"                                                       as "num_département_org",
+    organisations.siret                                                  as siret_org_prescripteur,
+    organisations."nom_département"                                      as dept_org,
+    organisations."département"                                          as "num_département_org",
     -- les deux colonnes suivantes sont en doublons le temps de vérifier les branchements de filtre sur metabase
-    organisations."région"                                                            as "région_org",
+    organisations."région"                                               as "région_org",
     organisations."région",
     /*bien mettre nom département et pas département */
-    appartenance_geo_communes.nom_departement                                         as "nom_département_insee",
-    appartenance_geo_communes.nom_arrondissement,
-    appartenance_geo_communes.nom_zone_emploi                                         as zone_emploi,
-    appartenance_geo_communes.nom_epci                                                as epci,
-    organisations_libelles.label                                                      as type_complet,
-    organisations_libelles.code                                                       as type_org,
-    coalesce(appartenance_geo_communes.libelle_commune, initcap(organisations.ville)) as ville,
-    coalesce(organisations.code_commune, appartenance_geo_communes.code_insee)        as code_commune,
+    dim_commune.nom_departement                                          as "nom_département_insee",
+    dim_commune.nom_arrondissement,
+    dim_commune.nom_zone_emploi                                          as zone_emploi,
+    dim_commune.nom_epci                                                 as epci,
+    organisations_libelles.label                                         as type_complet,
+    organisations_libelles.code                                          as type_org,
+    coalesce(dim_commune.nom_commune, initcap(organisations.ville))      as ville,
+    coalesce(organisations.code_commune, dim_commune.code_commune_insee) as code_commune,
     case
         when organisations.type in ('ML', 'FT', 'CAP_EMPLOI') then 'SPE'
         when organisations.type in ('DEPT', 'ODC') then 'Département'
         when organisations.type = 'Autre' then 'Autre'
         else 'Nouveaux prescripteurs'
-    end                                                                               as type_prescripteur,
+    end                                                                  as type_prescripteur,
     case
         when organisations."habilitée" = 1 then 'Prescripteur habilité'
         when organisations."habilitée" = 0 then 'Orienteur'
-    end                                                                               as habilitation,
+    end                                                                  as habilitation,
     case
         when organisations."habilitée" = 1 then concat('Prescripteur habilité ', organisations.type)
         when organisations."habilitée" = 0 then concat('Orienteur ', organisations.type)
-    end                                                                               as type_avec_habilitation,
+    end                                                                  as type_avec_habilitation,
     case
         when organisations."habilitée" = 1 then concat('Prescripteur habilité ', organisations.type_complet)
         when organisations."habilitée" = 0 then concat('Orienteur ', organisations.type_complet)
-    end                                                                               as type_complet_avec_habilitation
+    end                                                                  as type_complet_avec_habilitation
 from {{ source('emplois', 'organisations_v0') }} as organisations
 left join {{ source('emplois','c1_ref_type_prescripteur') }} as organisations_libelles
     on organisations.type = organisations_libelles.code
-left join {{ ref('stg_insee_appartenance_geo_communes') }} as appartenance_geo_communes
-    on organisations.code_commune = ltrim(appartenance_geo_communes.code_insee, '0')
+left join {{ ref('dim_commune') }}
+    on organisations.code_commune = dim_commune.code_commune_insee

--- a/dbt/models/staging/stg_structures.sql
+++ b/dbt/models/staging/stg_structures.sql
@@ -2,7 +2,7 @@ select
     s.id,
     s.id_asp,
     s.nom,
-    s.type                    as type_struct,
+    s.type                      as type_struct,
     s.siret,
     s.active,
     s.ville,
@@ -10,14 +10,15 @@ select
     s."nom_département",
     s."région",
     s.nom_epci_structure,
-    insee_geo.nom_zone_emploi as bassin_d_emploi,
-    s.nom_complet             as nom_structure_complet,
+    dim_commune.code_commune_insee,
+    dim_commune.nom_zone_emploi as bassin_d_emploi,
+    s.nom_complet               as nom_structure_complet,
     case
         when s.convergence_france = 1 then 'Oui'
         else 'Non'
-    end                       as structure_convergence
+    end                         as structure_convergence
 from
     {{ ref('structures') }} as s
 left join
-    {{ ref('stg_insee_appartenance_geo_communes') }} as insee_geo
-    on ltrim(s.code_commune, '0') = insee_geo.code_insee
+    {{ ref('dim_commune') }}
+    on s.code_commune = dim_commune.code_commune_insee


### PR DESCRIPTION
[Carte Notion](https://www.notion.so/gip-inclusion/Backlog-Diego-2ca5f321b60481c4877eef2bc37ce4b4?p=3565f321b6048068ba62f5a37723370e&pm=s)

### Pourquoi ?
On a créé une table `dim_commune` pour centraliser les informations relatives aux communes. Il y avait déjà une table qui contenait une partie de ces informations, donc il faut la remplacer par la nouvelle table.

* J’ai ignoré les marts de data inclusion parce que je crois que tu les couvres dans ta PR.
* Je n’ai pas fait de refacto. Même si j’ai trouvé des choses surprenantes, comme des modèles de staging pleins de jointures ou un modèle `stg_structures` basé sur un mart `structures`.
* J’ai simplement remplacé la table `stg_insee_appartenance_geo_communes` par la nouvelle `dim_commune`, en adaptant quand c’était nécessaire pour des raisons de zéros et de padding.
Parfois, comme dans `structures`, il y a des champs vides, comme le nom de l’EPCI, alors qu’on couvre ça dans `dim_commune`. Je l’ai laissé tel quel.

Peut-être que, pour les marts où on veut garantir la qualité des données géographiques, ça vaudrait le coup de s’assurer que 100 % des informations géographiques viennent de `dim_commune`.

Une fois que la PR pour les marts de data inclusion sera mergée, l’ancienne table ne sera plus utilisée nulle part et on pourra la supprimer.

### Checks

- [x] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

