### PR TITLE
fix: clarify geographic columns in candidatures_echelle_locale

### DIFF
--- a/dbt/models/marts/daily/candidatures_echelle_locale.sql
+++ b/dbt/models/marts/daily/candidatures_echelle_locale.sql
@@ -1,5 +1,10 @@
 select
-    {{ pilo_star(ref('stg_candidatures'), except=['origine_détaillée'], relation_alias='candidatures') }},
+    {{ pilo_star(
+        ref('stg_candidatures'),
+        except=['origine_détaillée'],
+        relation_alias='candidatures'
+    ) }},
+
     candidats.hash_nir,
     candidats.sous_type_auteur_diagnostic               as auteur_diag_candidat_detaille,
     candidats.type_auteur_diagnostic                    as auteur_diag_candidat,
@@ -7,16 +12,39 @@ select
     candidats.eligible_cej,
     candidats.eligible_cdi_inclusion,
     candidats.date_inscription                          as date_inscription_candidat,
-    orga."département"                                  as "département_orga",
+
+    -- colonne legacy conservée pour compatibilité downstream.
+    -- Elle est équivalente à candidatures."département" et à candidatures."num_département_org".
+    candidatures."département"                          as "département_orga",
+
+    -- géographie prescripteur, colonnes de référence
+    candidatures.code_commune_prescripteur              as prescripteur_code_commune,
+    candidatures.ville_prescripteur                     as prescripteur_ville,
+    candidatures."région"                               as prescripteur_region,
+    candidatures."nom_département_insee"                as prescripteur_nom_departement,
+    candidatures.nom_departement_complet                as prescripteur_departement,
+    candidatures.nom_arrondissement                     as prescripteur_arrondissement,
+    candidatures.zone_emploi                            as prescripteur_zone_emploi,
+    candidatures.epci                                   as prescripteur_epci,
+
+    -- géographie structure, colonnes de référence
+    candidatures."département_structure"                as structure_code_departement,
+    candidatures."nom_département_structure"            as structure_nom_departement,
+    candidatures."région_structure"                     as structure_region,
+    candidatures.nom_epci_structure                     as structure_epci,
+    candidatures.bassin_emploi_structure                as structure_bassin_emploi,
+
     case
         when candidatures.injection_ai = 0 then 'Non'
         else 'Oui'
     end                                                 as reprise_de_stock_ai,
+
     case
         when candidatures.type_org_prescripteur = org.code
             then org.label
         else candidatures."origine_détaillée"
     end                                                 as "origine_détaillée",
+
     case
         when candidatures.temps_de_prise_en_compte <= 30 then '30 jours ou moins'
         when candidatures.temps_de_prise_en_compte > 30 and candidatures.temps_de_prise_en_compte <= 45 then '31 à 45 jours'
@@ -24,6 +52,7 @@ select
         when candidatures.temps_de_prise_en_compte > 60 and candidatures.temps_de_prise_en_compte <= 90 then '61 à 90 jours'
         when candidatures.temps_de_prise_en_compte > 90 then 'Plus de 90 jours'
     end                                                 as temps_de_prise_en_compte_intervalle,
+
     case
         when candidatures.temps_de_reponse <= 30 then '30 jours ou moins'
         when candidatures.temps_de_reponse > 30 and candidatures.temps_de_reponse <= 45 then '31 à 45 jours'
@@ -31,13 +60,14 @@ select
         when candidatures.temps_de_reponse > 60 and candidatures.temps_de_reponse <= 90 then '61 à 90 jours'
         when candidatures.temps_de_reponse > 90 then 'Plus de 90 jours'
     end                                                 as temps_de_reponse_intervalle,
+
     coalesce(candidats.tranche_age, 'Non renseigné')    as tranche_age,
     coalesce(candidats.sexe_selon_nir, 'Non renseigné') as genre_candidat
 
 from {{ ref('stg_candidatures') }} as candidatures
+
 left join {{ ref('candidats') }} as candidats
     on candidatures.id_candidat = candidats.id
