### PR TITLE
add dag and dbt models to get dora data for actes metier

### DIFF
--- a/dags/dbt_dora.py
+++ b/dags/dbt_dora.py
@@ -1,0 +1,40 @@
+from airflow import DAG
+from airflow.operators import bash
+
+from dags.common import db, dbt, default_dag_args, slack
+
+
+DAG_ID = "dbt_dora"
+
+dag_args = default_dag_args() | {"default_args": dbt.get_default_args()}
+
+
+with DAG(
+    dag_id=DAG_ID,
+    schedule="0 5 * * *",
+    **dag_args,
+) as dag:
+    env_vars = db.connection_envvars()
+
+    dbt_deps = bash.BashOperator(
+        task_id="dbt_deps",
+        bash_command="dbt deps",
+        env=env_vars,
+        append_env=True,
+    )
+
+    dbt_seed = bash.BashOperator(
+        task_id="dbt_seed",
+        bash_command="dbt seed",
+        env=env_vars,
+        append_env=True,
+    )
+
+    dbt_build = bash.BashOperator(
+        task_id="dbt_build",
+        bash_command='dbt build --select "+tag:dora"',
+        env=env_vars,
+        append_env=True,
+    )
+
+    dbt_deps >> dbt_seed >> dbt_build >> slack.success_notifying_task()

--- a/dags/properties.yml
+++ b/dags/properties.yml
@@ -17,6 +17,9 @@ models:
     description: >
       Ce DAG recupere depuis Matomo les visites mensuelles des pages de recherche Emplois necessaires aux actes metier,
       sur les 14 derniers mois fermes. Il alimente les tables raw utilisees par dbt pour calculer les actes metier Matomo.
+  - name: dora
+    description: >
+      Ce DAG lance les modèles dbt tagués dora à partir des données déjà déposées dans le schéma raw_dora.
   - name: monrecap
     description: >
       Ce DAG permet de récupérer de manière quotidienne les données de contacts & commandes sur le airtable de monrecap.
@@ -53,5 +56,4 @@ models:
     description: >
       Ce DAG permet de copier (et enventuellement modifier) les tables présentes dans diverses bdd de la PDI, vers une bdd unique.
       Le but est de brancher matometa sur cette unique DB.
-
 

