### PR TITLE
[ESAT] Ajout d'un drop cascade pour eviter un fail du dag

### DIFF
--- a/dags/populate_esat_database.py
+++ b/dags/populate_esat_database.py
@@ -1,5 +1,6 @@
 import logging
 
+import sqlalchemy
 from airflow import DAG
 from airflow.decorators import task
 from airflow.operators import bash
@@ -18,7 +19,7 @@ logger = logging.getLogger(__name__)
 dag_args = default_dag_args() | {"default_args": dbt.get_default_args()}
 
 
-with DAG("populate_esat_database", schedule="@daily", **dag_args) as dag:
+with DAG("populate_esat_database", schedule=None, **dag_args) as dag:
     env_vars = db.connection_envvars()
 
     @task
@@ -29,6 +30,9 @@ with DAG("populate_esat_database", schedule="@daily", **dag_args) as dag:
             db.DBConnection(db_url_variable="PILO_FRONT_DB_URL_SECRET") as src_db,
             db.DBConnection(db_url_variable="EMPLOIS_DB_URL_SECRET") as dst_db,
         ):
+            with dst_db.engine.begin() as conn:
+                conn.execute(sqlalchemy.text(f'DROP TABLE IF EXISTS "{TARGET_SCHEMA}"."{TARGET_TABLE}" CASCADE'))
+
             first_write = True
 
             for chunk in src_db.query_chunked(query):


### PR DESCRIPTION
**Carte Notion : ** (non nécessaire si `label=hotfix`)

### Pourquoi ?

Ajout d'un drop cascade pour eviter un fail du dag

j'ai aussi passé le DAG en lancement manuel parce qu'il a pas besoin de tourner tous les jours étant donné que la campagne à une fin

### Checks

- [ ] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