-left join {{ ref('organisations') }} as orga
-    on candidatures.id_org_prescripteur = orga.id
+
 left join {{ source('emplois','c1_ref_type_prescripteur') }} as org
     on candidatures.type_org_prescripteur = org.code

--- a/dbt/models/staging/stg_candidatures.sql
+++ b/dbt/models/staging/stg_candidatures.sql
@@ -1,37 +1,82 @@
 select
     {{ pilo_star(source('emplois', 'candidatures'),
-        except=["date_mise_à_jour_metabase", "état", "motif_de_refus", "origine", "origine_détaillée", "candidature_archivee", "type_contrat"], relation_alias='candidatures') }},
+        except=[
+            "date_mise_à_jour_metabase",
+            "état",
+            "motif_de_refus",
+            "origine",
+            "origine_détaillée",
+            "candidature_archivee",
+            "type_contrat",
+
+            "département_structure",
+            "nom_département_structure",
+            "région_structure"
+        ],
+        relation_alias='candidatures'
+    ) }},
+
     {{ pilo_star(ref('stg_organisations'),
-        except=["id", "date_mise_à_jour_metabase", "ville", "code_commune", "type", "date_inscription", "total_candidatures", "total_membres", "total_embauches", "date_dernière_candidature"], relation_alias='org_prescripteur') }},
+        except=[
+            "id",
+            "date_mise_à_jour_metabase",
+            "ville",
+            "code_commune",
+            "type",
+            "date_inscription",
+            "total_candidatures",
+            "total_membres",
+            "total_embauches",
+            "date_dernière_candidature"
+        ],
+        relation_alias='org_prescripteur'
+    ) }},
+
     c_type.label                                           as type_contrat_candidature,
+
+    -- géographie structure depuis stg_structures, donc depuis dim_commune
+    struct."département"                                   as "département_structure",
+    struct."nom_département"                               as "nom_département_structure",
+    struct."région"                                        as "région_structure",
     struct.nom_epci_structure,
     struct.bassin_d_emploi                                 as bassin_emploi_structure,
+
+    -- géographie prescripteur depuis stg_organisations
     org_prescripteur.zone_emploi                           as bassin_emploi_prescripteur,
+    org_prescripteur.code_commune                          as code_commune_prescripteur,
+    org_prescripteur.ville                                 as ville_prescripteur,
+
     org_prescripteur.type                                  as type_org_prescripteur,
     org_prescripteur.date_inscription                      as date_inscription_orga,
     grp_strct.groupe                                       as categorie_structure,
     struct.structure_convergence,
+
     case
         when candidatures."état" = 'Candidature déclinée' then 'Candidature refusée'
         else candidatures."état"
     end                                                    as "état",
+
     case
         when candidatures.origine_id_structure != candidatures.id_structure
             then 'Employeur orienteur'
         else candidatures.origine
     end                                                    as origine,
+
     case
         when candidatures."origine_détaillée" = 'Prescripteur habilité Autre'
             then 'Prescripteur habilité par habilitation préfectorale'
         else candidatures."origine_détaillée"
     end                                                    as "origine_détaillée",
+
     case
         when candidatures.candidature_archivee = 1 then 'Candidatures archivées'
         else 'Candidatures non archivées'
     end                                                    as candidature_archivee,
+
     extract(day from candidatures."délai_de_réponse")      as temps_de_reponse,
     extract(day from candidatures."délai_prise_en_compte") as temps_de_prise_en_compte,
     extract(year from candidatures.date_candidature)       as annee_candidature,
+
     case
         when motif.label = 'Autre'
             then 'Autre (la SIAE a saisi le motif "autre")'
@@ -40,14 +85,18 @@ select
 
 from
     {{ source('emplois', 'candidatures') }} as candidatures
+
 left join {{ source('emplois', 'c1_ref_type_contrat') }} as c_type
     on candidatures.type_contrat = c_type.code
+
 left join {{ source('emplois', 'c1_ref_motif_de_refus') }} as motif
     on candidatures.motif_de_refus = motif.code
