### PR TITLE
add rdvi models for actes metier dashboard

### DIFF
--- a/dags/sync_rdvi_db.py
+++ b/dags/sync_rdvi_db.py
@@ -5,8 +5,9 @@ from pathlib import Path
 
 from airflow import DAG
 from airflow.decorators import task
+from airflow.operators import bash
 
-from dags.common import db, default_dag_args
+from dags.common import db, dbt, default_dag_args
 
 
 DAG_ID = "sync_rdvi_raw_schema"
@@ -15,6 +16,8 @@ SOURCE_SCHEMA = "rdvi"
 TARGET_SCHEMA = "raw_rdvi"
 
 LOCAL_TMP_ROOT = Path("/tmp") / DAG_ID
+
+dag_args = default_dag_args() | {"default_args": dbt.get_default_args()}
 
 
 def run_command(command_name, command, env=None):
@@ -49,8 +52,9 @@ ALTER SCHEMA "{SOURCE_SCHEMA}" RENAME TO "{TARGET_SCHEMA}";
 with DAG(
     dag_id=DAG_ID,
     schedule="0 5 * * *",
-    **default_dag_args(),
+    **dag_args,
 ) as dag:
+    env_vars = db.connection_envvars()
 
     @task
     def refresh_raw_schema(**context):
@@ -106,4 +110,27 @@ with DAG(
             shutil.rmtree(base_tmp, ignore_errors=True)
             print("END cleanup_tmp_files")
 
-    refresh_raw_schema()
+    dbt_debug = bash.BashOperator(
+        task_id="dbt_debug",
+        bash_command="dbt debug",
+        env=env_vars,
+        append_env=True,
+    )
+
+    dbt_deps = bash.BashOperator(
+        task_id="dbt_deps",
+        bash_command="dbt deps",
+        env=env_vars,
+        append_env=True,
+    )
+
+    dbt_build = bash.BashOperator(
+        task_id="dbt_build",
+        bash_command='dbt build --select "+tag:rdv-insertion"',
+        env=env_vars,
+        append_env=True,
+    )
+
+    refreshed = refresh_raw_schema()
+
+    refreshed >> dbt_debug >> dbt_deps >> dbt_build

--- a/dbt/models/_sources.yml
+++ b/dbt/models/_sources.yml
@@ -1028,9 +1028,10 @@ sources:
           - name: clicked
             description: >
               Indique si l'usager a cliqué sur le lien.
-          - name: trigger
+          - name: origin
             description: >
-              Déclencheur de l'invitation. Valeurs possibles : manual, reminder.
+              Origine de l'invitation. Valeurs possibles : legacy_triggered_by_agent,
+              legacy_triggered_by_periodic_job, reminder, user_list_upload.
           - name: delivery_status
             description: >
               Statut de livraison de l'invitation.

--- a/dbt/models/intermediate/rdvi/int_rdvi__actes_metiers.sql
+++ b/dbt/models/intermediate/rdvi/int_rdvi__actes_metiers.sql
@@ -1,0 +1,178 @@
+with invitations as (
+
+    select *
+    from {{ ref('stg_rdvi__invitations') }}
+
+),
+
+invitations_organisations as (
+
+    select *
+    from {{ ref('stg_rdvi__invitations_organisations') }}
+
+),
+
+organisations as (
+
+    select *
+    from {{ ref('stg_rdvi__organisations') }}
+
+),
+
+follow_ups as (
+
+    select *
+    from {{ ref('stg_rdvi__follow_ups') }}
+
+),
+
+participations as (
+
+    select *
+    from {{ ref('stg_rdvi__participations') }}
+
+),
+
+rdvs as (
+
+    select *
+    from {{ ref('stg_rdvi__rdvs') }}
+
+),
+
+motif_categories as (
+
+    select *
+    from {{ ref('stg_rdvi__motif_categories') }}
+
+),
+
+departments as (
+
+    select *
+    from {{ ref('stg_rdvi__departments') }}
+
+),
+
+inv_org as (
+
+    select distinct on (invitations_organisations.invitation_id)
+        invitations_organisations.invitation_id,
+        organisations.organisation_type
+    from invitations_organisations
+    inner join organisations
+        on invitations_organisations.organisation_id = organisations.id
+    order by
+        invitations_organisations.invitation_id,
+        organisations.organisation_type nulls last
+
+),
+
+rdvi_invitations as (
+
+    select
+        motif_categories.motif_category_type,
+        to_char(date_trunc('month', invitations.created_at), 'yyyy-mm')         as mois,
+        coalesce(inv_org.organisation_type, 'autre')                            as organisation_type,
+        coalesce(departments.number, 'Inconnu')                                 as raw_departement,
+        count(distinct invitations.id)                                          as nb_invitations,
+        count(distinct case when rdvs.uuid is not null then invitations.id end) as nb_with_rdv
+    from invitations
+    left join follow_ups
+        on invitations.follow_up_id = follow_ups.id
+    left join participations
+        on invitations.follow_up_id = participations.follow_up_id
+    left join rdvs
+        on participations.rdv_id = rdvs.id
+    left join motif_categories
+        on follow_ups.motif_category_id = motif_categories.id
+    left join inv_org
+        on invitations.id = inv_org.invitation_id
+    left join departments
+        on invitations.department_id = departments.id
+    where
+        invitations.created_at >= date_trunc('month', current_date) - interval '14 months'
+        and invitations.created_at < date_trunc('month', current_date)
+    group by
+        motif_categories.motif_category_type,
+        to_char(date_trunc('month', invitations.created_at), 'yyyy-mm'),
+        coalesce(inv_org.organisation_type, 'autre'),
+        coalesce(departments.number, 'Inconnu')
+
+),
+
+mapped_invitations as (
+
+    select
+        mois,
+        nb_invitations,
+        nb_with_rdv,
+        case motif_category_type
+            when 'rsa_orientation' then 'Invitation à un RDV d’orientation'
+            when 'rsa_accompagnement' then 'Invitation à un RDV d’accompagnement'
+            when 'siae' then 'Invitation à un Entretien SIAE'
+            when 'autre' then 'Invitation à un Autre RDV'
+            else motif_category_type
+        end                          as type_acte,
+        case organisation_type
+            when 'france_travail' then 'FRANCE_TRAVAIL'
+            when 'delegataire_rsa' then 'DELEGATAIRE_RSA'
+            when 'conseil_departemental' then 'CONSEIL_DEPARTEMENTAL'
+            when 'siae' then 'SIAE'
+            else 'Autre'
+        end                          as type_structure,
+        case
+            when raw_departement is null or trim(raw_departement) = '' then 'Inconnu'
+            when upper(split_part(trim(raw_departement), ' - ', 1)) in ('2A', '2B')
+                then upper(split_part(trim(raw_departement), ' - ', 1))
+            when
+                split_part(trim(raw_departement), ' - ', 1) ~ '^[0-9]+$'
+                and split_part(trim(raw_departement), ' - ', 1)::integer between 1 and 95
+                then lpad(split_part(trim(raw_departement), ' - ', 1), 2, '0')
+            when
+                split_part(trim(raw_departement), ' - ', 1) ~ '^[0-9]+$'
+                and split_part(trim(raw_departement), ' - ', 1)::integer between 971 and 976
+                then split_part(trim(raw_departement), ' - ', 1)
+            else 'Inconnu'
+        end                          as departement,
+        nb_invitations - nb_with_rdv as nb_without_rdv
+    from rdvi_invitations
+
+),
+
+actes_metiers as (
+
+    select
+        mois,
+        'rdvi'               as source,
+        type_acte,
+        'Accompagnement'     as categorie_acte,
+        true                 as north_star,
+        true                 as north_star_70,
+        true                 as traite,
+        type_structure,
+        departement,
+        nb_with_rdv::integer as nombre_actes
+    from mapped_invitations
+    where nb_with_rdv > 0
+
+    union all
+
+    select
+        mois,
+        'rdvi'                  as source,
+        type_acte,
+        'Accompagnement'        as categorie_acte,
+        false                   as north_star,
+        false                   as north_star_70,
+        false                   as traite,
+        type_structure,
+        departement,
+        nb_without_rdv::integer as nombre_actes
+    from mapped_invitations
+    where nb_without_rdv > 0
+
+)
+
+select *
+from actes_metiers

--- a/dbt/models/intermediate/rdvi/properties.yml
+++ b/dbt/models/intermediate/rdvi/properties.yml
@@ -1,0 +1,78 @@
+version: 2
+
+models:
+  - name: int_rdvi__actes_metiers
+    description: >
+      Ce modèle compte, par mois, le nombre d'invitations envoyées depuis rdv-insertion. Les résultats sont détaillés par type d'acte,
+      type de structure, département et statut north star. Il reprend dans dbt le calcul qui était auparavant fait par le fetcher Python
+      `fetch_rdvi`.
+
+      **ATTENTION : ce modèle réplique directement la logique qui existait sur Autometa pour le tableau de bord des actes métier.
+      Il est possible que cette modélisation soit revue. Si tu es en train de t'en servir pour quelque chose, vérifie d'abord
+      avec l'équipe data.**
+    config:
+      tags:
+        - actes-metier
+        - rdv-insertion
+    columns:
+      - name: mois
+        tests:
+          - not_null
+      - name: source
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - rdvi
+      - name: type_acte
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - Invitation à un RDV d’orientation
+                  - Invitation à un RDV d’accompagnement
+                  - Invitation à un Entretien SIAE
+                  - Invitation à un Autre RDV
+      - name: categorie_acte
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - Accompagnement
+      - name: north_star
+        tests:
+          - not_null
+      - name: north_star_70
+        tests:
+          - not_null
+      - name: traite
+        tests:
+          - not_null
+      - name: type_structure
+        tests:
+          - not_null
+      - name: departement
+        tests:
+          - not_null
+      - name: nombre_actes
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - mois
+              - source
+              - type_acte
+              - north_star
+              - north_star_70
+              - traite
+              - type_structure
+              - departement

--- a/dbt/models/staging/rdvi/properties.yml
+++ b/dbt/models/staging/rdvi/properties.yml
@@ -1,0 +1,294 @@
+version: 2
+
+models:
+  - name: stg_rdvi__departments
+    description: >
+      Représente les départements français.
+
+      Rôle : niveau administratif supérieur qui regroupe les organisations d'un territoire.
+
+    config:
+      tags:
+        - actes-metier
+        - rdv-insertion
+    columns:
+      - name: id
+        description: Identifiant unique du département dans rdv-insertion.
+        tests:
+          - not_null
+          - unique
+      - name: name
+        description: Nom du département.
+      - name: number
+        description: Numéro du département, par exemple 75 ou 93.
+      - name: capital
+        description: Préfecture du département.
+      - name: region
+        description: Région administrative du département.
+      - name: email
+        description: Email de contact départemental.
+      - name: phone_number
+        description: Numéro de téléphone de contact départemental.
+      - name: parcours_enabled
+        description: Indique si le module parcours est activé pour le département.
+      - name: disable_ft_webhooks
+        description: Indique si les webhooks France Travail sont désactivés pour le département.
+
+  - name: stg_rdvi__follow_ups
+    description: >
+      Table centrale du métier.
+
+      Représente le suivi d'un usager pour une catégorie de motif donnée.
+
+      Rôle : suit l'état d'avancement d'un usager dans son parcours, par exemple orientation ou
+      accompagnement.
+
+    config:
+      tags:
+        - actes-metier
+        - rdv-insertion
+    columns:
+      - name: id
+        description: Identifiant unique du suivi dans rdv-insertion.
+        tests:
+          - not_null
+          - unique
+      - name: user_id
+        description: Usager suivi.
+      - name: motif_category_id
+        description: >
+          Catégorie de motif du suivi, par exemple orientation RSA ou accompagnement RSA.
+      - name: status
+        description: >
+          Statut du suivi. Valeurs possibles : not_invited, invitation_pending,
+          rdv_pending, rdv_needs_status_update, rdv_noshow, rdv_revoked, rdv_excused,
+          rdv_seen, closed.
+      - name: closed_at
+        description: Date de clôture du suivi.
+
+  - name: stg_rdvi__invitations
+    description: >
+      Représente une invitation envoyée à un usager pour qu'il prenne rendez-vous.
+
+      Rôle : trace les invitations SMS, email ou courrier avec leur lien de prise de RDV.
+
+    config:
+      tags:
+        - actes-metier
+        - rdv-insertion
+    columns:
+      - name: id
+        description: Identifiant unique de l'invitation dans rdv-insertion.
+        tests:
+          - not_null
+          - unique
+      - name: user_id
+        description: Usager invité.
+      - name: follow_up_id
+        description: Suivi concerné par l'invitation.
+      - name: department_id
+        description: Identifiant du département de rattachement de l'invitation.
+      - name: format
+        description: "Format de l'invitation. Valeurs possibles : sms, email, postal."
+      - name: link
+        description: URL de prise de RDV sur RDV-Solidarités.
+      - name: rdv_solidarites_token
+        description: Token d'authentification RDV-Solidarités.
+      - name: uuid
+        description: Identifiant court utilisé dans l'URL publique.
+      - name: expires_at
+        description: Date d'expiration de l'invitation.
+      - name: clicked
+        description: Indique si l'usager a cliqué sur le lien.
+      - name: delivery_status
+        description: Statut de livraison de l'invitation.
+      - name: sms_provider
+        description: Fournisseur SMS utilisé pour les invitations SMS.
+      - name: last_brevo_webhook_received_at
+        description: Date du dernier webhook Brevo reçu.
+      - name: rdv_with_referents
+        description: Indique si l'invitation concerne un RDV avec référent.
+      - name: rdv_solidarites_lieu_id
+        description: Lieu pré-sélectionné dans le lien de prise de RDV.
+      - name: help_phone_number
+        description: Numéro d'aide affiché à l'usager.
+      - name: created_at
+        description: Date de création de l'invitation.
+        tests:
+          - not_null
+      - name: origin
+        description: >
+          Origine de l'invitation. Valeurs possibles : legacy_triggered_by_agent,
+          legacy_triggered_by_periodic_job, reminder, user_list_upload.
+
+  - name: stg_rdvi__invitations_organisations
+    description: >
+      Table de jonction simple.
+
+      Lie une invitation aux organisations concernées.
+
+    config:
+      tags:
+        - actes-metier
+        - rdv-insertion
+    columns:
+      - name: invitation_id
+        description: Invitation concernée.
+      - name: organisation_id
+        description: Organisation concernée par l'invitation.
+
+  - name: stg_rdvi__motif_categories
+    description: >
+      Représente les grandes catégories de RDV, par exemple orientation RSA ou accompagnement RSA.
+
+      Rôle : classification des types de suivis.
+
+    config:
+      tags:
+        - actes-metier
+        - rdv-insertion
+    columns:
+      - name: id
+        description: Identifiant unique de la catégorie de motif dans rdv-insertion.
+        tests:
+          - not_null
+          - unique
+      - name: rdv_solidarites_motif_category_id
+        description: ID de la catégorie de motif dans RDV-Solidarités.
+      - name: name
+        description: Nom complet de la catégorie de motif.
+      - name: short_name
+        description: Nom court unique de la catégorie de motif.
+      - name: motif_category_type
+        description: >
+          Type de catégorie de motif. Valeurs possibles : rsa_orientation,
+          rsa_accompagnement, siae, autre.
+      - name: template_id
+        description: Template de messages associé à la catégorie de motif.
+
+  - name: stg_rdvi__organisations
+    description: >
+      Représente les structures qui suivent les usagers, comme les conseils départementaux,
+      France Travail, les SIAE ou d'autres structures.
+
+      Rôle : structure organisationnelle qui regroupe agents, usagers et configuration.
+
+    config:
+      tags:
+        - actes-metier
+        - rdv-insertion
+    columns:
+      - name: id
+        description: Identifiant unique de l'organisation dans rdv-insertion.
+        tests:
+          - not_null
+          - unique
+      - name: rdv_solidarites_organisation_id
+        description: ID de l'organisation dans RDV-Solidarités.
+      - name: name
+        description: Nom de l'organisation.
+      - name: department_id
+        description: Département de rattachement.
+      - name: organisation_type
+        description: >
+          Type de l'organisation. Valeurs possibles : conseil_departemental,
+          delegataire_rsa, france_travail, siae, autre.
+      - name: email
+        description: Email de contact de l'organisation.
+      - name: phone_number
+        description: Numéro de téléphone de contact de l'organisation.
+      - name: safir_code
+        description: Code SAFIR pour France Travail.
+      - name: slug
+        description: Identifiant court utilisé pour repérer l'organisation dans les fichiers d'import.
+      - name: website
+        description: Site web de l'organisation.
+      - name: archived_at
+        description: Date d'archivage de l'organisation si elle est inactive.
+      - name: data_retention_duration_in_months
+        description: Durée de conservation des données, en mois, pour le RGPD.
+      - name: display_in_stats
+        description: Indique si l'organisation doit être incluse dans les statistiques.
+
+  - name: stg_rdvi__participations
+    description: >
+      Table de jonction enrichie entre users et rdvs.
+
+      Rôle : lie un usager à un RDV avec son statut de participation.
+
+    config:
+      tags:
+        - actes-metier
+        - rdv-insertion
+    columns:
+      - name: id
+        description: Identifiant unique de la participation dans rdv-insertion.
+      - name: user_id
+        description: Usager participant au RDV.
+      - name: rdv_id
+        description: Rendez-vous concerné.
+      - name: follow_up_id
+        description: Suivi associé à la participation.
+      - name: status
+        description: >
+          Statut de la participation. Valeurs possibles : unknown, excused, seen,
+          noshow, revoked.
+      - name: rdv_solidarites_participation_id
+        description: ID de la participation dans RDV-Solidarités.
+      - name: convocable
+        description: Indique s'il s'agit d'une convocation obligatoire.
+      - name: created_by_type
+        description: Type de créateur du RDV, par exemple Agent, User ou Prescripteur.
+      - name: created_by_agent_prescripteur
+        description: Indique si le RDV a été créé par un agent prescripteur.
+      - name: france_travail_id
+        description: ID France Travail de l'usager.
+
+  - name: stg_rdvi__rdvs
+    description: >
+      Représente un rendez-vous créé dans RDV-Solidarités.
+
+      Rôle : synchronise les RDV depuis RDV-Solidarités pour le suivi local.
+
+    config:
+      tags:
+        - actes-metier
+        - rdv-insertion
+    columns:
+      - name: id
+        description: Identifiant unique du rendez-vous dans rdv-insertion.
+        tests:
+          - not_null
+          - unique
+      - name: rdv_solidarites_rdv_id
+        description: ID du RDV dans RDV-Solidarités.
+      - name: starts_at
+        description: Date et heure de début du RDV.
+      - name: duration_in_min
+        description: Durée du RDV en minutes.
+      - name: organisation_id
+        description: Organisation concernée par le RDV.
+      - name: motif_id
+        description: Motif du RDV.
+      - name: lieu_id
+        description: Lieu du RDV. Peut être vide si le RDV est à distance.
+      - name: status
+        description: Statut du RDV.
+      - name: cancelled_at
+        description: Date d'annulation du RDV.
+      - name: created_by
+        description: Origine de création du RDV, par exemple agent, user ou prescripteur.
+      - name: context
+        description: Contexte ou notes du RDV.
+      - name: address
+        description: Adresse du RDV.
+      - name: visio_url
+        description: URL de visioconférence pour les RDV à distance.
+      - name: uuid
+        description: Identifiant utilisé dans les URLs publiques.
+      - name: time_zone
+        description: Fuseau horaire du RDV.
+      - name: users_count
+        description: Nombre de participants au RDV.
+      - name: max_participants_count
+        description: Nombre maximum de participants pour les RDV collectifs.

--- a/dbt/models/staging/rdvi/stg_rdvi__departments.sql
+++ b/dbt/models/staging/rdvi/stg_rdvi__departments.sql
@@ -1,0 +1,11 @@
+select
+    id,
+    name,
+    number::text                 as number,
+    capital,
+    region,
+    email,
+    phone_number,
+    parcours_enabled::boolean    as parcours_enabled,
+    disable_ft_webhooks::boolean as disable_ft_webhooks
+from {{ source('rdv_insertion', 'departments') }}

--- a/dbt/models/staging/rdvi/stg_rdvi__follow_ups.sql
+++ b/dbt/models/staging/rdvi/stg_rdvi__follow_ups.sql
@@ -1,0 +1,7 @@
+select
+    id,
+    user_id,
+    motif_category_id,
+    status,
+    closed_at::timestamp as closed_at
+from {{ source('rdv_insertion', 'follow_ups') }}

--- a/dbt/models/staging/rdvi/stg_rdvi__invitations.sql
+++ b/dbt/models/staging/rdvi/stg_rdvi__invitations.sql
@@ -1,0 +1,20 @@
+select
+    id,
+    user_id,
+    follow_up_id,
+    department_id,
+    format,
+    link,
+    rdv_solidarites_token,
+    uuid,
+    expires_at::timestamp                     as expires_at,
+    clicked::boolean                          as clicked,
+    delivery_status,
+    sms_provider,
+    last_brevo_webhook_received_at::timestamp as last_brevo_webhook_received_at,
+    rdv_with_referents::boolean               as rdv_with_referents,
+    rdv_solidarites_lieu_id,
+    help_phone_number,
+    created_at::timestamp                     as created_at,
+    origin
+from {{ source('rdv_insertion', 'invitations') }}

--- a/dbt/models/staging/rdvi/stg_rdvi__invitations_organisations.sql
+++ b/dbt/models/staging/rdvi/stg_rdvi__invitations_organisations.sql
@@ -1,0 +1,4 @@
+select
+    invitation_id,
+    organisation_id
+from {{ source('rdv_insertion', 'invitations_organisations') }}

--- a/dbt/models/staging/rdvi/stg_rdvi__motif_categories.sql
+++ b/dbt/models/staging/rdvi/stg_rdvi__motif_categories.sql
@@ -1,0 +1,8 @@
+select
+    id,
+    rdv_solidarites_motif_category_id,
+    name,
+    short_name,
+    motif_category_type,
+    template_id
+from {{ source('rdv_insertion', 'motif_categories') }}

--- a/dbt/models/staging/rdvi/stg_rdvi__organisations.sql
+++ b/dbt/models/staging/rdvi/stg_rdvi__organisations.sql
@@ -1,0 +1,15 @@
+select
+    id,
+    rdv_solidarites_organisation_id,
+    name,
+    department_id,
+    organisation_type,
+    email,
+    phone_number,
+    safir_code,
+    slug,
+    website,
+    archived_at::timestamp                     as archived_at,
+    data_retention_duration_in_months::integer as data_retention_duration_in_months,
+    display_in_stats::boolean                  as display_in_stats
+from {{ source('rdv_insertion', 'organisations') }}

--- a/dbt/models/staging/rdvi/stg_rdvi__participations.sql
+++ b/dbt/models/staging/rdvi/stg_rdvi__participations.sql
@@ -1,0 +1,12 @@
+select
+    id,
+    user_id,
+    rdv_id,
+    follow_up_id,
+    status,
+    rdv_solidarites_participation_id,
+    convocable::boolean                    as convocable,
+    created_by_type,
+    created_by_agent_prescripteur::boolean as created_by_agent_prescripteur,
+    france_travail_id
+from {{ source('rdv_insertion', 'participations') }}

--- a/dbt/models/staging/rdvi/stg_rdvi__rdvs.sql
+++ b/dbt/models/staging/rdvi/stg_rdvi__rdvs.sql
@@ -1,0 +1,19 @@
+select
+    id,
+    rdv_solidarites_rdv_id,
+    starts_at::timestamp            as starts_at,
+    duration_in_min::integer        as duration_in_min,
+    organisation_id,
+    motif_id,
+    lieu_id,
+    status,
+    cancelled_at::timestamp         as cancelled_at,
+    created_by,
+    context,
+    address,
+    visio_url,
+    uuid,
+    time_zone,
+    users_count::integer            as users_count,
+    max_participants_count::integer as max_participants_count
+from {{ source('rdv_insertion', 'rdvs') }}


### PR DESCRIPTION
**Carte Notion : ** (non nécessaire si `label=hotfix`)
https://app.notion.com/p/gip-inclusion/Cr-ation-des-mod-les-rdv-insertion-n-cessaires-au-tableau-de-bord-des-actes-m-tier-dc85f321b6048206995a01ea196f2ce0?source=copy_link

### Pourquoi ?
Comme pour la PR Matomo, cette PR sert à préparer les données nécessaires au tableau de bord des actes métier. Dans le cas de rdv-insertion, les données sont déjà disponibles dans la base, mais elles ne sont pas encore traitées avec dbt.

Dans cette PR, je crée le modèle intermédiaire qui réplique au mieux la logique des scripts Python actuellement utilisés pour les actes métier. J'ai également ajouté les modèles de staging nécessaires à ce modèle intermédiaire et corrigé la documentation de la source, car elle incluait une colonne `trigger` qui n'existe plus.



### Checks

- [x] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