--- a/dbt/models/intermediate/dora/int_dora__actes_metier.sql
+++ b/dbt/models/intermediate/dora/int_dora__actes_metier.sql
@@ -1,0 +1,263 @@
+with user_struct as (
+
+    select distinct on (dora_users.id)
+        dora_users.id as user_id,
+        structures.typology
+    from {{ source('dora', 'users_user') }} as dora_users
+    inner join {{ source('dora', 'structures_structuremember') }} as structure_members
+        on dora_users.id = structure_members.user_id
+    inner join {{ source('dora', 'structures_structure') }} as structures
+        on structure_members.structure_id = structures.id
+    where structures.typology is not null and structures.typology != ''
+    order by dora_users.id
+
+),
+
+raw_actes as (
+
+    select
+        to_char(date_trunc('month', orientations.creation_date), 'YYYY-MM') as mois,
+        'dora'                                                              as source,
+        'Orientation vers service'                                          as type_acte,
+        'Accompagnement'                                                    as categorie_acte,
+        orientations.status in ('VALIDÉE', 'REFUSÉE')                       as north_star,
+        orientations.status in ('VALIDÉE', 'REFUSÉE')                       as north_star_70,
+        orientations.status in ('VALIDÉE', 'REFUSÉE')                       as traite,
+        structures.typology                                                 as raw_type_structure,
+        coalesce(structures.department, 'Inconnu')                          as raw_departement,
+        count(*)                                                            as nombre_actes
+    from {{ source('dora', 'orientations_orientation') }} as orientations
+    left join {{ source('dora', 'structures_structure') }} as structures
+        on orientations.prescriber_structure_id = structures.id
+    where
+        orientations.creation_date >= date_trunc('month', current_date) - interval '14 months'
+        and orientations.creation_date < date_trunc('month', current_date)
+    group by
+        to_char(date_trunc('month', orientations.creation_date), 'YYYY-MM'),
+        orientations.status in ('VALIDÉE', 'REFUSÉE'),
+        structures.typology,
+        coalesce(structures.department, 'Inconnu')
+
+    union all
+
+    select
+        to_char(date_trunc('month', imer.date), 'YYYY-MM') as mois,
+        'dora'                                             as source,
+        'Intention d’orientation'                          as type_acte,
+        'Support'                                          as categorie_acte,
+        false                                              as north_star,
+        false                                              as north_star_70,
+        false                                              as traite,
+        user_struct.typology                               as raw_type_structure,
+        coalesce(imer.structure_department, 'Inconnu')     as raw_departement,
+        count(*)                                           as nombre_actes
+    from {{ ref('int_dora__imer') }} as imer
+    left join user_struct
+        on cast(user_struct.user_id as text) = cast(imer.user_id as text)
+    where
+        imer.user_kind in ('accompagnateur', 'accompagnateur_offreur', 'offreur')
+        and imer.date >= date_trunc('month', current_date) - interval '14 months'
+        and imer.date < date_trunc('month', current_date)
+    group by
+        to_char(date_trunc('month', imer.date), 'YYYY-MM'),
+        user_struct.typology,
+        coalesce(imer.structure_department, 'Inconnu')
+
+    union all
+
+    select
+        to_char(date_trunc('month', services.modification_date), 'YYYY-MM') as mois,
+        'dora'                                                              as source,
+        'Mise à jour offre de service, hors emploi solidaire'               as type_acte,
+        'Support'                                                           as categorie_acte,
+        false                                                               as north_star,
+        false                                                               as north_star_70,
+        false                                                               as traite,
+        structures.typology                                                 as raw_type_structure,
+        coalesce(structures.department, 'Inconnu')                          as raw_departement,
+        count(*)                                                            as nombre_actes
+    from {{ source('dora', 'services_service') }} as services
+    left join {{ source('dora', 'structures_structure') }} as structures
+        on services.structure_id = structures.id
+    where
+        services.last_editor_id is not null
+        and services.modification_date >= date_trunc('month', current_date) - interval '14 months'
+        and services.modification_date < date_trunc('month', current_date)
+    group by
+        to_char(date_trunc('month', services.modification_date), 'YYYY-MM'),
+        structures.typology,
+        coalesce(structures.department, 'Inconnu')
+
+    union all
+
+    select
+        to_char(date_trunc('month', services.creation_date), 'YYYY-MM') as mois,
+        'dora'                                                          as source,
+        'Création ou diffusion offre de service, hors emploi solidaire' as type_acte,
+        'Support'                                                       as categorie_acte,
+        false                                                           as north_star,
+        false                                                           as north_star_70,
+        false                                                           as traite,
+        structures.typology                                             as raw_type_structure,
+        coalesce(structures.department, 'Inconnu')                      as raw_departement,
+        count(*)                                                        as nombre_actes
+    from {{ source('dora', 'services_service') }} as services
+    left join {{ source('dora', 'structures_structure') }} as structures
+        on services.structure_id = structures.id
+    where
+        services.creation_date >= date_trunc('month', current_date) - interval '14 months'
+        and services.creation_date < date_trunc('month', current_date)
+    group by
+        to_char(date_trunc('month', services.creation_date), 'YYYY-MM'),
+        structures.typology,
+        coalesce(structures.department, 'Inconnu')
+
+    union all
+
+    select
+        to_char(date_trunc('month', structures.creation_date), 'YYYY-MM') as mois,
+        'dora'                                                            as source,
+        'Création structure, hors employeur solidaire'                    as type_acte,
+        'Support'                                                         as categorie_acte,
+        false                                                             as north_star,
+        false                                                             as north_star_70,
+        false                                                             as traite,
+        structures.typology                                               as raw_type_structure,
+        coalesce(structures.department, 'Inconnu')                        as raw_departement,
+        count(*)                                                          as nombre_actes
+    from {{ source('dora', 'structures_structure') }} as structures
+    where
+        structures.creation_date >= date_trunc('month', current_date) - interval '14 months'
+        and structures.creation_date < date_trunc('month', current_date)
+    group by
+        to_char(date_trunc('month', structures.creation_date), 'YYYY-MM'),
+        structures.typology,
+        coalesce(structures.department, 'Inconnu')
+
+    union all
+
+    select
+        to_char(date_trunc('month', structures.modification_date), 'YYYY-MM')      as mois,
+        'dora'                                                                     as source,
+        'Mise à jour d’une structure d’offre de service, hors employeur solidaire' as type_acte,
+        'Support'                                                                  as categorie_acte,
+        false                                                                      as north_star,
+        false                                                                      as north_star_70,
+        false                                                                      as traite,
+        structures.typology                                                        as raw_type_structure,
+        coalesce(structures.department, 'Inconnu')                                 as raw_departement,
+        count(*)                                                                   as nombre_actes
+    from {{ source('dora', 'structures_structure') }} as structures
+    where
+        structures.modification_date is not null
+        and structures.modification_date > structures.creation_date
+        and structures.modification_date >= date_trunc('month', current_date) - interval '14 months'
+        and structures.modification_date < date_trunc('month', current_date)
+    group by
+        to_char(date_trunc('month', structures.modification_date), 'YYYY-MM'),
+        structures.typology,
+        coalesce(structures.department, 'Inconnu')
+
+    union all
+
+    select
+        to_char(date_trunc('month', search_views.date), 'YYYY-MM') as mois,
+        'dora'                                                     as source,
+        'Recherche d’offre de service, hors emploi solidaire'      as type_acte,
+        'Support'                                                  as categorie_acte,
+        false                                                      as north_star,
+        false                                                      as north_star_70,
+        false                                                      as traite,
+        user_struct.typology                                       as raw_type_structure,
+        coalesce(search_views.department, 'Inconnu')               as raw_departement,
+        count(*)                                                   as nombre_actes
+    from {{ source('dora', 'stats_searchview') }} as search_views
+    left join user_struct
+        on cast(user_struct.user_id as text) = cast(search_views.user_id as text)
+    where
+        search_views.date >= date_trunc('month', current_date) - interval '14 months'
+        and search_views.date < date_trunc('month', current_date)
+    group by
+        to_char(date_trunc('month', search_views.date), 'YYYY-MM'),
+        user_struct.typology,
+        coalesce(search_views.department, 'Inconnu')
+
+),
+
+normalized as (
+
+    select
+        mois,
+        source,
+        type_acte,
+        categorie_acte,
+        north_star,
+        north_star_70,
+        traite,
+        nombre_actes,
+        case
+            when raw_type_structure is null or trim(cast(raw_type_structure as text)) = '' then 'Autre'
+            when raw_type_structure in ('FT', 'PE', 'france_travail') then 'FRANCE_TRAVAIL'
+            when raw_type_structure in ('ML', 'mission_locale') then 'MISSION_LOCALE'
+            when raw_type_structure in ('CAP_EMPLOI', 'cap_emploi') then 'CAP_EMPLOI'
+            when raw_type_structure in ('DEPT', 'CD', 'conseil_departemental') then 'CONSEIL_DEPARTEMENTAL'
+            when raw_type_structure in ('ODC', 'delegataire_rsa', 'DELEGATAIRE_RSA') then 'DELEGATAIRE_RSA'
+            when raw_type_structure in ('CCAS', 'CIAS', 'ASE') then 'CCAS_CIAS'
+            when raw_type_structure in ('SPIP', 'PJJ', 'JUSTICE') then 'JUSTICE_PROBATION'
+            when raw_type_structure in (
+                'CHU', 'CHRS', 'CPH', 'CADA', 'HUDA', 'RS_FJT', 'OIL', 'PENSION', 'ACT', 'LHSS',
+                'CHRS/Accueil de jour', 'Accueil de jour'
+            ) then 'TS_HEBERGEMENT'
+            when raw_type_structure in (
+                'EI', 'AI', 'ACI', 'ETTI', 'EITI', 'GEIQ', 'EA', 'EATT', 'OPCS', 'siae', 'employer',
+                'Groupements d’employeurs pour l’insertion et la qualification', 'SIAE'
+            ) then 'SIAE'
+            when raw_type_structure = 'PLIE' then 'PLIE'
+            when raw_type_structure in ('E2C', 'EPIDE', 'AFPA', 'OF', 'Organisme de formation') then 'E2C_EPIDE_AFPA'
+            when raw_type_structure in ('CIDFF', 'CSAPA', 'CAARUD', 'PREVENTION', 'OHPD', 'OCASF') then 'TS_SPECIALISES'
+            when raw_type_structure in ('CAF', 'MSA') then 'CAF_MSA'
+            when raw_type_structure in ('PIJ_BIJ', 'OACAS', 'CAVA') then 'AUTRES_INSERTION'
+            when raw_type_structure in ('BUYER', 'PARTNER', 'INDIVIDUAL', 'ADMIN') then 'Autre'
+            else 'Autre'
+        end as type_structure,
+        case
+            when raw_departement is null or trim(cast(raw_departement as text)) = '' then 'Inconnu'
+            when upper(split_part(trim(cast(raw_departement as text)), ' - ', 1)) in ('2A', '2B')
+                then upper(split_part(trim(cast(raw_departement as text)), ' - ', 1))
+            when
+                split_part(trim(cast(raw_departement as text)), ' - ', 1) ~ '^[0-9]+$'
+                and cast(split_part(trim(cast(raw_departement as text)), ' - ', 1) as integer) between 1 and 95
+                then lpad(split_part(trim(cast(raw_departement as text)), ' - ', 1), 2, '0')
+            when
+                split_part(trim(cast(raw_departement as text)), ' - ', 1) ~ '^[0-9]+$'
+                and cast(split_part(trim(cast(raw_departement as text)), ' - ', 1) as integer) between 971 and 976
+                then split_part(trim(cast(raw_departement as text)), ' - ', 1)
+            else 'Inconnu'
+        end as departement
+    from raw_actes
+
+)
+
+select
+    mois,
+    source,
+    type_acte,
+    categorie_acte,
+    north_star,
+    north_star_70,
+    traite,
+    type_structure,
+    departement,
+    cast(sum(nombre_actes) as integer) as nombre_actes
+from normalized
+where nombre_actes > 0
+group by
+    mois,
+    source,
+    type_acte,
+    categorie_acte,
+    north_star,
+    north_star_70,
+    traite,
+    type_structure,
+    departement

