### PR TITLE
Prise en compte des données calendaires dans les tables Autometa

### DIFF
--- a/dags/common/db.py
+++ b/dags/common/db.py
@@ -1,3 +1,4 @@
+import datetime
 import io
 import textwrap
 from contextlib import closing
@@ -96,6 +97,16 @@ class MetabaseDatabaseCursor3:
             self.connection.close()
 
 
+def date_column_types(df):
+    # pandas reads DATE columns as object dtype, which to_sql() maps to TEXT; map them back to DATE.
+    types = {}
+    for col in df.select_dtypes(include=["object"]):
+        values = df[col].dropna()
+        if not values.empty and type(values.iloc[0]) is datetime.date:
+            types[col] = sqlalchemy.Date()
+    return types
+
+
 class DBConnection:
     def __init__(self, db_url_variable, ssh_conn_id=None):
         self.db_url_variable = db_url_variable
@@ -132,14 +143,15 @@ class DBConnection:
         with self.engine.connect() as conn:
             yield from pd.read_sql_query(query, conn, chunksize=chunksize)
 
-    def to_sql(self, df, table, schema, if_exists="replace"):
+    def to_sql(self, df, table, schema, if_exists="replace", infer_dates=False):
         df = df.convert_dtypes(convert_string=False, convert_floating=False)
         for col in df.select_dtypes(include=["timedelta64"]):
             df[col] = df[col].astype("int64")
 
         if if_exists == "replace":
+            dtype = date_column_types(df) or None if infer_dates else None
             with self.engine.begin() as conn:
-                df.head(0).to_sql(name=table, con=conn, schema=schema, if_exists="replace", index=False)
+                df.head(0).to_sql(name=table, con=conn, schema=schema, if_exists="replace", index=False, dtype=dtype)
 
         with closing(self.engine.raw_connection()) as raw_conn:
             with raw_conn.cursor() as cur:

--- a/dags/populate_matometa_database.py
+++ b/dags/populate_matometa_database.py
@@ -156,7 +156,13 @@ def sync_tables(table_names, src_schema, dest_schema, from_db=None):
                         )
                         logger.info("Anonymized column %s in table %s.", col, table)
 
-                dst_db.to_sql(chunk, table=table, schema=dest_schema, if_exists="replace" if i == 0 else "append")
+                dst_db.to_sql(
+                    chunk,
+                    table=table,
+                    schema=dest_schema,
+                    if_exists="replace" if i == 0 else "append",
+                    infer_dates=True,
+                )
                 loaded = True
                 logger.info("Exported %d rows to %s.%s", len(chunk), dest_schema, table)
                 del chunk

--- a/tests/test_common_db.py
+++ b/tests/test_common_db.py
@@ -1,4 +1,26 @@
+import datetime
+
+import pandas as pd
+import sqlalchemy
+
 from dags.common import db
+
+
+def test_date_column_types():
+    df = pd.DataFrame(
+        {
+            "date_col": [datetime.date(2026, 1, 1), None],
+            "text_col": ["a", "b"],
+            "int_col": [1, 2],
+            "timestamp_col": pd.to_datetime(["2026-01-01", "2026-01-02"]),
+            "empty_col": [None, None],
+        }
+    )
+
+    types = db.date_column_types(df)
+
+    assert list(types) == ["date_col"]
+    assert isinstance(types["date_col"], sqlalchemy.Date)
 
 
 def test_connection_envvars(monkeypatch):


### PR DESCRIPTION
**[Carte Notion](https://notion.so/p/gip-inclusion/Ajouter-un-index-la-BDD-donn-es-37b5f321b60480508923fecddbb74190?v=30a5f321b604804e8d2a000c7207266b&source=copy_link)**

### Pourquoi ?

Les dates sont stockées format texte (ISO 8601), on gagnerait des choses à utiliser des colonnes date (ne serait que parce que les agents Autometa font comme si c'était des colonnes dates à la base).

### Checks

- [x] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

