### PR TITLE
[Emplois] Suivi des imer effectuées sur les emplois

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ pg_dump:
 		--table="structures_v0" \
 		--table="suivi_visiteurs_tb_publics_v1" \
 		--table="sorties_v2" \
+		--table='raw_emplois.imer_v0' \
 		--file=$(DUMP_DIR)
 	@echo "\n\n### Database dumped successfully. ###\n"
 	rm -rf $(RESTORE_DIR)
@@ -137,6 +138,7 @@ ifneq (,$(findstring clever-cloud,$(PGHOST)))
 else
 	dropdb ${PGDATABASE} || true
 	createdb ${PGDATABASE}
+	psql -d ${PGDATABASE} -c "CREATE SCHEMA IF NOT EXISTS raw_emplois"
 	time pg_restore --format=directory --clean --jobs=4 --verbose --no-owner --no-acl -d ${PGDATABASE} $(RESTORE_DIR) || true
 	@echo "\n\n### Database restored successfully ! ###\n"
 endif

--- a/dags/dbt_imer.py
+++ b/dags/dbt_imer.py
@@ -1,0 +1,37 @@
+import airflow
+from airflow.operators import bash
+
+from dags.common import db, dbt, default_dag_args, slack
+
+
+dag_args = default_dag_args() | {"default_args": dbt.get_default_args()}
+
+with airflow.DAG(
+    dag_id="dbt_imer",
+    schedule=None,
+    **dag_args,
+) as dag:
+    env_vars = db.connection_envvars()
+
+    dbt_debug = bash.BashOperator(
+        task_id="dbt_debug",
+        bash_command="dbt debug",
+        env=env_vars,
+        append_env=True,
+    )
+
+    dbt_deps = bash.BashOperator(
+        task_id="dbt_deps",
+        bash_command="dbt deps",
+        env=env_vars,
+        append_env=True,
+    )
+
+    dbt_build = bash.BashOperator(
+        task_id="dbt_build",
+        bash_command='dbt build --select "+tag:imer"',
+        env=env_vars,
+        append_env=True,
+    )
+
+    (dbt_debug >> dbt_deps >> dbt_build >> slack.success_notifying_task())

--- a/dbt/models/_sources.yml
+++ b/dbt/models/_sources.yml
@@ -32,6 +32,59 @@ sources:
       - name: fluxIAE_RefTypeFormation
       - name: fluxIAE_RefDureePoleEmploi
 
+  - name: raw_emplois
+    schema: raw_emplois
+    description: >
+      Tables générées chaque nuit par les Emplois de l'Inclusion à partir de leur base de données.
+      A partir de juillet 2026 nous mettons les nouvelles tables dans le schéma raw_emplois, plutôt que public.
+    tables:
+      - name: imer_v0
+        description: >
+          Table récupérant les intentions de mise en relation (IMER)effectuées sur les Emplois de l'Inclusion.
+          Chaque ligne représente une intention de mise
+          en relation initiée par un utilisateur (candidat, prescripteur ou employeur).
+        columns:
+          - name: id
+            description: >
+              Identifiant unique de l'intention de mise en relation. Clé primaire de la table.
+          - name: date
+            description: >
+              Date à laquelle l'intention de mise en relation a été enregistrée.
+          - name: user_session
+            description: >
+              Identifiant de la session de l'utilisateur à l'origine de l'intention.
+          - name: user_kind
+            description: >
+              Type d'utilisateur à l'origine de l'intention.
+          - name: user_id
+            description: >
+              Identifiant de l'utilisateur à l'origine de l'intention.
+          - name: user_prescriber_organization_id
+            description: >
+              Identifiant de l'organisation prescriptrice de l'utilisateur.
+          - name: user_company_id
+          - name: structure_id
+            description: >
+              Identifiant de la structure ciblée par l'intention de mise en relation.
+              Clé étrangère vers `les_emplois.structures_v0.id`.
+          - name: kind
+            description: >
+              Type de l'intention de mise en relation.
+          - name: service_id
+            description: >
+              Identifiant du service concerné par l'intention.
+          - name: source
+            description: >
+              Source de la structure de l'intention de mise en relation.
+          - name: external_link
+            description: >
+              Lien externe associé à l'intention de mise en relation.
+          - name: orientation_id
+            description: >
+              Identifiant de l'orientation. Renseigné uniquement lorsqu'une orientation a eu lieu.
+          - name: date_mise_à_jour_metabase
+            description: >
+              Date de la dernière synchronisation de cette ligne dans Metabase.
   - name: emplois
     schema: public
     description: >