--- a/dbt/models/intermediate/dora/int_dora__imer.sql
+++ b/dbt/models/intermediate/dora/int_dora__imer.sql
@@ -1,0 +1,32 @@
+select
+    'orientation'                                                                       as kind,
+    cast(orientation_id as text)                                                        as event_id,
+    orientation_creation_date                                                           as date, -- noqa: RF04
+    orientation_prescriber_id                                                           as user_id,
+    user_main_activity                                                                  as user_kind,
+    user_is_manager                                                                     as is_manager,
+    structure_typology,
+    structure_department,
+    coalesce(orientation_di_service_id is not null, false)                              as is_di_service,
+    coalesce(user_main_activity in ('accompagnateur', 'accompagnateur_offreur'), false) as is_prescriber,
+    null                                                                                as generates_orientation
+from {{ ref('int_dora__orientation_user_service') }}
+union all
+select
+    'mobilisation'                                                                        as kind,
+    m.event_id,
+    m.event_date                                                                          as date, -- noqa: RF04
+    m.user_id,
+    m.event_user_kind                                                                     as user_kind,
+    m.event_is_manager                                                                    as is_manager,
+    struct_members.structure_typology,
+    struct_members.structure_department,
+    m.event_is_di                                                                         as is_di_service,
+    coalesce(m.user_main_activity in ('accompagnateur', 'accompagnateur_offreur'), false) as is_prescriber,
+    o_m.generates_orientation
+from {{ ref('int_dora__mobilisationevent_user') }} as m
+left join
+    {{ ref('int_dora__structure_members') }} as struct_members
+    on m.user_id = struct_members.user_id and m.event_structure_id = cast(struct_members.structure_id as text)
+left join {{ ref('int_dora__mobilisation_to_orientation') }} as o_m
+    on m.event_id = o_m.mobilisation_id

