### PR TITLE
[Bug] Ajout d'une colonne numéro de dpt 

### DIFF
--- a/dbt/models/marts/daily/candidatures_echelle_locale.sql
+++ b/dbt/models/marts/daily/candidatures_echelle_locale.sql
@@ -21,6 +21,7 @@ select
     candidatures.code_commune_prescripteur              as prescripteur_code_commune,
     candidatures.ville_prescripteur                     as prescripteur_ville,
     candidatures."région"                               as prescripteur_region,
+    candidatures.numero_departement_insee               as prescripteur_numero_departement,
     candidatures."nom_département_insee"                as prescripteur_nom_departement,
     candidatures.nom_departement_complet                as prescripteur_departement,
     candidatures.nom_arrondissement                     as prescripteur_arrondissement,

--- a/dbt/models/staging/stg_organisations.sql
+++ b/dbt/models/staging/stg_organisations.sql
@@ -17,6 +17,7 @@ select
 
     -- nom_département_insee est recalculé depuis dim_commune
     -- et doit être utilisé comme référence géographique.
+    dim_commune.code_departement_insee                              as numero_departement_insee,
     dim_commune.nom_departement                                     as "nom_département_insee",
     dim_commune.nom_departement_complet,
     dim_commune.nom_arrondissement,


### PR DESCRIPTION
**Carte Notion : ** (non nécessaire si `label=hotfix`)

### Pourquoi ?

Certains TBs privés ont besoin d'un numero de departement en input afin d'avoir une vue personnalisée fonctionnelle.
Ajout de cette colonne.

### Checks

- [ ] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