--- a/dbt/models/marts/marts_core/daily/fct_imer.sql
+++ b/dbt/models/marts/marts_core/daily/fct_imer.sql
@@ -1,0 +1,19 @@
+select
+    imer.id,
+    imer.date,
+    imer.user_session,
+    imer.user_kind,
+    imer.user_id,
+    imer.user_prescriber_organization_id,
+    imer.user_company_id,
+    imer.structure_id as source_structure_id,
+    di_structure.structure_id,
+    imer.kind,
+    imer.service_id,
+    imer.source,
+    imer.external_link,
+    imer.orientation_id,
+    imer.date_mise_a_jour_metabase
+from {{ ref('stg_emplois__imer') }} as imer
+left join {{ ref('int_di__structure_source_mapping') }} as di_structure
+    on imer.structure_id = di_structure.source_structure_id

--- a/dbt/models/marts/marts_core/properties.yml
+++ b/dbt/models/marts/marts_core/properties.yml
@@ -292,3 +292,61 @@ models:
         description: >
           Numéro FINESS de l'établissement juridique auquel l'ESAT est rattaché.
           Ce champ permet de relier la dimension ESAT au modèle `int_esat__legal_entities`.
+
+  - name: fct_imer
+    config:
+      tags:
+        - imer
+    description: >
+      Table de faits des intentions de mise en relation (IMER) effectuées sur les Emplois de l'Inclusion.
+      L'id_structure de data inclusion est récupéré dans cette table afin de faciliter la jointure dans la table suivante.
+      Une ligne correspond à une intention de mise en relation.
+      à partir de stg_emplois__imer.
+    tests:
+      - dbt_utils.equal_rowcount:
+          compare_model: ref('stg_emplois__imer')
+    columns:
+      - name: id
+        description: Identifiant unique de l'intention de mise en relation.
+        tests:
+          - not_null
+          - unique
+      - name: date
+        description: Date à laquelle l'intention de mise en relation a été enregistrée.
+        tests:
+          - not_null
+      - name: user_session
+        description: Identifiant de la session de l'utilisateur à l'origine de l'intention.
+      - name: user_kind
+        description: Type d'utilisateur à l'origine de l'intention.
+      - name: user_id
+        description: Identifiant de l'utilisateur à l'origine de l'intention.
+      - name: user_prescriber_organization_id
+        description: Identifiant de l'organisation prescriptrice de l'utilisateur.
+      - name: user_company_id
+        description: Identifiant de la structure prescriptrice..
+      - name: source_structure_id
+        description: Identifiant source data inclusion de la structure ciblée par l'intention de mise en relation.
+      - name: structure_id
+        description: Identifiant unique de data inclusion de la structure ciblée par l'intention de mise en relation.
+      - name: kind
+        description: >
+          Type de l'intention de mise en relation.
+        tests:
+          - accepted_values:
+              values:
+                - service_ext_link
+                - service_orientation
+                - service_contact
+                - structure_contact
+      - name: service_id
+        description: Identifiant du service concerné par l'intention.
+      - name: source
+        description: Source du service concerné par l'intention.
+      - name: external_link
+        description: Lien externe associé à l'intention de mise en relation.
+      - name: orientation_id
+        description: >
+          Identifiant de l'orientation. Renseigné uniquement lorsqu'une orientation a eu lieu.
+      - name: date_mise_a_jour_metabase
+        description: Date de la dernière synchronisation de cette ligne dans Metabase.

--- a/dbt/models/reporting/properties.yml
+++ b/dbt/models/reporting/properties.yml
@@ -239,3 +239,103 @@ models:
       - name: no_answer_rate
         description: >
           Pourcentage d'ESAT sans réponse trouvée.