--- a/dbt/models/intermediate/dora/int_dora__mobilisation_to_orientation.sql
+++ b/dbt/models/intermediate/dora/int_dora__mobilisation_to_orientation.sql
@@ -1,0 +1,23 @@
+{{ config(
+    materialized='view'
+) }}
+
+select distinct on (m.user_id, m.event_id)
+    m.user_id,
+    m.event_id                                 as mobilisation_id,
+    o.orientation_id                           as first_following_orientation_id,
+    m.event_date                               as mobilisation_date,
+    o.orientation_creation_date                as first_following_orientation_date,
+    o.orientation_creation_date - m.event_date as delay,
+    o.orientation_id is not null               as generates_orientation
+from {{ ref('int_dora__mobilisationevent_user') }} as m
+left join {{ ref('int_dora__orientation_user_service') }} as o
+-- orientations that follows mobilisations have the same user_id, are done in the hour after the mobilisation, and concern the same service (slug)
+    on
+        m.user_id = o.user_id
+        and o.orientation_creation_date between m.event_date and m.event_date + INTERVAL '1 hour'
+        and split_part(m.event_path, '/', 3) = o.service_slug
+order by
+    m.user_id asc,
+    m.event_id asc,
+    o.orientation_creation_date asc

--- a/dbt/models/intermediate/dora/int_dora__mobilisationevent_user.sql
+++ b/dbt/models/intermediate/dora/int_dora__mobilisationevent_user.sql
@@ -1,0 +1,17 @@
+with users as (
+    select * from {{ ref('stg_dora__user') }}
+),
+
+events as (
+    select * from {{ ref('stg_dora__mobilisationevent') }}
+),
+
+final as (
+    select
+        {{ dbt_utils.star(relation_alias='events', from=ref('stg_dora__mobilisationevent'), prefix='event_') }},
+        {{ dbt_utils.star(relation_alias='users', from=ref('stg_dora__user'), prefix='user_') }}
+    from events
+    inner join users on events.user_id = users.id
+)
+
+select * from final