+
 left join {{ ref('stg_structures') }} as struct
     on candidatures.id_structure = struct.id
+
 left join {{ ref('stg_organisations') }} as org_prescripteur
     on candidatures.id_org_prescripteur = org_prescripteur.id
-left join
-    {{ ref('groupes_structures') }} as grp_strct
+
+left join {{ ref('groupes_structures') }} as grp_strct
     on candidatures.type_structure = grp_strct.structure

--- a/dbt/models/staging/stg_organisations.sql
+++ b/dbt/models/staging/stg_organisations.sql
@@ -1,45 +1,60 @@
 select
     {{ pilo_star(source('emplois', 'organisations_v0'),
-                 except = ['siret', 'nom_département', 'type_complet', 'ville', 'code_commune', 'région', 'nom_département'],
+                 except = ['siret', 'nom_département', 'type_complet', 'ville', 'code_commune', 'région'],
                  relation_alias = "organisations") }},
+
     -- récupérer la ville insee si le croisement insee a bien pu se faire
     -- pour les 492 villes restantes, récupérer la ville des emplois
     organisations."nom_département",
-    organisations.siret                                                  as siret_org_prescripteur,
-    organisations."nom_département"                                      as dept_org,
-    organisations."département"                                          as "num_département_org",
-    -- les deux colonnes suivantes sont en doublons le temps de vérifier les branchements de filtre sur metabase
-    organisations."région"                                               as "région_org",
-    organisations."région",
-    /*bien mettre nom département et pas département */
-    dim_commune.nom_departement                                          as "nom_département_insee",
+    organisations.siret                                             as siret_org_prescripteur,
+    organisations."nom_département"                                 as dept_org,
+    organisations."département"                                     as "num_département_org",
+
+    -- région_org conserve la valeur source historique.
+    -- région est recalculée depuis dim_commune et doit être utilisée comme référence géographique.
+    organisations."région"                                          as "région_org",
+    dim_commune.nom_region                                          as "région",
+
+    -- nom_département_insee est recalculé depuis dim_commune
+    -- et doit être utilisé comme référence géographique.
+    dim_commune.nom_departement                                     as "nom_département_insee",
+    dim_commune.nom_departement_complet,
     dim_commune.nom_arrondissement,
-    dim_commune.nom_zone_emploi                                          as zone_emploi,
-    dim_commune.nom_epci                                                 as epci,
-    organisations_libelles.label                                         as type_complet,
-    organisations_libelles.code                                          as type_org,
-    coalesce(dim_commune.nom_commune, initcap(organisations.ville))      as ville,
-    coalesce(organisations.code_commune, dim_commune.code_commune_insee) as code_commune,
+    dim_commune.nom_zone_emploi                                     as zone_emploi,
+    dim_commune.nom_epci                                            as epci,
+
+    organisations_libelles.label                                    as type_complet,
+    organisations_libelles.code                                     as type_org,
+
+    organisations.code_commune,
+    coalesce(dim_commune.nom_commune, initcap(organisations.ville)) as ville,
+
     case
         when organisations.type in ('ML', 'FT', 'CAP_EMPLOI') then 'SPE'
         when organisations.type in ('DEPT', 'ODC') then 'Département'
         when organisations.type = 'Autre' then 'Autre'
         else 'Nouveaux prescripteurs'
-    end                                                                  as type_prescripteur,
+    end                                                             as type_prescripteur,
+
     case
         when organisations."habilitée" = 1 then 'Prescripteur habilité'
         when organisations."habilitée" = 0 then 'Orienteur'
-    end                                                                  as habilitation,
+    end                                                             as habilitation,
+
     case
         when organisations."habilitée" = 1 then concat('Prescripteur habilité ', organisations.type)
         when organisations."habilitée" = 0 then concat('Orienteur ', organisations.type)
-    end                                                                  as type_avec_habilitation,
+    end                                                             as type_avec_habilitation,
+
     case
         when organisations."habilitée" = 1 then concat('Prescripteur habilité ', organisations.type_complet)
         when organisations."habilitée" = 0 then concat('Orienteur ', organisations.type_complet)