+
+
+  - name: rpt_imer
+    config:
+      tags:
+        - imer
+    description: >
+      Table de reporting large des intentions de mise en relation (IMER) sur les Emplois de l'Inclusion.
+
+      Une ligne correspond à une intention de mise en relation, enrichie des informations
+      de la structure et du service data inclusion ciblés, de l'organisation prescriptrice
+      et de la structure employeuse de l'utilisateur, ainsi que de leur localisation.
+
+    columns:
+      - name: id
+        description: Identifiant unique de l'intention de mise en relation.
+        tests:
+          - not_null
+          - unique
+          - relationships:
+              to: ref('fct_imer_orientation')
+              field: id
+      - name: date
+        description: Date à laquelle l'intention de mise en relation a été enregistrée.
+        tests:
+          - not_null
+      - name: user_session
+        description: Identifiant de la session de l'utilisateur à l'origine de l'intention.
+      - name: user_kind
+        description: Type d'utilisateur à l'origine de l'intention.
+      - name: user_id
+        description: Identifiant de l'utilisateur à l'origine de l'intention.
+      - name: user_prescriber_organization_id
+        description: Identifiant de l'organisation prescriptrice.
+      - name: user_company_id
+        description: Identifiant de la structure prescriptrice.
+      - name: structure_id
+        description: Identifiant de la structure ciblée par l'intention de mise en relation.
+      - name: kind
+        description: >
+          Type de l'intention de mise en relation.
+        tests:
+          - not_null
+          - accepted_values:
+              values:
+                - service_ext_link
+                - service_orientation
+                - service_contact
+                - structure_contact
+      - name: service_id
+        description: Identifiant du service concerné par l'intention.
+      - name: source
+        description: Source du service concerné par l'intention.
+      - name: orientation_id
+        description: >
+          Identifiant de l'orientation. Renseigné uniquement lorsqu'une orientation a eu lieu.
+      - name: di_nom_structure
+        description: Nom de la structure concernée par l'intention.
+      - name: di_siret_structure
+        description: SIRET de la structure concernée par l'intention.
+      - name: di_structure_code_commune
+        description: Code INSEE de la concernée par l'intention.
+      - name: di_structure_region
+        description: Région de la structure concernée par l'intention.
+      - name: di_structure_code_departement
+        description: Code INSEE du département de la structure concernée par l'intention.
+      - name: di_structure_nom_departement
+        description: Nom du département de la structure concernée par l'intention.
+      - name: di_services_nom
+        description: Nom du service concerné par l'intention.
+      - name: di_services_thematiques
+        description: Thématiques du service concerné par l'intention.
+      - name: di_services_region
+        description: Région du service concerné par l'intention.
+      - name: di_services_code_departement
+        description: Code INSEE du département du service concerné par l'intention.
+      - name: di_services_nom_departement
+        description: Nom du département du service concerné par l'intention.
+      - name: organization_nom
+        description: Nom de l'organisation prescriptrice.
+      - name: organization_type
+        description: Type de l'organisation prescriptrice.
+      - name: organization_region
+        description: Région de l'organisation prescriptrice.
+      - name: organization_numero_departement
+        description: Numéro de département INSEE de l'organisation prescriptrice.
+      - name: organization_nom_departement
+        description: Nom du département de l'organisation prescriptrice.
+      - name: company_nom
+        description: Nom de la structure prescriptrice.
+      - name: company_type
+        description: Type de la structure prescriptrice.
+      - name: company_region
+        description: Région de la structure prescriptrice.
+      - name: company_numero_departement
+        description: Numéro de département de la structure prescriptrice.
+      - name: company_nom_departement
+        description: Nom du département de la structure prescriptrice.
+      - name: company_source
+        description: Source de la structure prescriptrice.

--- a/dbt/models/reporting/rpt_imer.sql
+++ b/dbt/models/reporting/rpt_imer.sql
@@ -1,0 +1,117 @@
+with imer as (
+    select
+        id,
+        date,
+        user_session,
+        user_kind,
+        user_id,
+        user_prescriber_organization_id,
+        user_company_id,
+        structure_id,
+        source_structure_id,
+        kind,
+        service_id,
+        source,
+        orientation_id
+    from {{ ref('fct_imer') }}
+),
+
+communes as (
+    select
+        code_commune_insee,
+        nom_region,
+        code_departement_insee,
+        nom_departement_complet
+    from {{ ref('dim_commune') }}
+),
+
+structures as (
+    select
+        di.structure_id                  as di_structure_id,
+        di.nom                           as di_nom_structure,
+        di.siret                         as di_siret_structure,
+        di.code_commune_insee            as di_structure_code_commune,
+        communes.nom_region              as di_structure_region,
+        communes.code_departement_insee  as di_structure_code_departement,
+        communes.nom_departement_complet as di_structure_nom_departement
+    from {{ ref('dim_data_inclusion__structures') }} as di
+    left join communes on di.code_commune_insee = communes.code_commune_insee
+),
+
+services as (
+    select
+        di.service_id                    as di_services_id,
+        di.structure_id                  as di_services_structure_id,
+        di.nom                           as di_services_nom,
+        di.thematiques                   as di_services_thematiques,
+        communes.nom_region              as di_services_region,
+        communes.code_departement_insee  as di_services_code_departement,
+        communes.nom_departement_complet as di_services_nom_departement
+    from {{ ref('dim_data_inclusion__services') }} as di
+    left join communes on di.code_commune_insee = communes.code_commune_insee
+),
+
+organization as (
+    select
+        id                       as organization_id,
+        nom                      as organization_nom,
+        type                     as organization_type,
+        "région"                 as organization_region,
+        numero_departement_insee as organization_numero_departement,
+        "nom_département_insee"  as organization_nom_departement
+    from {{ ref('organisations') }}
+),
+
+company as (
+    select
+        id                   as company_id,
+        nom                  as company_nom,
+        type                 as company_type,
+        "région_c1"          as company_region,
+        "département_c1"     as company_numero_departement,
+        "nom_département_c1" as company_nom_departement,
+        source               as company_source
+    from {{ ref('structures') }}
+)
+
+select
+    imer.id,
+    imer.date,
+    imer.user_session,
+    imer.user_kind,
+    imer.user_id,
+    imer.user_prescriber_organization_id,
+    imer.user_company_id,
+    imer.structure_id,
+    imer.source_structure_id,
+    imer.kind,
+    imer.service_id,
+    imer.source,
+    imer.orientation_id,
+    structures.di_nom_structure,
+    structures.di_siret_structure,
+    structures.di_structure_code_commune,
+    structures.di_structure_region,
+    structures.di_structure_code_departement,
+    structures.di_structure_nom_departement,
+    services.di_services_nom,
+    services.di_services_thematiques,
+    services.di_services_region,
+    services.di_services_code_departement,
+    services.di_services_nom_departement,
+    organization.organization_nom,
+    organization.organization_type,
+    organization.organization_region,
+    organization.organization_numero_departement,
+    organization.organization_nom_departement,
+    company.company_nom,
+    company.company_type,
+    company.company_region,
+    company.company_numero_departement,
+    company.company_nom_departement,
+    company.company_source
+from imer
+left join structures on imer.structure_id = structures.di_structure_id
+left join services on imer.service_id = services.di_services_id
+left join organization on imer.user_prescriber_organization_id = organization.organization_id
+left join company on imer.user_company_id = company.company_id