--- a/dbt/models/intermediate/dora/int_dora__orientation_user_service.sql
+++ b/dbt/models/intermediate/dora/int_dora__orientation_user_service.sql
@@ -1,0 +1,13 @@
+select
+    {{ dbt_utils.star(relation_alias='orientations', from=ref('stg_dora__orientation'), prefix='orientation_') }},
+    {{ dbt_utils.star(relation_alias='dora_users', from=ref('stg_dora__user'), prefix='user_') }},
+    {{ dbt_utils.star(relation_alias='services', from=ref('int_dora__service_structure')) }}
+from {{ ref('stg_dora__orientation') }} as orientations
+-- left join pour considérer les orientations faites par des users supprimés
+left join {{ ref('stg_dora__user') }} as dora_users
+    on orientations.prescriber_id = dora_users.id
+-- left join pour considérer les cas suivants : 
+-- orientations faites sur des services sans service_id (ont un di_service_id)
+-- orientations faites sur des services non rattachés à une structure
+left join {{ ref('int_dora__service_structure') }} as services
+    on orientations.service_id = services.service_id

--- a/dbt/models/intermediate/dora/int_dora__service_structure.sql
+++ b/dbt/models/intermediate/dora/int_dora__service_structure.sql
@@ -1,0 +1,17 @@
+with services as (
+    select * from {{ ref("stg_dora__service") }}
+),
+
+structure as (
+    select * from {{ ref("stg_dora__structure") }}
+),
+
+final as (
+    select
+        {{ dbt_utils.star(relation_alias='services', from=ref("stg_dora__service"), prefix='service_') }},
+        {{ dbt_utils.star(relation_alias='structure', from=ref("stg_dora__structure"), prefix='structure_') }}
+    from services
+    inner join structure on services.structure_id = structure.id
+)
+
+select * from final

--- a/dbt/models/intermediate/dora/int_dora__structure_members.sql
+++ b/dbt/models/intermediate/dora/int_dora__structure_members.sql
@@ -1,0 +1,22 @@
+with users as (
+    select * from {{ ref('stg_dora__user') }}
+),
+
+structure as (
+    select * from {{ ref('stg_dora__structure') }}
+),
+
+member as (
+    select * from {{ source('dora', 'structures_structuremember') }}
+),
+
+final as (
+    select
+        {{ dbt_utils.star(relation_alias='users', from=ref('stg_dora__user'), prefix='user_') }},
+        {{ dbt_utils.star(relation_alias='structure', from=ref('stg_dora__structure'), prefix='structure_') }}
+    from member
+    inner join structure on member.structure_id = structure.id
+    inner join users on member.user_id = users.id
+)
+
+select * from final

