### PR TITLE
add dag and dbt models to get matomo data for actes metiers dashboard

### DIFF
--- a/dags/actes_metier_matomo.py
+++ b/dags/actes_metier_matomo.py
@@ -8,6 +8,9 @@ from airflow.operators import bash
 from dags.common import db, dbt, default_dag_args, matomo, slack
 
 
+# Valeurs reprises des scripts actes_metier de Pierre : site et segments Matomo
+# utilisés pour compter les visites des pages de résultats de recherche Emplois,
+# avec la dimension personnalisée 4 pour le drill down par département
 ID_SITE_EMPLOIS = matomo.PROJECTS_SITE_ID["emplois"]
 EMPLOYERS_RESULTS_SEGMENT = "pageUrl=@/search/employers/results"
 SERVICES_RESULTS_SEGMENT = "pageUrl=@/search/services/results"
@@ -93,6 +96,54 @@ def closed_months_to_fetch(months_to_fetch=MONTHS_TO_FETCH):
     return [first_month.add(months=i).date() for i in range(months_to_fetch)]
 
 
+def fetch_actes_metier_matomo_data_for_site(
+    matomo_base_url,
+    token,
+    site_id,
+    monthly_segments,
+    department_segment,
+    department_dimension_id,
+    months,
+    fetched_at,
+):
+    monthly_visits = []
+    department_visits = []
+
+    for month in months:
+        monthly_visits.extend(
+            {
+                "month": month,
+                "id_site": site_id,
+                "segment": segment,
+                "nb_visits": matomo.get_monthly_visits(matomo_base_url, token, site_id, segment, month),
+                "fetched_at": fetched_at,
+            }
+            for segment in monthly_segments
+        )
+
+        department_visits.extend(
+            {
+                "month": month,
+                "id_site": site_id,
+                "segment": department_segment,
+                "dimension_id": department_dimension_id,
+                "department_label": row["department_label"],
+                "nb_visits": row["nb_visits"],
+                "fetched_at": fetched_at,
+            }
+            for row in matomo.get_monthly_custom_dimension_visits(
+                matomo_base_url,
+                token,
+                site_id,
+                department_segment,
+                month,
+                department_dimension_id,
+            )
+        )
+
+    return monthly_visits, department_visits
+
+
 with DAG(
     "actes_metier_matomo",
     schedule="@monthly",
@@ -106,40 +157,16 @@ with DAG(
         token = Variable.get("MATOMO_ACTES_METIER_TOKEN")
         fetched_at = pendulum.now("UTC").naive()
 
-        monthly_visits = []
-        department_visits = []
-
-        for month in closed_months_to_fetch():
-            monthly_visits.extend(
-                {
-                    "month": month,
-                    "id_site": ID_SITE_EMPLOIS,
-                    "segment": segment,
-                    "nb_visits": matomo.get_monthly_visits(matomo_base_url, token, ID_SITE_EMPLOIS, segment, month),
-                    "fetched_at": fetched_at,
-                }
-                for segment in (EMPLOYERS_RESULTS_SEGMENT, SERVICES_RESULTS_SEGMENT)
-            )
-
-            department_visits.extend(
-                {
-                    "month": month,
-                    "id_site": ID_SITE_EMPLOIS,
-                    "segment": EMPLOYERS_RESULTS_SEGMENT,
-                    "dimension_id": DEPARTMENT_DIMENSION_ID,
-                    "department_label": row["department_label"],
-                    "nb_visits": row["nb_visits"],
-                    "fetched_at": fetched_at,
-                }
-                for row in matomo.get_monthly_custom_dimension_visits(
-                    matomo_base_url,
-                    token,
-                    ID_SITE_EMPLOIS,
-                    EMPLOYERS_RESULTS_SEGMENT,
-                    month,
-                    DEPARTMENT_DIMENSION_ID,
-                )
-            )
+        monthly_visits, department_visits = fetch_actes_metier_matomo_data_for_site(
+            matomo_base_url,
+            token,
+            site_id=ID_SITE_EMPLOIS,
+            monthly_segments=(EMPLOYERS_RESULTS_SEGMENT, SERVICES_RESULTS_SEGMENT),
+            department_segment=EMPLOYERS_RESULTS_SEGMENT,
+            department_dimension_id=DEPARTMENT_DIMENSION_ID,
+            months=closed_months_to_fetch(),
+            fetched_at=fetched_at,
+        )
 
         with db.connection_engine().begin() as conn:
             conn.execute(sqlalchemy.text(CREATE_TABLES_SQL))

--- a/dags/actes_metier_matomo.py
+++ b/dags/actes_metier_matomo.py
@@ -1,0 +1,173 @@
+import pendulum
+import sqlalchemy
+from airflow import DAG
+from airflow.decorators import task
+from airflow.models import Variable
+from airflow.operators import bash
+
+from dags.common import db, dbt, default_dag_args, matomo, slack
+
+
+ID_SITE_EMPLOIS = matomo.PROJECTS_SITE_ID["emplois"]
+EMPLOYERS_RESULTS_SEGMENT = "pageUrl=@/search/employers/results"
+SERVICES_RESULTS_SEGMENT = "pageUrl=@/search/services/results"
+DEPARTMENT_DIMENSION_ID = 4
+MONTHS_TO_FETCH = 14
+
+dag_args = default_dag_args() | {"default_args": dbt.get_default_args()}
+
+
+CREATE_TABLES_SQL = """
+
+CREATE TABLE IF NOT EXISTS raw.matomo__actes_metier_matomo_monthly_visits (
+    month DATE NOT NULL,
+    id_site INTEGER NOT NULL,
+    segment TEXT NOT NULL,
+    nb_visits INTEGER NOT NULL,
+    fetched_at TIMESTAMP NOT NULL,
+    PRIMARY KEY (month, id_site, segment)
+);
+
+CREATE TABLE IF NOT EXISTS raw.matomo__actes_metier_matomo_monthly_department_visits (
+    month DATE NOT NULL,
+    id_site INTEGER NOT NULL,
+    segment TEXT NOT NULL,
+    dimension_id INTEGER NOT NULL,
+    department_label TEXT NOT NULL,
+    nb_visits INTEGER NOT NULL,
+    fetched_at TIMESTAMP NOT NULL,
+    PRIMARY KEY (month, id_site, segment, dimension_id, department_label)
+);
+"""
+
+UPSERT_MONTHLY_VISITS_SQL = """
+INSERT INTO raw.matomo__actes_metier_matomo_monthly_visits (
+    month,
+    id_site,
+    segment,
+    nb_visits,
+    fetched_at
+)
+VALUES (
+    :month,
+    :id_site,
+    :segment,
+    :nb_visits,
+    :fetched_at
+)
+ON CONFLICT (month, id_site, segment)
+DO UPDATE SET
+    nb_visits = EXCLUDED.nb_visits,
+    fetched_at = EXCLUDED.fetched_at;
+"""
+
+UPSERT_DEPARTMENT_VISITS_SQL = """
+INSERT INTO raw.matomo__actes_metier_matomo_monthly_department_visits (
+    month,
+    id_site,
+    segment,
+    dimension_id,
+    department_label,
+    nb_visits,
+    fetched_at
+)
+VALUES (
+    :month,
+    :id_site,
+    :segment,
+    :dimension_id,
+    :department_label,
+    :nb_visits,
+    :fetched_at
+)
+ON CONFLICT (month, id_site, segment, dimension_id, department_label)
+DO UPDATE SET
+    nb_visits = EXCLUDED.nb_visits,
+    fetched_at = EXCLUDED.fetched_at;
+"""
+
+
+def closed_months_to_fetch(months_to_fetch=MONTHS_TO_FETCH):
+    last_closed_month = pendulum.now("Europe/Paris").start_of("month").subtract(months=1)
+    first_month = last_closed_month.subtract(months=months_to_fetch - 1)
+    return [first_month.add(months=i).date() for i in range(months_to_fetch)]
+
+
+with DAG(
+    "actes_metier_matomo",
+    schedule="@monthly",
+    **dag_args,
+) as dag:
+    env_vars = db.connection_envvars()
+
+    @task
+    def fetch_actes_metier_matomo_data():
+        matomo_base_url = Variable.get("MATOMO_BASE_URL")
+        token = Variable.get("MATOMO_ACTES_METIER_TOKEN")
+        fetched_at = pendulum.now("UTC").naive()
+
+        monthly_visits = []
+        department_visits = []
+
+        for month in closed_months_to_fetch():
+            monthly_visits.extend(
+                {
+                    "month": month,
+                    "id_site": ID_SITE_EMPLOIS,
+                    "segment": segment,
+                    "nb_visits": matomo.get_monthly_visits(matomo_base_url, token, ID_SITE_EMPLOIS, segment, month),
+                    "fetched_at": fetched_at,
+                }
+                for segment in (EMPLOYERS_RESULTS_SEGMENT, SERVICES_RESULTS_SEGMENT)
+            )
+
+            department_visits.extend(
+                {
+                    "month": month,
+                    "id_site": ID_SITE_EMPLOIS,
+                    "segment": EMPLOYERS_RESULTS_SEGMENT,
+                    "dimension_id": DEPARTMENT_DIMENSION_ID,
+                    "department_label": row["department_label"],
+                    "nb_visits": row["nb_visits"],
+                    "fetched_at": fetched_at,
+                }
+                for row in matomo.get_monthly_custom_dimension_visits(
+                    matomo_base_url,
+                    token,
+                    ID_SITE_EMPLOIS,
+                    EMPLOYERS_RESULTS_SEGMENT,
+                    month,
+                    DEPARTMENT_DIMENSION_ID,
+                )
+            )
+
+        with db.connection_engine().begin() as conn:
+            conn.execute(sqlalchemy.text(CREATE_TABLES_SQL))
+            conn.execute(sqlalchemy.text(UPSERT_MONTHLY_VISITS_SQL), monthly_visits)
+            if department_visits:
+                conn.execute(sqlalchemy.text(UPSERT_DEPARTMENT_VISITS_SQL), department_visits)
+
+    dbt_debug = bash.BashOperator(
+        task_id="dbt_debug",
+        bash_command="dbt debug",
+        env=env_vars,
+        append_env=True,
+    )
+
+    dbt_deps = bash.BashOperator(
+        task_id="dbt_deps",
+        bash_command="dbt deps",
+        env=env_vars,
+        append_env=True,
+    )
+
+    dbt_build = bash.BashOperator(
+        task_id="dbt_build",
+        bash_command='dbt build --select "+tag:matomo-actes-metier"',
+        env=env_vars,
+        append_env=True,
+    )
+
+    fetched = fetch_actes_metier_matomo_data()
+
+    fetched >> dbt_debug >> dbt_deps >> dbt_build >> slack.success_notifying_task()

--- a/dags/common/matomo.py
+++ b/dags/common/matomo.py
@@ -52,6 +52,10 @@ def _to_int(value):
     return int(float(value))
 
 
+def _format_custom_dimension_visit(row):
+    return {"department_label": row.get("label") or "", "nb_visits": _to_int(row.get("nb_visits"))}
+
+
 def get_monthly_visits(matomo_base_url, token, site_id, segment, month):
     data = _request_matomo_api(
         matomo_base_url,
@@ -80,7 +84,7 @@ def get_monthly_custom_dimension_visits(matomo_base_url, token, site_id, segment
     if isinstance(data, dict):
         data = data.get("subtable") or data.get("reportData") or []
 
-    return [{"department_label": row.get("label") or "", "nb_visits": _to_int(row.get("nb_visits"))} for row in data]
+    return [_format_custom_dimension_visit(row) for row in data]
 
 
 def get_visits_per_campaign_from_matomo(matomo_base_url, token):

--- a/dags/common/matomo.py
+++ b/dags/common/matomo.py
@@ -17,6 +17,72 @@ PROJECTS_SITE_ID = {
 }
 
 
+def _raise_for_matomo_error(data):
+    if isinstance(data, dict) and data.get("result") == "error":
+        raise RuntimeError(f"Matomo API error: {data.get('message')}")
+
+
+def _request_matomo_api(matomo_base_url, token, method, **params):
+    response = requests.get(
+        matomo_base_url,
+        headers={"Accept": "application/json"},
+        params={
+            "module": "API",
+            "method": method,
+            "format": "json",
+            "token_auth": token,
+            **params,
+        },
+        timeout=60,
+    )
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as e:
+        logger.error("HTTP error: %s", str(e).replace(token, "[TOKEN]"))
+        raise
+
+    data = response.json()
+    _raise_for_matomo_error(data)
+    return data
+
+
+def _to_int(value):
+    if value in (None, ""):
+        return 0
+    return int(float(value))
+
+
+def get_monthly_visits(matomo_base_url, token, site_id, segment, month):
+    data = _request_matomo_api(
+        matomo_base_url,
+        token,
+        "VisitsSummary.get",
+        idSite=site_id,
+        period="month",
+        date=month.strftime("%Y-%m-%d"),
+        segment=segment,
+    )
+    return _to_int(data.get("nb_visits"))
+
+
+def get_monthly_custom_dimension_visits(matomo_base_url, token, site_id, segment, month, dimension_id):
+    data = _request_matomo_api(
+        matomo_base_url,
+        token,
+        "CustomDimensions.getCustomDimension",
+        idSite=site_id,
+        period="month",
+        date=month.strftime("%Y-%m-%d"),
+        segment=segment,
+        idDimension=dimension_id,
+        filter_limit=-1,
+    )
+    if isinstance(data, dict):
+        data = data.get("subtable") or data.get("reportData") or []
+
+    return [{"department_label": row.get("label") or "", "nb_visits": _to_int(row.get("nb_visits"))} for row in data]
+
+
 def get_visits_per_campaign_from_matomo(matomo_base_url, token):
     """
     creates a dataframe composed of all visits for all c0 campaigns and all gip products

--- a/dags/properties.yml
+++ b/dags/properties.yml
@@ -13,6 +13,10 @@ models:
     description: >
       Ce DAG permet de récupérer (de manière hebdomadaire) pour chaque campagne matomo du c0 et chaque produit du gip les visiteurs et leurs actions.
       Mise à disposition de cette table sur metabase pour les statistiques internes du c0.
+  - name: actes_metier_matomo
+    description: >
+      Ce DAG recupere depuis Matomo les visites mensuelles des pages de recherche Emplois necessaires aux actes metier,
+      sur les 14 derniers mois fermes. Il alimente les tables raw utilisees par dbt pour calculer les actes metier Matomo.
   - name: monrecap
     description: >
       Ce DAG permet de récupérer de manière quotidienne les données de contacts & commandes sur le airtable de monrecap.

--- a/dbt/models/_sources.yml
+++ b/dbt/models/_sources.yml
@@ -405,6 +405,18 @@ sources:
         description: >
           Table générée par une tâche périodique côté Les Emplois de l'Inclusion et qui permet de remonter les
           visites sur les tableaux de bord publics du Pilotage.
+
+  - name: raw_matomo
+    schema: raw
+    description: >
+      Tables brutes Matomo ingerees par les DAGs du pilotage.
+    tables:
+      - name: matomo__actes_metier_matomo_monthly_visits
+        description: >
+          Visites mensuelles Matomo des pages de recherche Emplois necessaires aux actes metier.
+      - name: matomo__actes_metier_matomo_monthly_department_visits
+        description: >
+          Repartition par dimension personnalisee departement des visites mensuelles Matomo de la recherche d'offres d'emploi.
   - name: monrecap
     schema: monrecap
     description: >

--- a/dbt/models/intermediate/int_matomo__actes_metier.sql
+++ b/dbt/models/intermediate/int_matomo__actes_metier.sql
@@ -1,0 +1,137 @@
+with monthly_visits as (
+    select *
+    from {{ ref('stg_matomo__monthly_visits') }}
+),
+
+department_visits as (
+    select
+        mois,
+        id_site,
+        segment,
+        departement,
+        sum(nb_visits) as department_nb_visits
+    from {{ ref('stg_matomo__monthly_department_visits') }}
+    group by
+        mois,
+        id_site,
+        segment,
+        departement
+),
+
+employer_totals as (
+    select
+        mois,
+        id_site,
+        segment,
+        nb_visits as total_nb_visits
+    from monthly_visits
+    where segment = 'pageUrl=@/search/employers/results'
+),
+
+employer_department_weights as (
+    select
+        employer_totals.mois,
+        employer_totals.id_site,
+        employer_totals.segment,
+        employer_totals.total_nb_visits,
+        department_visits.departement,
+        department_visits.department_nb_visits,
+        sum(department_visits.department_nb_visits) over (
+            partition by employer_totals.mois, employer_totals.id_site, employer_totals.segment
+        ) as total_department_nb_visits
+    from employer_totals
+    inner join department_visits
+        on
+            employer_totals.mois = department_visits.mois
+            and employer_totals.id_site = department_visits.id_site
+            and employer_totals.segment = department_visits.segment
+),
+
+employer_department_allocations as (
+    select
+        mois,
+        id_site,
+        segment,
+        departement,
+        floor(total_nb_visits * department_nb_visits::numeric / nullif(total_department_nb_visits, 0))::integer
+            as nombre_actes
+    from employer_department_weights
+    where total_department_nb_visits > 0
+),
+
+employer_residual as (
+    select
+        employer_totals.mois,
+        employer_totals.id_site,
+        employer_totals.segment,
+        'Inconnu'                                                                                        as departement,
+        employer_totals.total_nb_visits - coalesce(sum(employer_department_allocations.nombre_actes), 0)
+            as nombre_actes
+    from employer_totals
+    left join employer_department_allocations
+        on
+            employer_totals.mois = employer_department_allocations.mois
+            and employer_totals.id_site = employer_department_allocations.id_site
+            and employer_totals.segment = employer_department_allocations.segment
+    group by
+        employer_totals.mois,
+        employer_totals.id_site,
+        employer_totals.segment,
+        employer_totals.total_nb_visits
+),
+
+employer_actes as (
+    select
+        mois,
+        'emplois'                    as source,
+        'Recherche d’offre d’emploi' as type_acte,
+        'Support'                    as categorie_acte,
+        false                        as north_star,
+        false                        as north_star_70,
+        false                        as traite,
+        'Inconnu'                    as type_structure,
+        departement,
+        nombre_actes
+    from employer_department_allocations
+
+    union all
+
+    select
+        mois,
+        'emplois'                    as source,
+        'Recherche d’offre d’emploi' as type_acte,
+        'Support'                    as categorie_acte,
+        false                        as north_star,
+        false                        as north_star_70,
+        false                        as traite,
+        'Inconnu'                    as type_structure,
+        departement,
+        nombre_actes
+    from employer_residual
+),
+
+service_actes as (
+    select
+        mois,
+        'emplois'                                             as source,
+        'Recherche d’offre de service, hors emploi solidaire' as type_acte,
+        'Support'                                             as categorie_acte,
+        false                                                 as north_star,
+        false                                                 as north_star_70,
+        false                                                 as traite,
+        'Inconnu'                                             as type_structure,
+        'Inconnu'                                             as departement,
+        nb_visits                                             as nombre_actes
+    from monthly_visits
+    where segment = 'pageUrl=@/search/services/results'
+)
+
+select *
+from employer_actes
+where nombre_actes > 0
+
+union all
+
+select *
+from service_actes
+where nombre_actes > 0

--- a/dbt/models/intermediate/properties.yml
+++ b/dbt/models/intermediate/properties.yml
@@ -215,3 +215,21 @@ models:
         description: >
           Nombre de codes postaux distincts associés à la commune.
 
+  - name: int_matomo__actes_metier
+    description: >
+      Reproduction en dbt de la logique Matomo des actes metier Emplois bases sur les recherches.
+
+      **ATTENTION : ce modèle réplique directement la logique qui existait sur Autometa pour le tableau de bord des actes métier.
+      Il est possible que cette modélisation soit revue. Si tu es en train de t'en servir pour quelque chose, vérifie d'abord
+      avec l'équipe data.**
+
+    config:
+      tags: ["matomo-actes-metier"]
+
+    columns:
+      - name: nombre_actes
+        tests:
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+

--- a/dbt/models/marts/matomo__actes_metier.sql
+++ b/dbt/models/marts/matomo__actes_metier.sql
@@ -1,0 +1,23 @@
+select
+    mois,
+    source,
+    type_acte,
+    categorie_acte,
+    north_star,
+    north_star_70,
+    traite,
+    type_structure,
+    departement,
+    sum(nombre_actes)::integer as nombre_actes
+from
+    {{ ref('int_matomo__actes_metier') }}
+group by
+    mois,
+    source,
+    type_acte,
+    categorie_acte,
+    north_star,
+    north_star_70,
+    traite,
+    type_structure,
+    departement

--- a/dbt/models/marts/properties.yml
+++ b/dbt/models/marts/properties.yml
@@ -130,12 +130,18 @@ models:
               - departement
     columns:
       - name: mois
+        description: >
+          Mois des visites Matomo agrégées.
         tests:
           - not_null
       - name: source
+        description: >
+          Produit auquel l'acte métier est rattaché. Pour ce modèle Matomo, la valeur est toujours `emplois`.
         tests:
           - not_null
       - name: type_acte
+        description: >
+          Type d'acte métier reconstruit à partir des visites Matomo.
         tests:
           - not_null
           - accepted_values:
@@ -143,21 +149,48 @@ models:
                 values:
                   - "Recherche d’offre d’emploi"
                   - "Recherche d’offre de service, hors emploi solidaire"
+      - name: categorie_acte
+        description: >
+          Catégorie métier de l'acte. Pour les actes Matomo de recherche, la valeur est toujours `Support`.
+        tests:
+          - not_null
       - name: nombre_actes
+        description: >
+          Nombre de visites Matomo interprété comme nombre d'actes métier. Pour les recherches d'offres d'emploi,
+          le total Matomo est decomposé par département ; pour les recherches de services, le total reste rattaché
+          au département `Inconnu`.
         tests:
           - not_null
           - dbt_utils.accepted_range:
               arguments:
                 min_value: 0
       - name: north_star
+        description: >
+          Indique si l'acte est comptabilisé dans la déclinaison North Star du référentiel des actes métier PDI.
+          Pour les actes Matomo de recherche, cette valeur est toujours `false`.
         tests:
           - not_null
       - name: north_star_70
+        description: >
+          Variante héritée du modèle commun des actes métier. Non applicable aux actes Matomo de recherche,
+          donc toujours `false`.
+        tests:
+          - not_null
+      - name: traite
+        description: >
+          Indicateur hérité du modèle commun des actes métier pour les actes traités. Non applicable aux visites
+          Matomo de recherche, donc toujours `false`.
         tests:
           - not_null
       - name: type_structure
+        description: >
+          Type de structure associé à l'acte métier. Cette information n'est pas disponible dans les données
+          Matomo utilisées ici, donc la valeur est toujours `Inconnu`.
         tests:
           - not_null
       - name: departement
+        description: >
+          Département associé à la recherche d'offre d'emploi lorsque la dimension personnalisée Matomo le permet.
+          La valeur est `Inconnu` quand le département n'est pas disponible ou pour les recherches de services.
         tests:
           - not_null

--- a/dbt/models/marts/properties.yml
+++ b/dbt/models/marts/properties.yml
@@ -106,3 +106,58 @@ models:
         description: >
           Score de qualité de la fiche structure dans Data Inclusion.
 
+  - name: matomo__actes_metier
+    description: >
+      Table finale reutilisable des actes metier Emplois calcules depuis Matomo.
+
+      **ATTENTION : ce modèle réplique directement la logique qui existait sur Autometa pour le tableau de bord des actes métier.
+      Il est possible que cette modélisation soit revue. Si tu es en train de t'en servir pour quelque chose, vérifie d'abord
+      avec l'équipe data.**
+
+    config:
+      tags: ["matomo-actes-metier"]
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - mois
+              - source
+              - type_acte
+              - north_star
+              - north_star_70
+              - type_structure
+              - departement
+    columns:
+      - name: mois
+        tests:
+          - not_null
+      - name: source
+        tests:
+          - not_null
+      - name: type_acte
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - "Recherche d’offre d’emploi"
+                  - "Recherche d’offre de service, hors emploi solidaire"
+      - name: nombre_actes
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+      - name: north_star
+        tests:
+          - not_null
+      - name: north_star_70
+        tests:
+          - not_null
+      - name: type_structure
+        tests:
+          - not_null
+      - name: departement
+        tests:
+          - not_null

--- a/dbt/models/staging/matomo/stg_matomo__monthly_department_visits.sql
+++ b/dbt/models/staging/matomo/stg_matomo__monthly_department_visits.sql
@@ -1,0 +1,32 @@
+with source as (
+    select
+        month::date                                                                as mois,
+        id_site::integer                                                           as id_site,
+        segment::text                                                              as segment,
+        dimension_id::integer                                                      as dimension_id,
+        department_label::text                                                     as department_label,
+        nb_visits::integer                                                         as nb_visits,
+        fetched_at,
+        upper(trim(regexp_replace(coalesce(department_label, ''), '\s*-.*$', ''))) as department_code
+    from {{ source('raw_matomo', 'matomo__actes_metier_matomo_monthly_department_visits') }}
+)
+
+select
+    mois,
+    id_site,
+    segment,
+    dimension_id,
+    department_label,
+    nb_visits,
+    fetched_at,
+    case
+        when nullif(department_code, '') is null then 'Inconnu'
+        when department_code in ('2A', '2B') then department_code
+        when department_code ~ '^[0-9]+$' and department_code::integer between 1 and 95
+            then lpad(department_code::integer::text, 2, '0')
+        when department_code ~ '^[0-9]+$' and department_code::integer between 971 and 976
+            then department_code::integer::text
+        else 'Inconnu'
+    end as departement
+from
+    source

--- a/dbt/models/staging/matomo/stg_matomo__monthly_visits.sql
+++ b/dbt/models/staging/matomo/stg_matomo__monthly_visits.sql
@@ -1,0 +1,7 @@
+select
+    month::date        as mois,
+    id_site::integer   as id_site,
+    segment::text      as segment,
+    nb_visits::integer as nb_visits,
+    fetched_at
+from {{ source('raw_matomo', 'matomo__actes_metier_matomo_monthly_visits') }}

--- a/dbt/models/staging/matomo/stg_matomo__properties.yml
+++ b/dbt/models/staging/matomo/stg_matomo__properties.yml
@@ -1,0 +1,42 @@
+version: 2
+
+models:
+  - name: stg_matomo__monthly_visits
+    description: >
+      Normalisation des visites mensuelles Matomo des recherches Emplois necessaires aux actes metier.
+
+      **ATTENTION : ce modèle réplique directement la logique qui existait sur Autometa pour le tableau de bord des actes métier.
+      Il est possible que cette modélisation soit revue. Si tu es en train de t'en servir pour quelque chose, vérifie d'abord
+      avec l'équipe data.**
+
+    config:
+      tags: ["matomo-actes-metier"]
+
+
+    columns:
+      - name: mois
+        tests:
+          - not_null
+      - name: nb_visits
+        tests:
+          - not_null
+
+  - name: stg_matomo__monthly_department_visits
+    description: >
+      Normalisation de la dimension departement Matomo pour la recherche d'offres d'emploi.
+
+      **ATTENTION : ce modèle réplique directement la logique qui existait sur Autometa pour le tableau de bord des actes métier.
+      Il est possible que cette modélisation soit revue. Si tu es en train de t'en servir pour quelque chose, vérifie d'abord
+      avec l'équipe data.**
+
+    config:
+      tags: ["matomo-actes-metier"]
+
+
+    columns:
+      - name: mois
+        tests:
+          - not_null
+      - name: departement
+        tests:
+          - not_null

--- a/dbt/tests/test_actes_metier_matomo_employers_total.sql
+++ b/dbt/tests/test_actes_metier_matomo_employers_total.sql
@@ -1,0 +1,25 @@
+with final as (
+    select
+        mois,
+        sum(nombre_actes) as nombre_actes
+    from {{ ref('matomo__actes_metier') }}
+    where type_acte = 'Recherche d’offre d’emploi'
+    group by mois
+),
+
+raw as (
+    select
+        mois,
+        nb_visits as nombre_actes
+    from {{ ref('stg_matomo__monthly_visits') }}
+    where segment = 'pageUrl=@/search/employers/results'
+)
+
+select
+    coalesce(final.mois, raw.mois)  as mois,
+    coalesce(final.nombre_actes, 0) as final_nombre_actes,
+    coalesce(raw.nombre_actes, 0)   as raw_nombre_actes
+from final
+full outer join raw
+    on final.mois = raw.mois
+where coalesce(final.nombre_actes, 0) != coalesce(raw.nombre_actes, 0)

--- a/dbt/tests/test_actes_metier_matomo_services_total.sql
+++ b/dbt/tests/test_actes_metier_matomo_services_total.sql
@@ -1,0 +1,25 @@
+with final as (
+    select
+        mois,
+        sum(nombre_actes) as nombre_actes
+    from {{ ref('matomo__actes_metier') }}
+    where type_acte = 'Recherche d’offre de service, hors emploi solidaire'
+    group by mois
+),
+
+raw as (
+    select
+        mois,
+        nb_visits as nombre_actes
+    from {{ ref('stg_matomo__monthly_visits') }}
+    where segment = 'pageUrl=@/search/services/results'
+)
+
+select
+    coalesce(final.mois, raw.mois)  as mois,
+    coalesce(final.nombre_actes, 0) as final_nombre_actes,
+    coalesce(raw.nombre_actes, 0)   as raw_nombre_actes
+from final
+full outer join raw
+    on final.mois = raw.mois
+where coalesce(final.nombre_actes, 0) != coalesce(raw.nombre_actes, 0)

--- a/dbt/tests/test_int_di__structure_mapping_source_structure_count.sql.sql
+++ b/dbt/tests/test_int_di__structure_mapping_source_structure_count.sql.sql
@@ -1,15 +1,13 @@
 with mapping as (
 
-    select
-        count(distinct source_structure_id) as source_structure_id_count
-    from {{ ref('int_di__structure_mapping') }}
+    select count(distinct source_structure_id) as source_structure_id_count
+    from {{ ref('int_di__structure_source_mapping') }}
 
 ),
 
 structures as (
 
-    select
-        count(distinct id) as structure_id_count
+    select count(distinct id) as structure_id_count
     from {{ ref('stg_di__structures') }}
 
 )


### PR DESCRIPTION
**Carte Notion : ** (non nécessaire si `label=hotfix`)
https://app.notion.com/p/gip-inclusion/Cr-ation-d-un-DAG-et-des-mod-les-associ-s-pour-r-cup-rer-les-donn-es-Matomo-n-cessaires-au-tableau-d-3975f321b60480acbd9bdf6a32238929?source=copy_link

### Pourquoi ?
Pour pouvoir répliquer le tableau de bord des actes métier dans dbt, il manque encore les données Matomo des Emplois. Cette PR ajoute leur ingestion et les premiers modèles dbt nécessaires pour les exploiter.

Ces modèles risquent d'évoluer avec le temps, car je n'ai fait que répliquer la logique déjà existante sur Autometa, sans la remettre en question. Je l'ai également signalé dans la documentation pour éviter qu'ils ne soient réutilisés à l'aveugle.

**EDIT**
**La CI compilait un test dbt existant qui référençait encore l’ancien modèle int_di__structure_mapping. La référence a été corrigée vers int_di__structure_source_mapping dans un commit séparé.**

### Checks

- [x] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

