### PR TITLE
[Tech] Ajouter automatiquement des index à toutes nos tables

### DIFF
--- a/dbt/macros/index_join_keys.sql
+++ b/dbt/macros/index_join_keys.sql
@@ -1,0 +1,16 @@
+{% macro index_join_keys() %}
+  {% if execute and model.config.materialized == 'table' %}
+    {#- extra columns indexed manually because they don't match the id pattern -#}
+    {%- set extra = ['hash_nir', 'finess_num', 'code_commune_insee',
+                     'code_commune_parente', 'code_rome'] -%}
+    {#- `this` is a dbt built-in: the model being built -#}
+    {%- for col in adapter.get_columns_in_relation(this) -%}
+      {%- set n = col.name | lower -%}
+      {%- if 'id' in n.split('_') or n in extra %}
+        {#- 63 = psql's identifier-length limit -#}
+        {%- set idx = (this.identifier ~ '_' ~ n ~ '_idx') | truncate(63, true, '') %}
+        create index if not exists "{{ idx }}" on {{ this }} ("{{ col.name }}");
+      {%- endif -%}
+    {%- endfor -%}
+  {% endif %}
+{% endmacro %}

--- a/dbt/models/indexed/contrats_sorties.sql
+++ b/dbt/models/indexed/contrats_sorties.sql
@@ -1,13 +1,3 @@
-{{ config(
-    materialized = 'table',
-    indexes=[
-      {'columns': ['emi_pph_id'], 'type' : 'btree', 'unique' : False},
-      {'columns': ['emi_ctr_id'], 'type' : 'btree', 'unique' : False},
-      {'columns': ['emi_afi_id'], 'type' : 'btree', 'unique' : False},
-    ]
- ) }}
-
-
 select distinct
     emi.emi_pph_id,
     emi.emi_afi_id,

--- a/dbt/models/indexed/corresp_af_contrats.sql
+++ b/dbt/models/indexed/corresp_af_contrats.sql
@@ -1,5 +1,4 @@
 {{ config(
-    materialized = 'table',
     indexes=[
       {'columns': ['contrat_id_ctr', 'contrat_id_pph'], 'type' : 'btree', 'unique' : False},
     ]

--- a/dbt/models/indexed/fluxIAE_ContratMission_v2.sql
+++ b/dbt/models/indexed/fluxIAE_ContratMission_v2.sql
@@ -1,10 +1,3 @@
-{{ config(
-    materialized = 'table',
-    indexes=[
-      {'columns': ['contrat_id_ctr'], 'type' : 'btree', 'unique' : False},
-    ]
- ) }}
-
 select
     {{ pilo_star(source('fluxIAE', 'fluxIAE_ContratMission'), except=['contrat_date_embauche', "contrat_date_fin_contrat"]) }},
     to_date(ctr.contrat_date_embauche, 'DD/MM/YYYY')    as contrat_date_embauche,

--- a/dbt/models/indexed/fluxIAE_EtatMensuelIndiv_v2.sql
+++ b/dbt/models/indexed/fluxIAE_EtatMensuelIndiv_v2.sql
@@ -1,12 +1,3 @@
-{{ config(
-    indexes=[
-      {'columns': ['emi_pph_id'], 'unique' : False},
-      {'columns': ['emi_afi_id'], 'unique' : False},
-      {'columns': ['emi_ctr_id'], 'unique' : False},
-      {'columns': ['emi_motif_sortie_id'], 'unique' : False},
-    ]
- ) }}
-
 select
     {{ pilo_star(source('fluxIAE', 'fluxIAE_EtatMensuelIndiv'), relation_alias='emi') }},
     to_date(concat('01-', emi.emi_sme_mois, '-', emi.emi_sme_annee), 'DD-MM-YYYY') as date_emi

--- a/dbt/models/indexed/fluxIAE_MarchesPublics_v2.sql
+++ b/dbt/models/indexed/fluxIAE_MarchesPublics_v2.sql
@@ -1,10 +1,3 @@
-{{ config(
-    materialized = 'table',
-    indexes=[
-      {'columns': ['mpu_af_id'], 'type' : 'btree', 'unique' : False},
-    ]
- ) }}
-
 with ranked_data as (
     select
         mpu_af_id,

--- a/dbt/models/indexed/fluxIAE_RefCategorieSort_v2.sql
+++ b/dbt/models/indexed/fluxIAE_RefCategorieSort_v2.sql
@@ -1,10 +1,3 @@
-{{ config(
-    materialized = 'table',
-    indexes=[
-      {'columns': ['rcs_id'], 'type' : 'btree', 'unique' : False},
-    ]
- ) }}
-
 select
     {{ pilo_star(source('fluxIAE', 'fluxIAE_RefCategorieSort')) }}
 from

--- a/dbt/models/indexed/fluxIAE_RefMotifSort_v2.sql
+++ b/dbt/models/indexed/fluxIAE_RefMotifSort_v2.sql
@@ -1,11 +1,3 @@
-{{ config(
-    materialized = 'table',
-    indexes=[
-      {'columns': ['rms_id'], 'type' : 'btree', 'unique' : False},
-      {'columns': ['rcs_id'], 'type' : 'btree', 'unique' : False},
-    ]
- ) }}
-
 select
     {{ pilo_star(source('fluxIAE', 'fluxIAE_RefMotifSort')) }}
 from

--- a/dbt/models/indexed/fluxIAE_Salarie_v2.sql
+++ b/dbt/models/indexed/fluxIAE_Salarie_v2.sql
@@ -1,10 +1,3 @@
-{{ config(
-    materialized = 'table',
-    indexes=[
-      {'columns': ['salarie_id'], 'type' : 'btree', 'unique' : False},
-    ]
- ) }}
-
 select distinct
     {{ pilo_star(source('fluxIAE', 'fluxIAE_Salarie'), except=["hash_numéro_pass_iae", "nir_chiffré"]) }},
     case

--- a/dbt/models/indexed/fluxIAE_Structure_v2.sql
+++ b/dbt/models/indexed/fluxIAE_Structure_v2.sql
@@ -1,10 +1,3 @@
-{{ config(
-    materialized = 'table',
-    indexes=[
-      {'columns': ['structure_id_siae'], 'type' : 'btree', 'unique' : False},
-    ]
- ) }}
-
 select distinct -- parfois l'ASP introduit des doublons, ici les élimine
     -- l'ASP préconise l'utilisation de l'adresse administrative pour récupérer la commune de la structure
     {{ pilo_star(source('fluxIAE', 'fluxIAE_Structure')) }},

--- a/dbt/models/indexed/heures_ai_etti.sql
+++ b/dbt/models/indexed/heures_ai_etti.sql
@@ -1,12 +1,3 @@
-{{ config(
-    materialized = 'table',
-    indexes=[
-      {'columns': ['emi_pph_id'], 'type' : 'btree', 'unique' : False},
-      {'columns': ['emi_ctr_id'], 'type' : 'btree', 'unique' : False},
-      {'columns': ['emi_afi_id'], 'type' : 'btree', 'unique' : False},
-    ]
- ) }}
-
 select
     {{ pilo_star(ref('etat_mensuel_heures_travaillees_sorties'), relation_alias='ems') }},
     {{ pilo_star(ref('motif_sorties_salaries'), relation_alias='sorties') }}

--- a/dbt/models/indexed/motif_sorties_salaries.sql
+++ b/dbt/models/indexed/motif_sorties_salaries.sql
@@ -1,12 +1,3 @@
-{{ config(
-    materialized = 'table',
-    indexes=[
-      {'columns': ['sorties_pph_id'], 'type' : 'btree', 'unique' : False},
-      {'columns': ['sorties_afi_id'], 'type' : 'btree', 'unique' : False},
-      {'columns': ['sorties_ctr_id'], 'type' : 'btree', 'unique' : False},
-    ]
- ) }}
-
 select distinct
     emi.emi_pph_id as sorties_pph_id,
     emi.emi_afi_id as sorties_afi_id,

--- a/dbt/models/indexed/sorties_v2.sql
+++ b/dbt/models/indexed/sorties_v2.sql
@@ -1,7 +1,5 @@
 {{ config(
-    materialized = 'table',
     indexes=[
-      {'columns': ['emi_pph_id'], 'unique' : False},
       {'columns': ['af_numero_annexe_financiere'], 'unique' : False},
     ]
  ) }}

--- a/dbt/models/legacy/weekly/fluxIAE_AnnexeFinanciere_v2.sql
+++ b/dbt/models/legacy/weekly/fluxIAE_AnnexeFinanciere_v2.sql
@@ -9,12 +9,7 @@ L'objectif est de retravailler les variables de la table fluxIAE_AnnexeFinancier
 
 */
 
- {{ config(
-    materialized = 'table',
-    indexes=[
-      {'columns': ['af_id_annexe_financiere'], 'type' : 'btree', 'unique' : False},
-    ]
- ) }}
+{{ config(materialized = 'table') }}
 
 with "AnnexeFinanciere_v1" as (
     select

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -33,14 +33,23 @@ models:
       +materialized: ephemeral
     indexed:
       +materialized: table
+      +post-hook: ["{{ index_join_keys() }}"]
     legacy:
       +materialized: table
+      +post-hook: ["{{ index_join_keys() }}"]
     marts:
       +schema: public
+      +materialized: table
+      +post-hook: ["{{ index_join_keys() }}"]
+    data_inclusion:
+      +schema: data_inclusion
+    reporting:
+      +schema: reporting
       +materialized: table
     intermediate:
       +schema: intermediate
       +materialized: table
+      +post-hook: ["{{ index_join_keys() }}"]
     staging:
       +schema: staging
       +materialized: view
@@ -48,6 +57,7 @@ models:
       +schema: monrecap
       marts:
         +materialized: table
+        +post-hook: ["{{ index_join_keys() }}"]
       staging:
         +materialized: view
     reporting:


### PR DESCRIPTION
**Carte Notion : ** (non nécessaire si `label=hotfix`) https://app.notion.com/p/gip-inclusion/Rajouter-des-index-aux-mod-les-dbt-pr-sents-dans-autometa_db-37b5f321b604802bb47fe868b083b620?source=copy_link

### Pourquoi ?

Ajouter automatique des index à toutes nos tables dès qu'elles contiennent les caractères `id` + ajout manuel de certaines colonnes.

Cela va améliorer les perfs de notre dbt + lorsqu'on branchera autometa à la db pilotage ça aidera au bon fonctionnement des requêtes  

### Checks

- [ ] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