--- a/dbt/models/intermediate/dora/properties.yml
+++ b/dbt/models/intermediate/dora/properties.yml
@@ -1,0 +1,207 @@
+version: 2
+
+models:
+  - name: int_dora__imer
+    description: |
+      Table contenant les intentions de mise en relation (mobilisation et orientations)
+    config:
+      tags:
+        - dora
+    columns:
+      - name: event_id
+        description: identifiant de la mise en relation
+        tests:
+          - unique
+          - not_null
+  - name: int_dora__actes_metier
+    description: >
+      Ce modele compte, par mois, les actes metier DORA reconstruits depuis les requetes historiques du fetcher Python
+      des actes metier sur Autometa : orientations, intentions d'orientation iMER, recherches, creations et mises a jour
+      de services et de structures.
+
+      **ATTENTION : ce modele replique volontairement le fetcher Python au plus proche. Certaines tables sont donc
+      appelees directement via `source('dora', ...)` plutot que via les modeles staging/intermediate dbt, notamment
+      `orientations_orientation`, `services_service`, `structures_structure`, `stats_searchview`, `users_user` et
+      `structures_structuremember`. Cette dette est intentionnelle pour la premiere reprise dbt des actes metier, mais
+      elle devra etre revisitée.**
+    config:
+      tags:
+        - actes-metier
+        - dora
+    columns:
+      - name: mois
+        description: >
+          Mois de réalisation de l'acte métier DORA, au format `YYYY-MM`. Le modèle ne conserve que les actes des
+          14 derniers mois complets.
+        tests:
+          - not_null
+      - name: source
+        description: >
+          Produit auquel l'acte métier est rattaché. Pour ce modèle, la valeur est toujours `dora`.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - dora
+      - name: type_acte
+        description: >
+          Type d'acte métier DORA reconstruit depuis les tables sources : orientation vers un service, intention
+          d'orientation iMER, recherche d'offre de service, création ou mise à jour d'offre de service, création ou
+          mise à jour de structure.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - Orientation vers service
+                  - Intention d’orientation
+                  - Mise à jour offre de service, hors emploi solidaire
+                  - Création ou diffusion offre de service, hors emploi solidaire
+                  - Création structure, hors employeur solidaire
+                  - Mise à jour d’une structure d’offre de service, hors employeur solidaire
+                  - Recherche d’offre de service, hors emploi solidaire
+      - name: categorie_acte
+        description: >
+          Catégorie métier de l'acte dans le référentiel des actes métier PDI. Les orientations vers service sont
+          classées en `Accompagnement`; les intentions d'orientation, recherches, créations et mises à jour sont
+          classées en `Support`.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - Accompagnement
+                  - Support
+      - name: north_star
+        description: >
+          Indique si l'acte est comptabilisé dans la déclinaison North Star du référentiel des actes métier PDI.
+          Pour DORA, seules les orientations vers service avec un statut `VALIDÉE` ou `REFUSÉE` sont marquées à
+          `true`; tous les autres types d'actes sont à `false`.
+        tests:
+          - not_null
+      - name: north_star_70
+        description: >
+          Variante héritée du modèle commun des actes métier. Pour DORA, elle reprend la même valeur que
+          `north_star` sur les orientations vers service traitées (`VALIDÉE` ou `REFUSÉE`) et vaut `false` pour les
+          autres actes.
+        tests:
+          - not_null
+      - name: traite
+        description: >
+          Indique si l'acte a été traité au sens du référentiel commun. Pour DORA, seules les orientations vers
+          service dont le statut est `VALIDÉE` ou `REFUSÉE` sont considérées comme traitées; les autres actes ne sont
+          pas concernés et valent `false`.
+        tests:
+          - not_null
+      - name: type_structure
+        description: >
+          Type de structure associé à l'acte métier, normalisé à partir de la typologie brute DORA de la structure
+          prescriptrice, de la structure porteuse du service, ou de la structure rattachée à l'utilisateur selon le
+          type d'acte. Les valeurs non reconnues ou absentes sont regroupées dans `Autre`.
+        tests:
+          - not_null
+      - name: departement
+        description: >
+          Département associé à l'acte métier, normalisé au format code INSEE (`01` à `95`, `2A`, `2B`, `971` à
+          `976`). La valeur est `Inconnu` lorsque le département est absent, vide ou non interprétable.
+        tests:
+          - not_null
+      - name: nombre_actes
+        description: >
+          Nombre d'actes métier agrégés au grain mois, source, type d'acte, indicateurs North Star / traité, type de
+          structure et département. Chaque compteur provient d'un `count(*)` sur la table source correspondant au type
+          d'acte, puis d'une somme après normalisation.
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - mois
+              - source
+              - type_acte
+              - north_star
+              - north_star_70
+              - traite
+              - type_structure
+              - departement
+  - name: int_dora__mobilisation_to_orientation
+    description:
+      Cette vue associe Ã  chaque mobilisation la premiÃ¨re orientation qui en suit si il y en a une.
+      Une orientation suit une mobilisation si elle a le mÃªme user_id, est faite dans l'heure aprÃ¨s la mobilisation,
+      et concerne le mÃªme service (slug)
+    config:
+      tags:
+        - dora
+    columns:
+      - name: mobilisation_id
+        description: identifiant de la mobilisation
+        tests:
+          - unique
+          - not_null
+      - name: user_id
+        description: identifiant de l'utilisateur Ã  l'origine de la prescription
+        tests:
+          - not_null
+      - name: first_following_orientation_id
+        description: id de la premiÃ¨re orientation qui suit la mobilisation. Peut Ãªtre null si aucune orientation est faite suite Ã  la mobilisation.
+      - name: mobilisation_date
+        description: date de la mobilisation
+        tests:
+          - not_null
+      - name: first_following_orientation_date
+        description: date de la premiÃ¨re orientation qui suit la mobilisation. Peut Ãªtre null si aucune orientation est faite suite Ã  la mobilisation.
+      - name: delay
+        description: temps passÃ© en entre la mobilisation et l'orientation.
+  - name: int_dora__mobilisationevent_user
+    description: |
+      Ã‰vÃ©nements de mobilisation des utilisateurs.
+    config:
+      tags:
+        - dora
+    columns:
+      - name: event_id
+        description: |
+          Identifiant de l'Ã©vÃ©nement de mobilisation
+        tests:
+          - unique
+          - not_null
+      - name: user_id
+        tests:
+          - not_null
+  - name: int_dora__orientation_user_service
+    description: |
+      Orientations des utilisateurs vers des services.
+    config:
+      tags:
+        - dora
+      indexes:
+        - columns: [user_id, orientation_creation_date, service_slug]
+    columns:
+      - name: orientation_id
+        description: |
+          Identifiant de l'orientation
+        tests:
+          - unique
+          - not_null
+  - name: int_dora__service_structure
+    description: |
+      Structures de services.
+    config:
+      tags:
+        - dora
+      indexes:
+        - columns: [service_id]
+
+  - name: int_dora__structure_members
+    description: |
+      Membres des structures.
+    config:
+      tags:
+        - dora
+

