### PR TITLE
Index pour les tables Autometa

### DIFF
--- a/dags/populate_matometa_database.py
+++ b/dags/populate_matometa_database.py
@@ -6,6 +6,7 @@ import logging
 from airflow import DAG
 from airflow.decorators import task
 from airflow.models import Variable
+from sqlalchemy import text
 
 from dags.common import db, dbt, default_dag_args, slack
 
@@ -54,9 +55,79 @@ TABLES_DORA = [
 
 COLS_TO_ANONYMIZE = ["hash_nir", "hash_numéro_pass_iae"]
 
+# Columns frequently used in WHERE/JOIN clauses by autometa's agent (tables are rebuilt
+# daily by `if_exists="replace"`, so indexes must be recreated after each load).
+INDEXES = {
+    "candidats": [("id",), ("département",)],
+    "candidatures_echelle_locale": [
+        ("id_candidat",),
+        ("id_structure",),
+        ("id_org_prescripteur",),
+        ("date_candidature",),
+        ("état",),
+        ("département_structure",),
+    ],
+    "fiches_de_poste_par_candidature": [("id_candidature",), ("id_fiche_de_poste",)],
+    "structures": [("id",), ("département",), ("type",), ("siret",)],
+    "prolongations": [("id_pass_agrément",)],
+    "organisations": [("id",), ("département",), ("type",)],
+    "utilisateurs": [("id",), ("type",)],
+    "pass_agréments": [("id",), ("id_candidat",), ("id_structure",), ("date_début",), ("date_fin",)],
+    "suspensions_pass": [("id_pass_agrément",)],
+    "suivi_auto_prescription": [
+        ("id_candidat",),
+        ("id_structure",),
+        ("date_candidature",),
+        ("département_structure",),
+    ],
+    "fluxIAE_Structure_v2": [("structure_id_siae",)],
+    "suivi_realisation_convention_par_structure": [("id_annexe_financiere",), ("structure_id_siae",), ("annee_af",)],
+    "suivi_realisation_convention_mensuelle": [("id_annexe_financiere",), ("structure_id_siae",), ("annee_af",)],
+    "suivi_etp_conventionnes_v2": [("id_annexe_financiere",), ("structure_id_siae",), ("annee_af",)],
+    "fluxIAE_ContratMission_v2": [
+        ("contrat_id_ctr",),
+        ("contrat_id_pph",),
+        ("contrat_id_structure",),
+        ("contrat_date_embauche",),
+    ],
+    "fluxIAE_Salarie_v2": [("salarie_id",)],
+    "Commandes": [("département",)],
+    "structures_v1": [("id",), ("source",), ("siret",), ("code_postal",)],
+    "services_v1": [("id",), ("structure_id",), ("source",)],
+    "pdi_base_unique_tous_les_pros": [("email",), ("source",), ("departement_structure",)],
+    "structures_structure": [("id",), ("department",), ("siret",)],
+    "structures_structuremember": [("user_id",), ("structure_id",)],
+    "services_service": [("id",), ("structure_id",), ("status",)],
+    "services_service_categories": [("service_id",), ("servicecategory_id",)],
+    "orientations_orientation": [("id",), ("service_id",), ("prescriber_structure_id",), ("creation_date",)],
+    "users_user": [("id",), ("email",)],
+    "stats_searchview": [("date",), ("department",), ("user_kind",)],
+    "stats_serviceview": [("date",), ("structure_department",), ("user_kind",), ("service_id",), ("structure_id",)],
+    "stats_mobilisationevent": [("date",), ("structure_department",), ("user_kind",), ("service_id",)],
+    "stats_structureinfosview": [("date",), ("structure_department",), ("structure_id",)],
+    "stats_structureview": [("date",), ("structure_department",), ("user_kind",), ("structure_id",)],
+}
+
 
 def get_hmac_secret():
     return Variable.get("MATOMETA_HMAC_SECRET").encode()
+
+
+def index_statements(table, schema):
+    statements = []
+    for columns in INDEXES.get(table, ()):
+        # PostgreSQL truncates identifiers above 63 bytes; slicing keeps the name stable for IF NOT EXISTS.
+        name = f"idx_{table}_{'_'.join(columns)}"[:63]
+        cols = ", ".join(f'"{col}"' for col in columns)
+        statements.append(f'CREATE INDEX IF NOT EXISTS "{name}" ON "{schema}"."{table}" ({cols})')
+    return statements
+
+
+def create_indexes(dst_db, table, schema):
+    with dst_db.engine.begin() as conn:
+        for statement in index_statements(table, schema):
+            conn.execute(text(statement))
+        conn.execute(text(f'ANALYZE "{schema}"."{table}"'))
 
 
 def sync_tables(table_names, src_schema, dest_schema, from_db=None):
@@ -66,6 +137,7 @@ def sync_tables(table_names, src_schema, dest_schema, from_db=None):
         for table in table_names:
             query = f'SELECT * FROM "{src_schema}"."{table}";'
 
+            loaded = False
             for i, chunk in enumerate(from_db.query_chunked(query)):
                 if len(chunk) == 0:
                     logger.error("Empty chunk for table %s at index %d, aborting.", table, i)
@@ -85,8 +157,13 @@ def sync_tables(table_names, src_schema, dest_schema, from_db=None):
                         logger.info("Anonymized column %s in table %s.", col, table)
 
                 dst_db.to_sql(chunk, table=table, schema=dest_schema, if_exists="replace" if i == 0 else "append")
+                loaded = True
                 logger.info("Exported %d rows to %s.%s", len(chunk), dest_schema, table)
                 del chunk
+
+            if loaded:
+                create_indexes(dst_db, table, dest_schema)
+                logger.info("Created indexes and refreshed statistics for %s.%s", dest_schema, table)
 
 
 with DAG("populate_matometa_db", schedule="@daily", **dag_args) as dag:

--- a/tests/test_populate_matometa_database.py
+++ b/tests/test_populate_matometa_database.py
@@ -1,0 +1,43 @@
+import json
+import pathlib
+
+import pytest
+
+
+@pytest.fixture
+def matometa_dag(monkeypatch):
+    for var in json.loads(pathlib.Path("dag-variables.json").read_text()):
+        monkeypatch.setenv(f"AIRFLOW_VAR_{var}", "dummy")
+    from dags import populate_matometa_database
+
+    return populate_matometa_database
+
+
+def test_index_statements(matometa_dag):
+    assert matometa_dag.index_statements("suspensions_pass", "les_emplois") == [
+        'CREATE INDEX IF NOT EXISTS "idx_suspensions_pass_id_pass_agrément"'
+        ' ON "les_emplois"."suspensions_pass" ("id_pass_agrément")',
+    ]
+
+
+def test_index_statements_unknown_table(matometa_dag):
+    assert matometa_dag.index_statements("barometre", "monrecap") == []
+
+
+def test_index_statements_name_truncation(matometa_dag):
+    statements = matometa_dag.index_statements("suivi_realisation_convention_par_structure", "asp")
+    for statement in statements:
+        name = statement.split('"')[1]
+        assert len(name) <= 63
+
+
+def test_indexes_only_reference_synced_tables(matometa_dag):
+    synced = set(
+        matometa_dag.TABLES_EMPLOI
+        + matometa_dag.TABLES_ASP
+        + matometa_dag.TABLES_MONRECAP
+        + matometa_dag.TABLES_DI
+        + matometa_dag.TABLES_DATALAKE
+        + matometa_dag.TABLES_DORA
+    )
+    assert set(matometa_dag.INDEXES) <= synced


### PR DESCRIPTION
[Carte Notion](https://notion.so/p/gip-inclusion/Ajouter-un-index-la-BDD-donn-es-37b5f321b60480508923fecddbb74190?v=30a5f321b604804e8d2a000c7207266b&source=copy_link).

### Pourquoi ?

Certaines conversations Autometa prennent, littéralement, plus de 30 minutes pour calculer des stats.

### Checks

> JE SAIS PAS QUOI FAIRE DE ÇA 🔽

- [x] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