-    end                                                                  as type_complet_avec_habilitation
+    end                                                             as type_complet_avec_habilitation
+
 from {{ source('emplois', 'organisations_v0') }} as organisations
+
 left join {{ source('emplois','c1_ref_type_prescripteur') }} as organisations_libelles
     on organisations.type = organisations_libelles.code
+
 left join {{ ref('dim_commune') }}
     on organisations.code_commune = dim_commune.code_commune_insee

--- a/dbt/models/staging/stg_structures.sql
+++ b/dbt/models/staging/stg_structures.sql
@@ -2,23 +2,31 @@ select
     s.id,
     s.id_asp,
     s.nom,
-    s.type                      as type_struct,
+    s.type                                     as type_struct,
     s.siret,
     s.active,
-    s.ville,
-    s."département",
-    s."nom_département",
-    s."région",
-    s.nom_epci_structure,
-    dim_commune.code_commune_insee,
-    dim_commune.nom_zone_emploi as bassin_d_emploi,
-    s.nom_complet               as nom_structure_complet,
+
+    s.code_commune,
+    dim_commune.code_departement_insee         as "département",
+
+    dim_commune.nom_departement                as "nom_département",
+    dim_commune.nom_departement_complet,
+    dim_commune.nom_region                     as "région",
+    dim_commune.nom_arrondissement,
+    dim_commune.nom_epci                       as nom_epci_structure,
+    dim_commune.nom_zone_emploi                as bassin_d_emploi,
+    s.nom_complet                              as nom_structure_complet,
+
+    coalesce(dim_commune.nom_commune, s.ville) as ville,
+
     case
         when s.convergence_france = 1 then 'Oui'
         else 'Non'
-    end                         as structure_convergence
+    end                                        as structure_convergence
+
 from
     {{ ref('structures') }} as s
+
 left join
     {{ ref('dim_commune') }}
     on s.code_commune = dim_commune.code_commune_insee


### PR DESCRIPTION
**Carte Notion : ** (non nécessaire si `label=hotfix`)
https://notion.so/p/gip-inclusion/Bug-donn-es-geoloc-3725f321b6048096b50becb94fcf79ef?source=copy_link

### Pourquoi ?

Cette PR clarifie les colonnes géographiques utilisées dans `candidatures_echelle_locale`.

Aujourd'hui, ce modèle récupère beaucoup de colonnes via `pilo_star`. Certaines informations géographiques existent donc plusieurs fois, avec des noms différents. Ça rend l'utilisation dans Metabase assez confuse.

Je n'ai pas supprimé les anciennes colonnes, car `candidatures_echelle_locale` est utilisé par plusieurs modèles en aval. Les supprimer maintenant pourrait casser des modèles ou des questions Metabase existantes.

Ce que fait cette PR :

- elle utilise `dim_commune` comme source de référence pour les informations géographiques ;
- elle fait venir la géographie du prescripteur depuis `stg_organisations` ;
- elle fait venir la géographie de la structure depuis `stg_structures` ;
- elle garde les anciennes colonnes pour compatibilité ;
- elle ajoute de nouvelles colonnes plus explicites dans `candidatures_echelle_locale`.

Les nouvelles colonnes à utiliser dans Metabase sont les suivantes.

Pour le prescripteur :

- `prescripteur_code_commune`
- `prescripteur_ville`
- `prescripteur_region`
- `prescripteur_nom_departement`
- `prescripteur_departement`
- `prescripteur_arrondissement`
- `prescripteur_zone_emploi`
- `prescripteur_epci`

Pour la structure :

- `structure_code_departement`
- `structure_nom_departement`
- `structure_region`
- `structure_epci`
- `structure_bassin_emploi`

Les anciennes colonnes restent disponibles, mais elles ne devraient plus être utilisées pour les nouvelles questions Metabase. Je vais remplacer également les colonnes dans le dashboard d'Alice avec celles-ci

### Checks

- [x] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

