### PR TITLE
fix definitions in esat survey dbt models documentation

### DIFF
--- a/dbt/models/marts/esat/properties.yml
+++ b/dbt/models/marts/esat/properties.yml
@@ -645,8 +645,8 @@ models:
 
       - name: pct_more_than50
         description: >
-          Nombre de travailleurs et travailleuses de plus de 50 ans ayant travaillé dans
-          l'ESAT en année n-1.
+          Proportion de travailleurs et travailleuses de plus de 50 ans parmi ceux ayant
+          bénéficié d'actions de préparation à la retraite.
 
       - name: documents_falclist
         description: >

--- a/dbt/models/staging/esat/properties.yml
+++ b/dbt/models/staging/esat/properties.yml
@@ -454,8 +454,8 @@ models:
 
         - name: pct_more_than50
           description: >
-            Nombre de travailleurs et travailleuses de plus de 50 ans ayant travaillé
-            dans l’ESAT en année n-1.
+            Proportion de travailleurs et travailleuses de plus de 50 ans parmi ceux
+            ayant bénéficié d’actions de préparation à la retraite.
 
         # Language accessibility
         - name: documents_falclist


### PR DESCRIPTION
**Carte Notion : ** (non nécessaire si `label=hotfix`)
https://app.notion.com/p/gip-inclusion/Ecrire-DAG-extraction-donn-es-ESAT-33b5f321b60480589b90c2f0bb08e43e?source=copy_link

### Pourquoi ?
Je me suis rendu compte que la définition de la colonne 'pct_more_than50' du questionnaire ESAT était incorrecte sur les yml dbt. La PR est uniquement la correction. 

### Checks

- [x] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