--- a/dbt/models/staging/emplois/_properties.yml
+++ b/dbt/models/staging/emplois/_properties.yml
@@ -1,0 +1,58 @@
+version: 2
+
+models:
+  - name: stg_emplois__imer
+    description: >
+      Intentions de mise en relation (IMER) effectuées sur les
+      Emplois de l'Inclusion.
+
+      Chaque ligne représente une intention de mise en relation initiée par un utilisateur,
+      canidat, prescripteur ou employeur.
+
+    config:
+      tags:
+        - imer
+    columns:
+      - name: id
+        description: Identifiant unique de l'intention de mise en relation.
+        tests:
+          - not_null
+          - unique
+      - name: date
+        description: Date à laquelle l'intention de mise en relation a été enregistrée.
+        tests:
+          - not_null
+      - name: user_session
+        description: Identifiant de la session de l'utilisateur à l'origine de l'intention.
+      - name: user_kind
+        description: Type d'utilisateur à l'origine de l'intention.
+      - name: user_id
+        description: Identifiant de l'utilisateur à l'origine de l'intention.
+      - name: user_prescriber_organization_id
+        description: Identifiant de l'organisation prescriptrice de l'utilisateur.
+      - name: user_company_id
+        description: Identifiant de la structure employeuse de l'utilisateur.
+      - name: structure_id
+        description: Identifiant de la structure ciblée par l'intention de mise en relation.
+      - name: kind
+        description: >
+          Type de l'intention de mise en relation. Valeurs possibles : service_ext_link,
+          service_orientation, service_contact, structure_contact.
+        tests:
+          - accepted_values:
+              values:
+                - service_ext_link
+                - service_orientation
+                - service_contact
+                - structure_contact
+      - name: service_id
+        description: Identifiant du service concerné par l'intention.
+      - name: source
+        description: Source à l'origine de l'intention de mise en relation.
+      - name: external_link
+        description: Lien externe associé à l'intention de mise en relation.
+      - name: orientation_id
+        description: >
+          Identifiant de l'orientation. Renseigné uniquement lorsqu'une orientation a eu lieu.
+      - name: date_mise_a_jour_metabase
+        description: Date de la dernière synchronisation de cette ligne dans Metabase.

--- a/dbt/models/staging/emplois/stg_emplois__imer.sql
+++ b/dbt/models/staging/emplois/stg_emplois__imer.sql
@@ -1,0 +1,16 @@
+select
+    id,
+    date,
+    user_session,
+    user_kind,
+    user_id,
+    user_prescriber_organization_id,
+    user_company_id,
+    structure_id,
+    kind,
+    service_id,
+    source,
+    external_link,
+    orientation_id,
+    "date_mise_à_jour_metabase" as date_mise_a_jour_metabase
+from {{ source('raw_emplois', 'imer_v0') }}


### PR DESCRIPTION
**Carte Notion : ** (non nécessaire si `label=hotfix`) https://app.notion.com/p/gip-inclusion/DATA-Stats-iMER-et-orientations-Emplois-3905f321b6048012919ce260321b7d87?source=copy_link

### Pourquoi ?

A la demande du métier nous souhaitons suivre l'impact de la MEP permettant de faire des imer via les emplois.

@dfelicesm dans un second temps il faudra rapatrier les données de DORA dans la table de faits, mais pour ça attendons que DORA et les emplois aient la possibilité de discuter.

Cf mess slack ici  https://gip-inclusion.slack.com/archives/C0890D48P2Q/p1784533663159559?thread_ts=1784533165.038619&cid=C0890D48P2Q
 
### Checks

- [ ] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