--- a/dbt/models/staging/dora/properties.yml
+++ b/dbt/models/staging/dora/properties.yml
@@ -1,0 +1,87 @@
+version: 2
+
+models:
+  - name: stg_dora__user
+    config:
+      tags:
+        - dora
+      indexes:
+        - columns: [id]
+          unique: true
+    columns:
+      - name: id
+        data_tests:
+          - unique
+          - not_null
+
+      - name: department
+        description : >
+          Première valeur présente dans la colonne `departments`.
+
+          Il est possible qu’un même utilisateur soit rattaché à plusieurs départements. Pour gérer cette complexité, on a le modèle
+          `int_user_departments`, avec une ligne par couple utilisateur x département.
+
+
+  - name: stg_dora__structure
+    config:
+      tags:
+        - dora
+      indexes:
+        - columns: [id]
+          unique: true
+    columns:
+      - name: id
+        data_tests:
+          - unique
+          - not_null
+      - name: id_jointure_di
+        description: >
+          id prefixé par "dora--" permettant une jointure facile est immédiate avec les données data inclusion.
+
+
+  - name: stg_dora__orientation
+    config:
+      tags:
+        - dora
+      indexes:
+        - columns: [id]
+          unique: true
+    columns:
+      - name: id
+        data_tests:
+          - unique
+          - not_null
+      - name: prescriber_id
+        data_test:
+          - unique
+
+  - name: stg_dora__mobilisationevent
+    config:
+      tags:
+        - dora
+      indexes:
+        - columns: [id]
+          unique: true
+    columns:
+      - name: id
+        data_tests:
+          - unique
+          - not_null
+
+
+
+  - name: stg_dora__service
+    config:
+      tags:
+        - dora
+      indexes:
+        - columns: [id]
+          unique: true
+    columns:
+      - name: id
+        data_tests:
+          - unique
+          - not_null
+      - name: id_jointure_di
+        description: >
+          id prefixé par "dora--" permettant une jointure facile est immédiate avec les données data inclusion.

--- a/dbt/models/staging/dora/stg_dora__mobilisationevent.sql
+++ b/dbt/models/staging/dora/stg_dora__mobilisationevent.sql
@@ -1,0 +1,61 @@
+with src_events as (
+    select * from {{ source('dora', 'stats_mobilisationevent') }}
+),
+
+src_di_events as (
+    select * from {{ source('dora', 'stats_dimobilisationevent') }}
+),
+
+events as (
+    select
+        'dora-' || src.id              as id,
+        src.path,
+        src.date,
+        src.anonymous_user_hash,
+        src.is_logged,
+        src.is_staff,
+        src.is_manager,
+        src.is_an_admin,
+        src.is_structure_admin,
+        src.is_structure_member,
+        src.user_kind,
+        src.structure_department,
+        cast(src.structure_id as text) as structure_id,
+        src.user_id,
+        false                          as is_di
+
+    from src_events as src
+
+),
+
+di_events as (
+    select
+        'di-' || src.id                as id,
+        src.path,
+        src.date,
+        src.anonymous_user_hash,
+        src.is_logged,
+        src.is_staff,
+        src.is_manager,
+        src.is_an_admin,
+        false
+            as is_structure_admin,
+        false
+            as is_structure_member,
+        src.user_kind,
+        src.structure_department,
+        cast(src.structure_id as text) as structure_id,
+        src.user_id,
+        true                           as is_di
+    from src_di_events as src
+),
+
+final as (
+    select * from events
+    union
+    select *
+    from di_events
+    where date >= '2024-01-01'
+)
+
+select * from final

--- a/dbt/models/staging/dora/stg_dora__orientation.sql
+++ b/dbt/models/staging/dora/stg_dora__orientation.sql
@@ -1,0 +1,11 @@
+with orientations as (
+    select * from {{ source('dora', 'orientations_orientation') }}
+),
+
+final as (
+    select * from orientations
+    -- date discutée avec Chloé pour limiter la taille de la table
+    where cast(creation_date as DATE) >= '2024-01-01'
+)
+
+select * from final

