### PR TITLE
inclure toutes les réponses dans le profil FAGERH

### DIFF
--- a/dbt/models/marts/fagerh/fagerh__profil_etablissements.sql
+++ b/dbt/models/marts/fagerh/fagerh__profil_etablissements.sql
@@ -9,6 +9,7 @@ final as (
 
     select
         uuid,
+        is_response_completed,
         finess,
         establishment_name,
         departement,
@@ -41,8 +42,6 @@ final as (
         shared_kitchen_open_weekend
 
     from etablissements
-
-    where is_response_completed is true
 
 )
 

--- a/dbt/models/marts/fagerh/properties.yml
+++ b/dbt/models/marts/fagerh/properties.yml
@@ -347,12 +347,17 @@ models:
       Il ne contient pas les données d'activité des prestations. Il ne contient pas non plus les publics accompagnés, les métiers
       ou les ETP par dispositif. Ces sujets sont traités dans d'autres modèles.
 
+      Le modèle inclut les réponses validées et non validées. Le statut de validation est exposé dans la colonne `is_response_completed` pour permettre un filtrage explicite dans les analyses.
+
     columns:
       - name: uuid
         description: Identifiant unique de la réponse au questionnaire.
         data_tests:
           - not_null
           - unique
+
+      - name: is_response_completed
+        description: Indique si la réponse au questionnaire a été validée.
 
       - name: finess
         description: Numéro FINESS de l'établissement.


### PR DESCRIPTION
**Carte Notion : ** (non nécessaire si `label=hotfix`)
https://app.notion.com/p/gip-inclusion/FAGERH-Cr-ation-du-DAG-et-des-mod-les-n-cessaires-pour-traiter-les-r-ponses-au-questionnaire-37a5f321b60480ab9177f52b7410e13c?source=copy_link

### Pourquoi ?
Il y a un champ *saisie terminée* que j'utilisais pour filtrer les marts. Sauf qu'en réalité, toutes les réponses sont terminées maintenant que le questionnaire est fermé.

Si je conservais ce filtre, il y avait des incohérences avec les autres marts qui ne l'utilisent pas. Je considère donc qu'il est préférable de le supprimer.

### Checks

- [x] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

