### PR TITLE
remove duplicates from offer/demand

### DIFF
--- a/dbt/models/intermediate/data_inclusion/int_thematiques_clpe.sql
+++ b/dbt/models/intermediate/data_inclusion/int_thematiques_clpe.sql
@@ -1,7 +1,7 @@
 with thematiques_per_service as (
     select
-        id                                                                                                        as id_service,
-        code_insee,
+        services.id                                                                                               as id_service,
+        services.code_insee,
         max(case when thematique_principale like '%numerique%' then 1 else 0 end)                                 as numerique_thematique,
         max(case when thematique_principale like '%logement-hebergement%' then 1 else 0 end)                      as logement_hebergement_thematique,
         max(case when thematique_principale like '%sante%' then 1 else 0 end)                                     as sante_thematique,
@@ -10,12 +10,14 @@ with thematiques_per_service as (
         max(case when thematique_principale like '%famille%' then 1 else 0 end)                                   as famille_thematique,
         max(case when thematique_principale like '%difficultes_administratives_ou_juridiques%' then 1 else 0 end) as difficultes_administratives_ou_juridiques_thematique,
         max(case when thematique_principale like '%difficultes_financieres%' then 1 else 0 end)                   as difficultes_financieres_thematique
-    from {{ ref('stg_di__services') }},
-        unnest(thematiques) as thematique_principale
-    where thematiques is not null
+    from {{ ref('stg_di__services') }} as services
+    inner join {{ ref('stg_di__structures_deduplicated') }} as structure
+        on services.structure_id = structure.id,
+        unnest(services.thematiques) as thematique_principale
+    where services.thematiques is not null
     group by
-        id,
-        code_insee
+        services.id,
+        services.code_insee
 )
 
 select


### PR DESCRIPTION
**Carte Notion : ** https://notion.so/p/gip-inclusion/Backlog-commun-Yannick-s-version-28b5f321b60480b8977ff7dcfe7e7b1b?p=36f5f321b604802db57fd7a0e3a054fe&pm=s&assetsVersion=23.13.20260610.0244

### Pourquoi ?

Retirer les services associés aux structures dédoublonnées dans le script de l'offre insertion

J'ai fermé cette PR car il y avait énormément de conflits à gérer https://github.com/gip-inclusion/pilotage-airflow/pull/659 et j'ai décidé de juste `cherry-pick` le dernier commit qui m'intéressait.


### Checks

- [ ] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