--- a/dbt/models/staging/dora/stg_dora__service.sql
+++ b/dbt/models/staging/dora/stg_dora__service.sql
@@ -1,0 +1,41 @@
+with src as (
+    select * from {{ source('dora', 'services_service') }}
+    where is_model is false
+),
+
+services as (
+    select
+        {{ pilo_star(source('dora', 'services_service'), relation_alias='src', except=['geom']) }},
+        'dora--' || src.id               as id_jointure_di,
+        st_y(cast(src.geom as geometry)) as latitude,
+        st_x(cast(src.geom as geometry)) as longitude,
+        case
+            when src.status != 'PUBLISHED' then false
+            when
+                src.update_frequency = 'tous-les-mois'
+                and src.modification_date + interval '1 month' <= now() then true
+            when
+                src.update_frequency = 'tous-les-3-mois'
+                and src.modification_date + interval '3 months' <= now() then true
+            when
+                src.update_frequency = 'tous-les-6-mois'
+                and src.modification_date + interval '6 months' <= now() then true
+            when
+                src.update_frequency = 'tous-les-12-mois'
+                and src.modification_date + interval '12 months' <= now() then true
+            when
+                src.update_frequency = 'tous-les-16-mois'
+                and src.modification_date + interval '16 months' <= now() then true
+            else false
+        end                              as update_needed
+    from src
+),
+
+final as (
+    select
+        services.*,
+        concat('https://dora.inclusion.beta.gouv.fr/services/', services.slug) as dora_url
+    from services
+)
+
+select * from final

--- a/dbt/models/staging/dora/stg_dora__structure.sql
+++ b/dbt/models/staging/dora/stg_dora__structure.sql
@@ -1,0 +1,14 @@
+with structures as (
+    select * from {{ source('dora', 'structures_structure') }}
+),
+
+final as (
+    select
+        structures.*,
+        'dora--' || structures.id                                             as id_jointure_di,
+        concat('https://dora.inclusion.gouv.fr/structures/', structures.slug) as dora_url
+    from structures
+)
+
+select * from final
+where not is_obsolete

--- a/dbt/models/staging/dora/stg_dora__user.sql
+++ b/dbt/models/staging/dora/stg_dora__user.sql
@@ -1,0 +1,30 @@
+with src as (
+    select *
+    from {{ source('dora', 'users_user') }}
+    where
+        is_active is true
+        and is_valid is true
+        and is_staff is false
+),
+
+final as (
+    select
+        id,
+        email,
+        last_name,
+        first_name,
+        is_manager,
+        departments,
+        date_joined,
+        last_login,
+        last_service_reminder_email_sent,
+        newsletter,
+        main_activity,
+        last_service_reminder_email_sent as last_notification_email_sent,
+        departments[1]                   as department,
+        last_login is not null           as is_activated
+    from src
+)
+
+select *
+from final

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
 
   postgres:
     container_name: pilotage_postgres
-    image: postgres:17
+    image: postgis/postgis:17-3.5
     # Disable some safety switches for a faster postgres: https://www.postgresql.org/docs/current/non-durability.html
     command: -c fsync=off -c full_page_writes=off -c synchronous_commit=off
     environment:

--- a/docker/postgres/initdb.d/create-db.sh
+++ b/docker/postgres/initdb.d/create-db.sh
@@ -4,4 +4,6 @@ set -e
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
 	CREATE DATABASE airflow;
 	CREATE DATABASE pilotage;
+	\connect pilotage
+	CREATE EXTENSION IF NOT EXISTS postgis;
 EOSQL


### PR DESCRIPTION
**Carte Notion : ** (non nécessaire si `label=hotfix`)
https://app.notion.com/p/gip-inclusion/Cr-ation-des-mod-les-DORA-n-cessaires-au-tableau-de-bord-des-actes-m-tier-c6b5f321b60483a7b032019cbad93a1e?source=copy_link

### Pourquoi ?
Cette PR ajoute les modèles DORA nécessaires pour répliquer la partie DORA des actes métier.
Comme pour les PR précédentes, je me suis limité à reprendre le plus fidèlement possible les scripts Python actuels des actes métier. La particularité ici, c’est que les modèles DORA existaient déjà. Je les ai donc copiés quasiment tels quels, avec seulement quelques adaptations, notamment un pilotage_star et des noms modifiés pour respecter notre nomenclature. Les fichiers YAML sont aussi les mêmes que dans le repo DORA.
J’ai également ajouté PostGIS au Postgres local, car les modèles DORA calculent la latitude et la longitude des services à partir du champ géographique geom. Sans l’extension PostGIS, le DAG échouait avant même d’arriver au modèle des actes métier.

### Checks

- [x] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

