### PR TITLE
fix:pad departments in fagerh answers to easier join with dim_commune

### DIFF
--- a/dbt/models/staging/stg_fagerh__reponses.sql
+++ b/dbt/models/staging/stg_fagerh__reponses.sql
@@ -305,7 +305,11 @@ renamed as (
         {{ clean_integer('entree_sans_emploi_plus2ans__espo') }} as entree_sans_emploi_plus2ans__espo,
         {{ clean_integer('entree_sans_emploi_plus2ans__esrp') }} as entree_sans_emploi_plus2ans__esrp,
         {{ clean_integer('entree_sans_emploi_plus2ans__ueros') }} as entree_sans_emploi_plus2ans__ueros,
-        {{ clean_text('es_departement') }} as es_departement,
+        case
+            when {{ clean_text('es_departement') }} ~ '^[0-9]$'
+                then lpad({{ clean_text('es_departement') }}, 2, '0')
+            else upper({{ clean_text('es_departement') }})
+        end as es_departement,
         {{ clean_text('es_nom') }} as es_nom,
         {{ clean_text('finess_json') }} as finess_json,
         {{ clean_text('finess_main') }} as finess_main,


### PR DESCRIPTION
**Carte Notion : ** (non nécessaire si `label=hotfix`)
https://app.notion.com/p/gip-inclusion/FAGERH-Cr-ation-du-DAG-et-des-mod-les-n-cessaires-pour-traiter-les-r-ponses-au-questionnaire-37a5f321b60480ab9177f52b7410e13c?source=copy_link

### Pourquoi ?
Les départements 1, 2, 3, etc. ne font pas correctement la jointure avec `dim_commune`. J'ajoute donc un 0 devant pour que ce soit bien normalisé.


### Checks

- [x] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

