### PR TITLE
add the final sources , models and dags for the replication of actes metier dashboard

### DIFF
--- a/dags/actes_metier.py
+++ b/dags/actes_metier.py
@@ -145,8 +145,8 @@ def fetch_actes_metier_matomo_data_for_site(
 
 
 with DAG(
-    "actes_metier_matomo",
-    schedule="@monthly",
+    "actes_metier",
+    schedule="0 8 1 * *",
     **dag_args,
 ) as dag:
     env_vars = db.connection_envvars()
@@ -190,7 +190,7 @@ with DAG(
 
     dbt_build = bash.BashOperator(
         task_id="dbt_build",
-        bash_command='dbt build --select "+tag:matomo-actes-metier"',
+        bash_command='dbt build --select "tag:actes-metier"',
         env=env_vars,
         append_env=True,
     )

--- a/dags/properties.yml
+++ b/dags/properties.yml
@@ -13,10 +13,10 @@ models:
     description: >
       Ce DAG permet de récupérer (de manière hebdomadaire) pour chaque campagne matomo du c0 et chaque produit du gip les visiteurs et leurs actions.
       Mise à disposition de cette table sur metabase pour les statistiques internes du c0.
-  - name: actes_metier_matomo
+  - name: actes_metier
     description: >
       Ce DAG recupere depuis Matomo les visites mensuelles des pages de recherche Emplois necessaires aux actes metier,
-      sur les 14 derniers mois fermes. Il alimente les tables raw utilisees par dbt pour calculer les actes metier Matomo.
+      sur les 14 derniers mois fermes. Il lance ensuite, chaque premier jour du mois a 08:00, les modèles dbt tagués actes-metier.
   - name: dora
     description: >
       Ce DAG lance les modèles dbt tagués dora à partir des données déjà déposées dans le schéma raw_dora.
@@ -56,4 +56,3 @@ models:
     description: >
       Ce DAG permet de copier (et enventuellement modifier) les tables présentes dans diverses bdd de la PDI, vers une bdd unique.
       Le but est de brancher matometa sur cette unique DB.
-

--- a/dags/sync_marche_db.py
+++ b/dags/sync_marche_db.py
@@ -5,8 +5,9 @@ from pathlib import Path
 
 from airflow import DAG
 from airflow.decorators import task
+from airflow.operators import bash
 
-from dags.common import db, default_dag_args
+from dags.common import db, dbt, default_dag_args
 
 
 DAG_ID = "sync_marche_raw_schema"
@@ -16,6 +17,8 @@ TEMP_SCHEMA = "raw_marche_tmp"
 TARGET_SCHEMA = "raw_marche"
 
 LOCAL_TMP_ROOT = Path("/tmp") / DAG_ID
+
+dag_args = default_dag_args() | {"default_args": dbt.get_default_args()}
 
 
 def run_command(command_name, command, env=None):
@@ -92,8 +95,9 @@ ALTER SCHEMA "{TEMP_SCHEMA}" RENAME TO "{TARGET_SCHEMA}";
 with DAG(
     dag_id=DAG_ID,
     schedule="0 5 * * *",
-    **default_dag_args(),
+    **dag_args,
 ) as dag:
+    env_vars = db.connection_envvars()
 
     @task
     def refresh_raw_schema(**context):
@@ -155,4 +159,25 @@ with DAG(
             shutil.rmtree(base_tmp, ignore_errors=True)
             print("END cleanup_tmp_files")
 
-    refresh_raw_schema()
+    dbt_deps = bash.BashOperator(
+        task_id="dbt_deps",
+        bash_command="dbt deps",
+        env=env_vars,
+        append_env=True,
+    )
+
+    dbt_seed = bash.BashOperator(
+        task_id="dbt_seed",
+        bash_command="dbt seed",
+        env=env_vars,
+        append_env=True,
+    )
+
+    dbt_build = bash.BashOperator(
+        task_id="dbt_build",
+        bash_command='dbt build --select "+tag:marche"',
+        env=env_vars,
+        append_env=True,
+    )
+
+    refresh_raw_schema() >> dbt_deps >> dbt_seed >> dbt_build

--- a/dbt/models/_sources.yml
+++ b/dbt/models/_sources.yml
@@ -470,6 +470,27 @@ sources:
       - name: matomo__actes_metier_matomo_monthly_department_visits
         description: >
           Repartition par dimension personnalisee departement des visites mensuelles Matomo de la recherche d'offres d'emploi.
+
+  - name: raw_marche
+    schema: raw_marche
+    description: >
+      Tables brutes du Marché, chargées par le DAG `sync_marche_raw_schema`.
+    tables:
+      - name: tenders_tender
+        description: >
+          Utilisée pour compter les diffusions d'offre inclusive.
+      - name: users_user
+        description: >
+          Utilisée pour connaître le type de l'auteur d'une diffusion.
+      - name: perimeters_perimeter
+        description: >
+          Utilisée pour rattacher une diffusion à un département.
+      - name: siaes_siaeoffer
+        description: >
+          Utilisée pour compter les mises à jour de fiche entreprise.
+      - name: siaes_siae
+        description: >
+          Utilisée pour rattacher une fiche entreprise à un département.
   - name: monrecap
     schema: monrecap
     description: >

--- a/dbt/models/_sources.yml
+++ b/dbt/models/_sources.yml
@@ -471,6 +471,19 @@ sources:
         description: >
           Repartition par dimension personnalisee departement des visites mensuelles Matomo de la recherche d'offres d'emploi.
 
+  - name: raw_actes_metier
+    schema: raw
+    description: >
+      Tables brutes utilisées pour reconstruire les actes métier historiques.
+    tables:
+      - name: stats_pdi_actes_metiers_data_inclusion
+        identifier: stats_pdi-actes_metiers-data_inclusion
+        quoting:
+          identifier: true
+        description: >
+          Table brute historique des actes métier data inclusion, utilisée pour répliquer le fetcher
+          `fetch_data_inclusion`.
+
   - name: raw_marche
     schema: raw_marche
     description: >

--- a/dbt/models/intermediate/data_inclusion/_models.yml
+++ b/dbt/models/intermediate/data_inclusion/_models.yml
@@ -45,3 +45,92 @@ models:
           combination_of_columns:
             - source
             - source_structure_id
+
+  - name: int_data_inclusion__actes_metier
+    description: >
+      Compte les actes métier data inclusion par mois : recherche data·inclusion, mise à jour de service
+      et mise à jour de structure.
+
+      **ATTENTION : ce modèle réplique directement la logique qui existait sur Autometa pour le tableau de bord des actes métier.
+      Il est possible que cette modélisation soit revue. Si tu es en train de t'en servir pour quelque chose, vérifie d'abord
+      avec l'équipe data.**
+
+    config:
+        tags:
+            - actes-metier
+
+    columns:
+      - name: mois
+        description: >
+          Mois de l'acte, au format `YYYY-MM`. Le modèle garde les 14 derniers mois complets.
+        tests:
+          - not_null
+      - name: source
+        description: Toujours `data-inclusion`.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - data-inclusion
+      - name: type_acte
+        description: Type d'acte métier normalisé.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - Recherche data·inclusion
+                  - Mise à jour d’une structure d’offre de service, hors employeur solidaire
+                  - Mise à jour offre de service, hors emploi solidaire
+      - name: categorie_acte
+        description: Toujours `Support` pour data inclusion.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - Support
+      - name: north_star
+        description: Toujours `false` pour ces actes.
+        tests:
+          - not_null
+      - name: north_star_70
+        description: Toujours `false` pour ces actes.
+        tests:
+          - not_null
+      - name: traite
+        description: Toujours `false` pour ces actes.
+        tests:
+          - not_null
+      - name: type_structure
+        description: >
+          Type de structure déduit du contexte pour les recherches, ou des réseaux porteurs pour les mises à jour.
+          Vaut `Autre` si aucun mapping n'est trouvé.
+        tests:
+          - not_null
+      - name: departement
+        description: Code département normalisé. Vaut `Inconnu` si le département est vide ou non reconnu.
+        tests:
+          - not_null
+      - name: nombre_actes
+        description: Nombre d'actes pour ce grain.
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - mois
+              - source
+              - type_acte
+              - north_star
+              - north_star_70
+              - traite
+              - type_structure
+              - departement

--- a/dbt/models/intermediate/data_inclusion/int_data_inclusion__actes_metier.sql
+++ b/dbt/models/intermediate/data_inclusion/int_data_inclusion__actes_metier.sql
@@ -1,0 +1,269 @@
+with raw_actes as (
+
+    select
+        type_acte_raw,
+        contexte_acte,
+        reseaux_porteurs,
+        to_char(date_trunc('month', mois), 'YYYY-MM') as mois,
+        coalesce(raw_departement, 'Inconnu')          as raw_departement,
+        sum(nombre_actes_metier)                      as nombre_actes
+    from {{ ref('stg_actes_metier__data_inclusion') }}
+    where
+        mois >= date_trunc('month', current_date) - interval '14 months'
+        and mois < date_trunc('month', current_date)
+        and (
+            contexte_acte is null
+            or contexte_acte not in (
+                'emplois-demo-widget',
+                'emplois-pentest-widget',
+                'les-emplois-demo-2026-01',
+                'les-emplois-review-app-2026-01'
+            )
+        )
+    group by
+        to_char(date_trunc('month', mois), 'YYYY-MM'),
+        type_acte_raw,
+        contexte_acte,
+        reseaux_porteurs,
+        coalesce(raw_departement, 'Inconnu')
+
+),
+
+reseau_tokens as (
+
+    select
+        raw_actes.mois,
+        raw_actes.type_acte_raw,
+        raw_actes.contexte_acte,
+        raw_actes.reseaux_porteurs,
+        raw_actes.raw_departement,
+        raw_actes.nombre_actes,
+        tokens.ord,
+        trim(both '"' from trim(tokens.reseau)) as reseau
+    from raw_actes
+    left join
+        lateral unnest(
+            string_to_array(trim(both '{}' from coalesce(raw_actes.reseaux_porteurs, '')), ',')
+        ) with ordinality as tokens (reseau, ord)
+        on raw_actes.type_acte_raw in ('mise à jour de structure', 'mise à jour de service')
+
+),
+
+mapped_reseaux as (
+
+    select
+        mois,
+        type_acte_raw,
+        contexte_acte,
+        reseaux_porteurs,
+        raw_departement,
+        nombre_actes,
+        ord,
+        case reseau
+            when 'france-travail' then 'FRANCE_TRAVAIL'
+            when 'mission-locale' then 'MISSION_LOCALE'
+            when 'cap-emploi-reseau-cheops' then 'CAP_EMPLOI'
+            when 'departements' then 'CONSEIL_DEPARTEMENTAL'
+            when 'maisons-des-solidarites' then 'CONSEIL_DEPARTEMENTAL'
+            when 'maison-departementale-de-lautonomie' then 'CONSEIL_DEPARTEMENTAL'
+            when 'ccas-cias' then 'CCAS_CIAS'
+            when 'caf' then 'CAF_MSA'
+            when 'residences-fjt' then 'CAF_MSA'
+            when 'cnam' then 'CAF_MSA'
+            when 'cpam' then 'CAF_MSA'
+            when 'aci' then 'SIAE'
+            when 'ei' then 'SIAE'
+            when 'etti' then 'SIAE'
+            when 'eiti' then 'SIAE'
+            when 'esat' then 'SIAE'
+            when 'geiq' then 'SIAE'
+            when 'coorace' then 'SIAE'
+            when 'unea' then 'SIAE'
+            when 'chantier-ecole' then 'SIAE'
+            when 'etcld' then 'SIAE'
+            when 'inae' then 'SIAE'
+            when 'agil-ess' then 'SIAE'
+            when 'action-logement' then 'TS_HEBERGEMENT'
+            when 'chrs' then 'TS_HEBERGEMENT'
+            when 'chu' then 'TS_HEBERGEMENT'
+            when 'cada' then 'TS_HEBERGEMENT'
+            when 'cph' then 'TS_HEBERGEMENT'
+            when 'siao' then 'TS_HEBERGEMENT'
+            when 'federation-des-acteurs-de-la-solidarite' then 'TS_HEBERGEMENT'
+            when 'afpa' then 'E2C_EPIDE_AFPA'
+            when 'ecoles-de-la-deuxieme-chance' then 'E2C_EPIDE_AFPA'
+            when 'reseau-app' then 'E2C_EPIDE_AFPA'
+            when 'collectif-emploi' then 'E2C_EPIDE_AFPA'
+            when 'reseau-bge' then 'E2C_EPIDE_AFPA'
+            when 'agefiph' then 'TS_SPECIALISES'
+            when 'cidff' then 'TS_SPECIALISES'
+            when 'csapa' then 'TS_SPECIALISES'
+            when 'cmp' then 'TS_SPECIALISES'
+            when 'mdph' then 'TS_SPECIALISES'
+            when 'croix-rouge' then 'TS_SPECIALISES'
+            when 'restos-du-coeur' then 'TS_SPECIALISES'
+            when 'secours-populaire' then 'TS_SPECIALISES'
+            when 'plie' then 'PLIE'
+            when 'alliance-villes-emploi' then 'PLIE'
+            when 'maisons-de-l-emploi' then 'PLIE'
+            when 'spip' then 'JUSTICE_PROBATION'
+            when 'pjj' then 'JUSTICE_PROBATION'
+            when 'points-justice' then 'JUSTICE_PROBATION'
+            when 'mobin' then 'MOBILITE'
+            when 'wimoov' then 'MOBILITE'
+            when 'conseillers-numeriques' then 'ACC_NUMERIQUE'
+            when 'aidants-connect' then 'ACC_NUMERIQUE'
+            when 'mediation-numerique' then 'ACC_NUMERIQUE'
+        end as mapped_type_structure
+    from reseau_tokens
+
+),
+
+with_reseau_type as (
+
+    select
+        mois,
+        type_acte_raw,
+        contexte_acte,
+        reseaux_porteurs,
+        raw_departement,
+        nombre_actes,
+        coalesce(
+            (array_agg(mapped_type_structure order by ord) filter (
+                where mapped_type_structure is not null and mapped_type_structure != 'ACC_NUMERIQUE'
+            ))[1],
+            (array_agg(mapped_type_structure order by ord) filter (
+                where mapped_type_structure = 'ACC_NUMERIQUE'
+            ))[1],
+            'Autre'
+        ) as reseau_type_structure
+    from mapped_reseaux
+    group by
+        mois,
+        type_acte_raw,
+        contexte_acte,
+        reseaux_porteurs,
+        raw_departement,
+        nombre_actes
+
+),
+
+normalized as (
+
+    select
+        mois,
+        'data-inclusion' as source,
+        'Support'        as categorie_acte,
+        false            as north_star,
+        false            as north_star_70,
+        false            as traite,
+        raw_departement,
+        nombre_actes,
+        case type_acte_raw
+            when 'recherche' then 'Recherche data·inclusion'
+            when 'mise à jour de structure'
+                then 'Mise à jour d’une structure d’offre de service, hors employeur solidaire'
+            when 'mise à jour de service' then 'Mise à jour offre de service, hors emploi solidaire'
+            else type_acte_raw
+        end              as type_acte,
+        case
+            when type_acte_raw in ('mise à jour de structure', 'mise à jour de service') then reseau_type_structure
+            when contexte_acte = 'france-travail' then 'FRANCE_TRAVAIL'
+            when contexte_acte = 'mes-aides-france-travail' then 'FRANCE_TRAVAIL'
+            when contexte_acte = 'pilotage-réunion-france-travail' then 'FRANCE_TRAVAIL'
+            when contexte_acte = 'les-emplois' then 'SIAE'
+            when contexte_acte = 'emplois-de-linclusion' then 'SIAE'
+            when contexte_acte = 'cd35' then 'CONSEIL_DEPARTEMENTAL'
+            when contexte_acte = 'cd80-widget' then 'CONSEIL_DEPARTEMENTAL'
+            when contexte_acte = 'hautespyrenees-widget' then 'CONSEIL_DEPARTEMENTAL'
+            when contexte_acte = 'worldline-parcoursrsa' then 'DELEGATAIRE_RSA'
+            when contexte_acte = 'monenfant' then 'CAF_MSA'
+            when contexte_acte = 'agefiph' then 'TS_SPECIALISES'
+            when contexte_acte = 'finess' then 'TS_SPECIALISES'
+            when contexte_acte = 'action-logement' then 'TS_HEBERGEMENT'
+            when contexte_acte = 'alhpi-widget' then 'TS_HEBERGEMENT'
+            when contexte_acte = 'association-entourage-widget' then 'TS_HEBERGEMENT'
+            when contexte_acte = 'rezosocial.com' then 'TS_HEBERGEMENT'
+            when contexte_acte = 'soliguide' then 'TS_HEBERGEMENT'
+            when contexte_acte = 'cfppa-widget' then 'E2C_EPIDE_AFPA'
+            when contexte_acte = 'ouvreboite-afpa-widget' then 'E2C_EPIDE_AFPA'
+            when contexte_acte = 'cscendoume-widget' then 'CCAS_CIAS'
+            when contexte_acte = 'mdemarseille-widget' then 'CCAS_CIAS'
+            when contexte_acte = 'mon-suivi-social-widget' then 'CCAS_CIAS'
+            when contexte_acte = 'pyramide-est-widget' then 'CCAS_CIAS'
+            else 'Autre'
+        end              as type_structure
+    from with_reseau_type
+
+),
+
+department_tokens as (
+
+    select
+        mois,
+        source,
+        type_acte,
+        categorie_acte,
+        north_star,
+        north_star_70,
+        traite,
+        type_structure,
+        raw_departement,
+        nombre_actes,
+        upper(split_part(trim(cast(raw_departement as text)), ' - ', 1)) as departement_token
+    from normalized
+
+),
+
+with_departement as (
+
+    select
+        mois,
+        source,
+        type_acte,
+        categorie_acte,
+        north_star,
+        north_star_70,
+        traite,
+        type_structure,
+        nombre_actes,
+        case
+            when raw_departement is null or trim(cast(raw_departement as text)) = '' then 'Inconnu'
+            when departement_token in ('2A', '2B') then departement_token
+            when
+                departement_token ~ '^[0-9]+$'
+                and cast(departement_token as integer) between 1 and 95
+                then lpad(cast(cast(departement_token as integer) as text), 2, '0')
+            when
+                departement_token ~ '^[0-9]+$'
+                and cast(departement_token as integer) between 971 and 976
+                then cast(cast(departement_token as integer) as text)
+            else 'Inconnu'
+        end as departement
+    from department_tokens
+
+)
+
+select
+    mois,
+    source,
+    type_acte,
+    categorie_acte,
+    north_star,
+    north_star_70,
+    traite,
+    type_structure,
+    departement,
+    cast(sum(nombre_actes) as integer) as nombre_actes
+from with_departement
+where nombre_actes > 0
+group by
+    mois,
+    source,
+    type_acte,
+    categorie_acte,
+    north_star,
+    north_star_70,
+    traite,
+    type_structure,
+    departement

--- a/dbt/models/intermediate/dora/properties.yml
+++ b/dbt/models/intermediate/dora/properties.yml
@@ -27,7 +27,6 @@ models:
     config:
       tags:
         - actes-metier
-        - dora
     columns:
       - name: mois
         description: >

--- a/dbt/models/intermediate/emplois/int_emplois__actes_metier.sql
+++ b/dbt/models/intermediate/emplois/int_emplois__actes_metier.sql
@@ -1,0 +1,262 @@
+with raw_actes as (
+
+    select
+        to_char(date_trunc('month', candidatures.date_candidature), 'YYYY-MM')                                                   as mois,
+        'emplois'                                                                                                                as source,
+        'candidature_employeur_solidaire'                                                                                        as type_acte_code,
+        'Accompagnement'                                                                                                         as categorie_acte,
+        coalesce(candidatures."état" not in ('Nouvelle candidature', 'Candidature en attente', 'Candidature à l''étude'), false)
+        and candidatures.date_traitement is not null
+        and candidatures.date_traitement - candidatures.date_candidature between 0 and 30
+            as north_star,
+        coalesce(candidatures."état" not in ('Nouvelle candidature', 'Candidature en attente', 'Candidature à l''étude'), false)
+        and candidatures.date_traitement is not null
+        and candidatures.date_traitement - candidatures.date_candidature between 0 and 70
+            as north_star_70,
+        coalesce(candidatures."état" not in ('Nouvelle candidature', 'Candidature en attente', 'Candidature à l''étude'), false)
+            as traite,
+        candidatures.type_org_prescripteur                                                                                       as raw_type_structure,
+        coalesce(candidatures.dept_org, 'Inconnu')                                                                               as raw_departement,
+        count(*)                                                                                                                 as nombre_actes
+    from {{ ref('candidatures_echelle_locale') }} as candidatures
+    where
+        candidatures.injection_ai = 0
+        and candidatures.date_candidature >= date_trunc('month', current_date) - interval '14 months'
+        and candidatures.date_candidature < date_trunc('month', current_date)
+    group by
+        to_char(date_trunc('month', candidatures.date_candidature), 'YYYY-MM'),
+        coalesce(candidatures."état" not in ('Nouvelle candidature', 'Candidature en attente', 'Candidature à l''étude'), false)
+        and candidatures.date_traitement is not null
+        and candidatures.date_traitement - candidatures.date_candidature between 0 and 30,
+        coalesce(candidatures."état" not in ('Nouvelle candidature', 'Candidature en attente', 'Candidature à l''étude'), false)
+        and candidatures.date_traitement is not null
+        and candidatures.date_traitement - candidatures.date_candidature between 0 and 70,
+        coalesce(candidatures."état" not in ('Nouvelle candidature', 'Candidature en attente', 'Candidature à l''étude'), false),
+        candidatures.type_org_prescripteur,
+        coalesce(candidatures.dept_org, 'Inconnu')
+
+    union all
+
+    select
+        to_char(date_trunc('month', fiches.date_creation), 'YYYY-MM') as mois,
+        'emplois'                                                     as source,
+        'creation_offre_emploi'                                       as type_acte_code,
+        'Support'                                                     as categorie_acte,
+        true                                                          as north_star,
+        true                                                          as north_star_70,
+        true                                                          as traite,
+        fiches.type_employeur                                         as raw_type_structure,
+        coalesce(fiches.departement_employeur, 'Inconnu')             as raw_departement,
+        count(*)                                                      as nombre_actes
+    from {{ ref('stg_emplois__fiches_de_poste') }} as fiches
+    where
+        fiches.date_creation >= date_trunc('month', current_date) - interval '14 months'
+        and fiches.date_creation < date_trunc('month', current_date)
+    group by
+        to_char(date_trunc('month', fiches.date_creation), 'YYYY-MM'),
+        fiches.type_employeur,
+        coalesce(fiches.departement_employeur, 'Inconnu')
+
+    union all
+
+    select
+        to_char(date_trunc('month', fiches.date_derniere_modification), 'YYYY-MM') as mois,
+        'emplois'                                                                  as source,
+        'mise_a_jour_offre_emploi'                                                 as type_acte_code,
+        'Support'                                                                  as categorie_acte,
+        true                                                                       as north_star,
+        true                                                                       as north_star_70,
+        true                                                                       as traite,
+        fiches.type_employeur                                                      as raw_type_structure,
+        coalesce(fiches.departement_employeur, 'Inconnu')                          as raw_departement,
+        count(*)                                                                   as nombre_actes
+    from {{ ref('stg_emplois__fiches_de_poste') }} as fiches
+    where
+        fiches.date_derniere_modification > fiches.date_creation
+        and fiches.date_derniere_modification >= date_trunc('month', current_date) - interval '14 months'
+        and fiches.date_derniere_modification < date_trunc('month', current_date)
+    group by
+        to_char(date_trunc('month', fiches.date_derniere_modification), 'YYYY-MM'),
+        fiches.type_employeur,
+        coalesce(fiches.departement_employeur, 'Inconnu')
+
+    union all
+
+    select
+        to_char(date_trunc('month', structures.date_inscription), 'YYYY-MM') as mois,
+        'emplois'                                                            as source,
+        'creation_employeur_solidaire'                                       as type_acte_code,
+        'Support'                                                            as categorie_acte,
+        false                                                                as north_star,
+        false                                                                as north_star_70,
+        false                                                                as traite,
+        'SIAE'                                                               as raw_type_structure,
+        coalesce(structures."département", 'Inconnu')                        as raw_departement,
+        count(*)                                                             as nombre_actes
+    from {{ ref('structures') }} as structures
+    where
+        structures.date_inscription >= date_trunc('month', current_date) - interval '14 months'
+        and structures.date_inscription < date_trunc('month', current_date)
+    group by
+        to_char(date_trunc('month', structures.date_inscription), 'YYYY-MM'),
+        coalesce(structures."département", 'Inconnu')
+
+    union all
+
+    select
+        to_char(date_trunc('month', candidats.date_diagnostic), 'YYYY-MM')                            as mois,
+        'emplois'                                                                                     as source,
+        'diagnostic_iae'                                                                              as type_acte_code,
+        'Accompagnement'                                                                              as categorie_acte,
+        false                                                                                         as north_star,
+        false                                                                                         as north_star_70,
+        false                                                                                         as traite,
+        regexp_replace(trim(candidats.sous_type_auteur_diagnostic), '^[^[:space:]]+[[:space:]]+', '')
+            as raw_type_structure,
+        coalesce(candidats."département_diag", 'Inconnu')                                             as raw_departement,
+        count(distinct candidats.id)                                                                  as nombre_actes
+    from {{ ref('candidats') }} as candidats
+    where
+        candidats.date_diagnostic >= date_trunc('month', current_date) - interval '14 months'
+        and candidats.date_diagnostic < date_trunc('month', current_date)
+    group by
+        to_char(date_trunc('month', candidats.date_diagnostic), 'YYYY-MM'),
+        regexp_replace(trim(candidats.sous_type_auteur_diagnostic), '^[^[:space:]]+[[:space:]]+', ''),
+        coalesce(candidats."département_diag", 'Inconnu')
+
+),
+
+normalized_type_structure as (
+
+    select
+        mois,
+        source,
+        type_acte_code,
+        categorie_acte,
+        north_star,
+        north_star_70,
+        traite,
+        raw_departement,
+        nombre_actes,
+        case
+            when raw_type_structure is null or trim(cast(raw_type_structure as text)) = '' then 'Autre'
+            when raw_type_structure in ('FT', 'PE', 'france_travail') then 'FRANCE_TRAVAIL'
+            when raw_type_structure in ('ML', 'mission_locale') then 'MISSION_LOCALE'
+            when raw_type_structure in ('CAP_EMPLOI', 'cap_emploi') then 'CAP_EMPLOI'
+            when raw_type_structure in ('DEPT', 'CD', 'conseil_departemental') then 'CONSEIL_DEPARTEMENTAL'
+            when raw_type_structure in ('ODC', 'delegataire_rsa', 'DELEGATAIRE_RSA') then 'DELEGATAIRE_RSA'
+            when raw_type_structure in ('CCAS', 'CIAS', 'ASE') then 'CCAS_CIAS'
+            when raw_type_structure in ('SPIP', 'PJJ', 'JUSTICE') then 'JUSTICE_PROBATION'
+            when raw_type_structure in (
+                'CHU', 'CHRS', 'CPH', 'CADA', 'HUDA', 'RS_FJT', 'OIL', 'PENSION', 'ACT', 'LHSS',
+                'CHRS/Accueil de jour', 'Accueil de jour'
+            ) then 'TS_HEBERGEMENT'
+            when raw_type_structure in (
+                'EI', 'AI', 'ACI', 'ETTI', 'EITI', 'GEIQ', 'EA', 'EATT', 'OPCS', 'siae', 'employer',
+                'Groupements d’employeurs pour l’insertion et la qualification', 'SIAE'
+            ) then 'SIAE'
+            when raw_type_structure = 'PLIE' then 'PLIE'
+            when raw_type_structure in ('E2C', 'EPIDE', 'AFPA', 'OF', 'Organisme de formation') then 'E2C_EPIDE_AFPA'
+            when raw_type_structure in ('CIDFF', 'CSAPA', 'CAARUD', 'PREVENTION', 'OHPD', 'OCASF') then 'TS_SPECIALISES'
+            when raw_type_structure in ('CAF', 'MSA') then 'CAF_MSA'
+            when raw_type_structure in ('PIJ_BIJ', 'OACAS', 'CAVA') then 'AUTRES_INSERTION'
+            when raw_type_structure in ('BUYER', 'PARTNER', 'INDIVIDUAL', 'ADMIN') then 'Autre'
+            else 'Autre'
+        end as type_structure
+    from raw_actes
+
+),
+
+department_tokens as (
+
+    select
+        mois,
+        source,
+        type_acte_code,
+        categorie_acte,
+        north_star,
+        north_star_70,
+        traite,
+        type_structure,
+        raw_departement,
+        nombre_actes,
+        upper(split_part(trim(cast(raw_departement as text)), ' - ', 1)) as departement_token
+    from normalized_type_structure
+
+),
+
+normalized as (
+
+    select
+        mois,
+        source,
+        type_acte_code,
+        categorie_acte,
+        north_star,
+        north_star_70,
+        traite,
+        type_structure,
+        nombre_actes,
+        case
+            when raw_departement is null or trim(cast(raw_departement as text)) = '' then 'Inconnu'
+            when departement_token in ('2A', '2B') then departement_token
+            when
+                departement_token ~ '^[0-9]+$'
+                and cast(departement_token as integer) between 1 and 95
+                then lpad(cast(cast(departement_token as integer) as text), 2, '0')
+            when
+                departement_token ~ '^[0-9]+$'
+                and cast(departement_token as integer) between 971 and 976
+                then cast(cast(departement_token as integer) as text)
+            else 'Inconnu'
+        end as departement
+    from department_tokens
+
+),
+
+labeled as (
+
+    select
+        mois,
+        source,
+        categorie_acte,
+        north_star,
+        north_star_70,
+        traite,
+        type_structure,
+        departement,
+        nombre_actes,
+        case type_acte_code
+            when 'candidature_employeur_solidaire' then 'Candidature auprès d’un employeur solidaire'
+            when 'creation_offre_emploi' then 'Création offre d’emploi'
+            when 'mise_a_jour_offre_emploi' then 'Mise à jour offre d’emploi'
+            when 'creation_employeur_solidaire' then 'Création employeur solidaire'
+            when 'diagnostic_iae' then 'Diagnostic IAE'
+        end as type_acte
+    from normalized
+
+)
+
+select
+    mois,
+    source,
+    type_acte,
+    categorie_acte,
+    north_star,
+    north_star_70,
+    traite,
+    type_structure,
+    departement,
+    cast(sum(nombre_actes) as integer) as nombre_actes
+from labeled
+where nombre_actes > 0
+group by
+    mois,
+    source,
+    type_acte,
+    categorie_acte,
+    north_star,
+    north_star_70,
+    traite,
+    type_structure,
+    departement

--- a/dbt/models/intermediate/emplois/properties.yml
+++ b/dbt/models/intermediate/emplois/properties.yml
@@ -1,0 +1,100 @@
+version: 2
+
+models:
+  - name: int_emplois__actes_metier
+    description: >
+      Compte les actes métier Emplois par mois : candidatures, créations et mises à jour d'offres d'emploi,
+      créations d'employeurs solidaires et diagnostics IAE.
+    config:
+      tags:
+        - actes-metier
+    columns:
+      - name: mois
+        description: >
+          Mois de l'acte, au format `YYYY-MM`. Le modèle garde les 14 derniers mois complets.
+        tests:
+          - not_null
+      - name: source
+        description: >
+          Toujours `emplois`.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - emplois
+      - name: type_acte
+        description: >
+          Nom de l'acte : candidature, création ou mise à jour d'offre d'emploi, création d'employeur solidaire
+          ou diagnostic IAE.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - Candidature auprès d’un employeur solidaire
+                  - Création offre d’emploi
+                  - Mise à jour offre d’emploi
+                  - Création employeur solidaire
+                  - Diagnostic IAE
+      - name: categorie_acte
+        description: >
+          Catégorie de l'acte. Les candidatures et diagnostics sont dans `Accompagnement`; les autres actes
+          sont dans `Support`.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - Accompagnement
+                  - Support
+      - name: north_star
+        description: >
+          Vaut `true` pour une candidature traitée en moins de 30 jours et pour les créations ou mises à jour
+          d'offres d'emploi. Vaut `false` sinon.
+        tests:
+          - not_null
+      - name: north_star_70
+        description: >
+          Variante de `north_star` à 70 jours pour les candidatures. Pour les autres actes, même valeur que
+          `north_star`.
+        tests:
+          - not_null
+      - name: traite
+        description: >
+          Vaut `true` pour une candidature sortie des statuts de nouvelle candidature, attente ou étude. Pour les
+          créations et mises à jour d'offres d'emploi, vaut `true`; pour les autres actes, vaut `false`.
+        tests:
+          - not_null
+      - name: type_structure
+        description: >
+          Type de structure normalisé depuis le type de prescripteur, d'employeur ou d'auteur du diagnostic.
+          Vaut `Autre` si le type n'est pas reconnu.
+        tests:
+          - not_null
+      - name: departement
+        description: >
+          Code département normalisé. Vaut `Inconnu` si le département est vide ou non reconnu.
+        tests:
+          - not_null
+      - name: nombre_actes
+        description: >
+          Nombre d'actes pour ce grain.
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - mois
+              - source
+              - type_acte
+              - north_star
+              - north_star_70
+              - traite
+              - type_structure
+              - departement

--- a/dbt/models/intermediate/gps/int_gps__actes_metier.sql
+++ b/dbt/models/intermediate/gps/int_gps__actes_metier.sql
@@ -1,0 +1,154 @@
+with raw_actes as (
+
+    select
+        'GPS'                                                       as source,
+        'Support'                                                   as categorie_acte,
+        false                                                       as north_star,
+        false                                                       as north_star_70,
+        false                                                       as traite,
+        gps_logs.type_org                                           as raw_type_structure,
+        to_char(date_trunc('month', gps_logs.timestamp), 'YYYY-MM') as mois,
+        case
+            when gps_logs.view_name in (
+                'gps:group_memberships',
+                'gps:group_beneficiary',
+                'gps:display_contact_info',
+                'gps:old_group_list'
+            ) then 'Consultation groupe de suivi'
+            else 'Mise à jour groupe de suivi'
+        end                                                         as type_acte,
+        coalesce(gps_logs.dept_org, 'Inconnu')                      as raw_departement,
+        count(*)                                                    as nombre_actes
+    from {{ ref('gps_logs_users') }} as gps_logs
+    where
+        gps_logs.group_id is not null
+        and gps_logs.view_name != 'gps:group_list'
+        and gps_logs.timestamp >= date_trunc('month', current_date) - interval '14 months'
+        and gps_logs.timestamp < date_trunc('month', current_date)
+    group by
+        to_char(date_trunc('month', gps_logs.timestamp), 'YYYY-MM'),
+        case
+            when gps_logs.view_name in (
+                'gps:group_memberships',
+                'gps:group_beneficiary',
+                'gps:display_contact_info',
+                'gps:old_group_list'
+            ) then 'Consultation groupe de suivi'
+            else 'Mise à jour groupe de suivi'
+        end,
+        gps_logs.type_org,
+        coalesce(gps_logs.dept_org, 'Inconnu')
+
+),
+
+normalized_type_structure as (
+
+    select
+        mois,
+        source,
+        type_acte,
+        categorie_acte,
+        north_star,
+        north_star_70,
+        traite,
+        raw_departement,
+        nombre_actes,
+        case
+            when raw_type_structure is null or trim(cast(raw_type_structure as text)) = '' then 'Autre'
+            when raw_type_structure in ('FT', 'PE', 'france_travail') then 'FRANCE_TRAVAIL'
+            when raw_type_structure in ('ML', 'mission_locale') then 'MISSION_LOCALE'
+            when raw_type_structure in ('CAP_EMPLOI', 'cap_emploi') then 'CAP_EMPLOI'
+            when raw_type_structure in ('DEPT', 'CD', 'conseil_departemental') then 'CONSEIL_DEPARTEMENTAL'
+            when raw_type_structure in ('ODC', 'delegataire_rsa', 'DELEGATAIRE_RSA') then 'DELEGATAIRE_RSA'
+            when raw_type_structure in ('CCAS', 'CIAS', 'ASE') then 'CCAS_CIAS'
+            when raw_type_structure in ('SPIP', 'PJJ', 'JUSTICE') then 'JUSTICE_PROBATION'
+            when raw_type_structure in (
+                'CHU', 'CHRS', 'CPH', 'CADA', 'HUDA', 'RS_FJT', 'OIL', 'PENSION', 'ACT', 'LHSS',
+                'CHRS/Accueil de jour', 'Accueil de jour'
+            ) then 'TS_HEBERGEMENT'
+            when raw_type_structure in (
+                'EI', 'AI', 'ACI', 'ETTI', 'EITI', 'GEIQ', 'EA', 'EATT', 'OPCS', 'siae', 'employer',
+                'Groupements d’employeurs pour l’insertion et la qualification', 'SIAE'
+            ) then 'SIAE'
+            when raw_type_structure = 'PLIE' then 'PLIE'
+            when raw_type_structure in ('E2C', 'EPIDE', 'AFPA', 'OF', 'Organisme de formation') then 'E2C_EPIDE_AFPA'
+            when raw_type_structure in ('CIDFF', 'CSAPA', 'CAARUD', 'PREVENTION', 'OHPD', 'OCASF') then 'TS_SPECIALISES'
+            when raw_type_structure in ('CAF', 'MSA') then 'CAF_MSA'
+            when raw_type_structure in ('PIJ_BIJ', 'OACAS', 'CAVA') then 'AUTRES_INSERTION'
+            when raw_type_structure in ('BUYER', 'PARTNER', 'INDIVIDUAL', 'ADMIN') then 'Autre'
+            else 'Autre'
+        end as type_structure
+    from raw_actes
+
+),
+
+department_tokens as (
+
+    select
+        mois,
+        source,
+        type_acte,
+        categorie_acte,
+        north_star,
+        north_star_70,
+        traite,
+        type_structure,
+        raw_departement,
+        nombre_actes,
+        upper(split_part(trim(cast(raw_departement as text)), ' - ', 1)) as departement_token
+    from normalized_type_structure
+
+),
+
+normalized as (
+
+    select
+        mois,
+        source,
+        type_acte,
+        categorie_acte,
+        north_star,
+        north_star_70,
+        traite,
+        type_structure,
+        nombre_actes,
+        case
+            when raw_departement is null or trim(cast(raw_departement as text)) = '' then 'Inconnu'
+            when departement_token in ('2A', '2B') then departement_token
+            when
+                departement_token ~ '^[0-9]+$'
+                and cast(departement_token as integer) between 1 and 95
+                then lpad(cast(cast(departement_token as integer) as text), 2, '0')
+            when
+                departement_token ~ '^[0-9]+$'
+                and cast(departement_token as integer) between 971 and 976
+                then cast(cast(departement_token as integer) as text)
+            else 'Inconnu'
+        end as departement
+    from department_tokens
+
+)
+
+select
+    mois,
+    source,
+    type_acte,
+    categorie_acte,
+    north_star,
+    north_star_70,
+    traite,
+    type_structure,
+    departement,
+    cast(sum(nombre_actes) as integer) as nombre_actes
+from normalized
+where nombre_actes > 0
+group by
+    mois,
+    source,
+    type_acte,
+    categorie_acte,
+    north_star,
+    north_star_70,
+    traite,
+    type_structure,
+    departement

--- a/dbt/models/intermediate/gps/properties.yml
+++ b/dbt/models/intermediate/gps/properties.yml
@@ -1,0 +1,87 @@
+version: 2
+
+models:
+  - name: int_gps__actes_metier
+    description: >
+      Compte les actes métier GPS par mois. Le modèle reprend la logique du fetcher Python.
+      Il distingue les consultations et les mises à jour de groupes de suivi.
+
+      **ATTENTION : ce modèle réplique directement la logique qui existait sur Autometa pour le tableau de bord des actes métier.
+      Il est possible que cette modélisation soit revue. Si tu es en train de t'en servir pour quelque chose, vérifie d'abord
+      avec l'équipe data.**
+    config:
+      tags:
+        - actes-metier
+    columns:
+      - name: mois
+        description: >
+          Mois de l'acte, au format `YYYY-MM`. Le modèle garde les 14 derniers mois complets.
+        tests:
+          - not_null
+      - name: source
+        description: Toujours `GPS`.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - GPS
+      - name: type_acte
+        description: Type d'acte GPS.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - Consultation groupe de suivi
+                  - Mise à jour groupe de suivi
+      - name: categorie_acte
+        description: Toujours `Support` pour GPS.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - Support
+      - name: north_star
+        description: Toujours `false` pour ces actes.
+        tests:
+          - not_null
+      - name: north_star_70
+        description: Toujours `false` pour ces actes.
+        tests:
+          - not_null
+      - name: traite
+        description: Toujours `false` pour ces actes.
+        tests:
+          - not_null
+      - name: type_structure
+        description: >
+          Type de structure normalisé depuis le type d'organisation de l'utilisateur.
+          Vaut `Autre` si le type n'est pas reconnu.
+        tests:
+          - not_null
+      - name: departement
+        description: Code département normalisé. Vaut `Inconnu` si le département est vide ou non reconnu.
+        tests:
+          - not_null
+      - name: nombre_actes
+        description: Nombre d'actes pour ce grain.
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - mois
+              - source
+              - type_acte
+              - north_star
+              - north_star_70
+              - traite
+              - type_structure
+              - departement

--- a/dbt/models/intermediate/marche/int_marche__actes_metier.sql
+++ b/dbt/models/intermediate/marche/int_marche__actes_metier.sql
@@ -1,0 +1,131 @@
+with raw_actes as (
+
+    select
+        to_char(date_trunc('month', tenders.created_at), 'YYYY-MM') as mois,
+        'marche'                                                    as source,
+        'Diffusion d’offre inclusive'                               as type_acte,
+        'Support'                                                   as categorie_acte,
+        coalesce(tenders.siae_count > 0, false)                     as north_star,
+        coalesce(tenders.siae_count > 0, false)                     as north_star_70,
+        coalesce(tenders.siae_count > 0, false)                     as traite,
+        case marche_users.kind
+            when 'SIAE' then 'SIAE'
+            else 'Autre'
+        end                                                         as type_structure,
+        coalesce(perimeters.department_code, 'Inconnu')             as raw_departement,
+        count(*)                                                    as nombre_actes
+    from {{ ref('stg_marche__tenders') }} as tenders
+    left join {{ ref('stg_marche__users') }} as marche_users
+        on tenders.author_id = marche_users.id
+    left join {{ ref('stg_marche__perimeters') }} as perimeters
+        on tenders.location_id = perimeters.id
+    where
+        tenders.kind in ('TENDER', 'PROJ', 'QUOTE')
+        and tenders.status in ('SUBMITTED', 'SENT')
+        and tenders.created_at >= date_trunc('month', current_date) - interval '14 months'
+        and tenders.created_at < date_trunc('month', current_date)
+    group by
+        to_char(date_trunc('month', tenders.created_at), 'YYYY-MM'),
+        coalesce(tenders.siae_count > 0, false),
+        case marche_users.kind
+            when 'SIAE' then 'SIAE'
+            else 'Autre'
+        end,
+        coalesce(perimeters.department_code, 'Inconnu')
+
+    union all
+
+    select
+        to_char(date_trunc('month', siae_offers.updated_at), 'YYYY-MM') as mois,
+        'marche'                                                        as source,
+        'Mise à jour fiche entreprise'                                  as type_acte,
+        'Support'                                                       as categorie_acte,
+        false                                                           as north_star,
+        false                                                           as north_star_70,
+        false                                                           as traite,
+        'SIAE'                                                          as type_structure,
+        coalesce(siaes.department, 'Inconnu')                           as raw_departement,
+        count(*)                                                        as nombre_actes
+    from {{ ref('stg_marche__siae_offers') }} as siae_offers
+    inner join {{ ref('stg_marche__siaes') }} as siaes
+        on siae_offers.siae_id = siaes.id
+    where
+        siae_offers.updated_at >= date_trunc('month', current_date) - interval '14 months'
+        and siae_offers.updated_at < date_trunc('month', current_date)
+    group by
+        to_char(date_trunc('month', siae_offers.updated_at), 'YYYY-MM'),
+        coalesce(siaes.department, 'Inconnu')
+
+),
+
+department_tokens as (
+
+    select
+        mois,
+        source,
+        type_acte,
+        categorie_acte,
+        north_star,
+        north_star_70,
+        traite,
+        type_structure,
+        raw_departement,
+        nombre_actes,
+        split_part(trim(cast(raw_departement as text)), ' - ', 1) as departement_token
+    from raw_actes
+
+),
+
+normalized as (
+
+    select
+        mois,
+        source,
+        type_acte,
+        categorie_acte,
+        north_star,
+        north_star_70,
+        traite,
+        type_structure,
+        nombre_actes,
+        case
+            when raw_departement is null or trim(cast(raw_departement as text)) = '' then 'Inconnu'
+            when upper(departement_token) in ('2A', '2B')
+                then upper(departement_token)
+            when
+                departement_token ~ '^[0-9]+$'
+                and cast(departement_token as integer) between 1 and 95
+                then lpad(cast(cast(departement_token as integer) as text), 2, '0')
+            when
+                departement_token ~ '^[0-9]+$'
+                and cast(departement_token as integer) between 971 and 976
+                then cast(cast(departement_token as integer) as text)
+            else 'Inconnu'
+        end as departement
+    from department_tokens
+
+)
+
+select
+    mois,
+    source,
+    type_acte,
+    categorie_acte,
+    north_star,
+    north_star_70,
+    traite,
+    type_structure,
+    departement,
+    cast(sum(nombre_actes) as integer) as nombre_actes
+from normalized
+where nombre_actes > 0
+group by
+    mois,
+    source,
+    type_acte,
+    categorie_acte,
+    north_star,
+    north_star_70,
+    traite,
+    type_structure,
+    departement

--- a/dbt/models/intermediate/marche/properties.yml
+++ b/dbt/models/intermediate/marche/properties.yml
@@ -1,0 +1,97 @@
+version: 2
+
+models:
+  - name: int_marche__actes_metier
+    description: >
+      Compte les actes métier du Marché par mois : diffusion d'offre inclusive et mise à jour de fiche entreprise.
+    config:
+      tags:
+        - actes-metier
+        - marche
+    columns:
+      - name: mois
+        description: >
+          Mois de l'acte, au format `YYYY-MM`. Le modèle garde les 14 derniers mois complets.
+        tests:
+          - not_null
+      - name: source
+        description: >
+          Toujours `marche`.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - marche
+      - name: type_acte
+        description: >
+          Nom de l'acte. Pour `Mise à jour fiche entreprise`, le modèle utilise `siaes_siaeoffer.updated_at`.
+          Comme `updated_at` change à chaque modification, une fiche peut passer d'un ancien mois à un mois plus récent.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - Diffusion d’offre inclusive
+                  - Mise à jour fiche entreprise
+      - name: categorie_acte
+        description: >
+          Toujours `Support` pour le Marché.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - Support
+      - name: north_star
+        description: >
+          Vaut `true` pour une diffusion d'offre inclusive quand `siae_count > 0`. Vaut `false` sinon.
+        tests:
+          - not_null
+      - name: north_star_70
+        description: >
+          Même valeur que `north_star`.
+        tests:
+          - not_null
+      - name: traite
+        description: >
+          Même valeur que `north_star`.
+        tests:
+          - not_null
+      - name: type_structure
+        description: >
+          Pour une diffusion, vaut `SIAE` si l'auteur est une SIAE, sinon `Autre`. Pour une mise à jour de fiche
+          entreprise, vaut `SIAE`.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - SIAE
+                  - Autre
+      - name: departement
+        description: >
+          Code département normalisé. Vaut `Inconnu` si le département est vide ou non reconnu.
+        tests:
+          - not_null
+      - name: nombre_actes
+        description: >
+          Nombre d'actes pour ce grain.
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - mois
+              - source
+              - type_acte
+              - north_star
+              - north_star_70
+              - traite
+              - type_structure
+              - departement

--- a/dbt/models/intermediate/marche/properties.yml
+++ b/dbt/models/intermediate/marche/properties.yml
@@ -7,7 +7,6 @@ models:
     config:
       tags:
         - actes-metier
-        - marche
     columns:
       - name: mois
         description: >

--- a/dbt/models/intermediate/monrecap/int_monrecap__actes_metier.sql
+++ b/dbt/models/intermediate/monrecap/int_monrecap__actes_metier.sql
@@ -1,0 +1,278 @@
+with recursive commandes as (
+
+    select
+        commandes."Type de structure"                                          as raw_type_structure,
+        commandes."Nom Departement"                                            as raw_departement,
+        to_char(date_trunc('month', commandes."Date d'expédition"), 'YYYY-MM') as mois_expedition,
+        sum(cast(commandes."Nombre de Carnets" as integer))                    as carnets
+    from {{ ref('Commandes') }} as commandes
+    where
+        commandes."Date d'expédition" is not null
+        and commandes."Date d'expédition" >= '2024-01-01'
+        and commandes."Date d'expédition" < date_trunc('month', current_date)
+    group by
+        to_char(date_trunc('month', commandes."Date d'expédition"), 'YYYY-MM'),
+        commandes."Type de structure",
+        commandes."Nom Departement"
+
+),
+
+normalized_commandes as (
+
+    select
+        mois_expedition,
+        carnets,
+        case
+            when raw_type_structure is null or trim(cast(raw_type_structure as text)) = '' then 'Autre'
+            when raw_type_structure in ('FT', 'PE', 'france_travail') then 'FRANCE_TRAVAIL'
+            when raw_type_structure in ('ML', 'mission_locale') then 'MISSION_LOCALE'
+            when raw_type_structure in ('CAP_EMPLOI', 'cap_emploi') then 'CAP_EMPLOI'
+            when raw_type_structure in ('DEPT', 'CD', 'conseil_departemental') then 'CONSEIL_DEPARTEMENTAL'
+            when raw_type_structure in ('ODC', 'delegataire_rsa', 'DELEGATAIRE_RSA') then 'DELEGATAIRE_RSA'
+            when raw_type_structure in ('CCAS', 'CIAS', 'ASE') then 'CCAS_CIAS'
+            when raw_type_structure in ('SPIP', 'PJJ', 'JUSTICE') then 'JUSTICE_PROBATION'
+            when raw_type_structure in (
+                'CHU', 'CHRS', 'CPH', 'CADA', 'HUDA', 'RS_FJT', 'OIL', 'PENSION', 'ACT', 'LHSS',
+                'CHRS/Accueil de jour', 'Accueil de jour'
+            ) then 'TS_HEBERGEMENT'
+            when raw_type_structure in (
+                'EI', 'AI', 'ACI', 'ETTI', 'EITI', 'GEIQ', 'EA', 'EATT', 'OPCS', 'siae', 'employer',
+                'Groupements d’employeurs pour l’insertion et la qualification', 'SIAE'
+            ) then 'SIAE'
+            when raw_type_structure = 'PLIE' then 'PLIE'
+            when raw_type_structure in ('E2C', 'EPIDE', 'AFPA', 'OF', 'Organisme de formation') then 'E2C_EPIDE_AFPA'
+            when raw_type_structure in ('CIDFF', 'CSAPA', 'CAARUD', 'PREVENTION', 'OHPD', 'OCASF') then 'TS_SPECIALISES'
+            when raw_type_structure in ('CAF', 'MSA') then 'CAF_MSA'
+            when raw_type_structure in ('PIJ_BIJ', 'OACAS', 'CAVA') then 'AUTRES_INSERTION'
+            when raw_type_structure in ('BUYER', 'PARTNER', 'INDIVIDUAL', 'ADMIN') then 'Autre'
+            else 'Autre'
+        end as type_structure,
+        case
+            when raw_departement is null or trim(cast(raw_departement as text)) = '' then 'Inconnu'
+            when upper(split_part(trim(cast(raw_departement as text)), ' - ', 1)) in ('2A', '2B')
+                then upper(split_part(trim(cast(raw_departement as text)), ' - ', 1))
+            when
+                split_part(trim(cast(raw_departement as text)), ' - ', 1) ~ '^[0-9]+$'
+                and cast(split_part(trim(cast(raw_departement as text)), ' - ', 1) as integer) between 1 and 95
+                then lpad(cast(cast(split_part(trim(cast(raw_departement as text)), ' - ', 1) as integer) as text), 2, '0')
+            when
+                split_part(trim(cast(raw_departement as text)), ' - ', 1) ~ '^[0-9]+$'
+                and cast(split_part(trim(cast(raw_departement as text)), ' - ', 1) as integer) between 971 and 976
+                then cast(cast(split_part(trim(cast(raw_departement as text)), ' - ', 1) as integer) as text)
+            else 'Inconnu'
+        end as departement
+    from commandes
+
+),
+
+grouped_commandes as (
+
+    select
+        mois_expedition,
+        type_structure,
+        departement,
+        sum(carnets) as carnets
+    from normalized_commandes
+    group by
+        mois_expedition,
+        type_structure,
+        departement
+
+),
+
+distribution as (
+
+    select
+        to_char(
+            to_date(grouped_commandes.mois_expedition || '-01', 'YYYY-MM-DD')
+            + ((months_after.value - 1) * interval '1 month'),
+            'YYYY-MM'
+        )                                                                                    as mois,
+        grouped_commandes.mois_expedition,
+        'monrecap'                                                                           as source,
+        'Distribution carnet Mon Récap'                                                      as type_acte,
+        'Accompagnement'                                                                     as categorie_acte,
+        false                                                                                as north_star,
+        false                                                                                as north_star_70,
+        false                                                                                as traite,
+        grouped_commandes.type_structure,
+        grouped_commandes.departement,
+        cast(grouped_commandes.carnets as double precision) * cast(0.10 as double precision) as nombre_actes
+    from grouped_commandes
+    cross join generate_series(1, 10) as months_after (value)
+
+),
+
+remplissage as (
+
+    select
+        to_char(
+            to_date(grouped_commandes.mois_expedition || '-01', 'YYYY-MM-DD')
+            + ((months_after.value - 1) * interval '1 month'),
+            'YYYY-MM'
+        )                                 as mois,
+        grouped_commandes.mois_expedition,
+        'monrecap'                        as source,
+        'Remplissage carnet Mon Récap'    as type_acte,
+        'Support'                         as categorie_acte,
+        false                             as north_star,
+        false                             as north_star_70,
+        false                             as traite,
+        grouped_commandes.type_structure,
+        grouped_commandes.departement,
+        cast(grouped_commandes.carnets as double precision)
+        * (
+            least(cast(months_after.value as double precision) / 10, 1)
+            - least(cast(greatest(months_after.value - 6, 0) as double precision) / 10, 1)
+        )
+        * cast(1.093 as double precision) as nombre_actes
+    from grouped_commandes
+    cross join generate_series(1, 6) as months_after (value)
+
+),
+
+actes as (
+
+    select *
+    from distribution
+
+    union all
+
+    select *
+    from remplissage
+
+),
+
+ordered_actes as (
+
+    select
+        mois,
+        mois_expedition,
+        source,
+        type_acte,
+        categorie_acte,
+        north_star,
+        north_star_70,
+        traite,
+        type_structure,
+        departement,
+        nombre_actes,
+        row_number() over (
+            partition by
+                mois,
+                source,
+                type_acte,
+                categorie_acte,
+                north_star,
+                north_star_70,
+                traite,
+                type_structure,
+                departement
+            order by mois_expedition
+        ) as contribution_rank
+    from actes
+    where
+        to_date(mois || '-01', 'YYYY-MM-DD') >= date_trunc('month', current_date) - interval '14 months'
+        and to_date(mois || '-01', 'YYYY-MM-DD') < date_trunc('month', current_date)
+
+),
+
+running_totals as (
+
+    select
+        mois,
+        source,
+        type_acte,
+        categorie_acte,
+        north_star,
+        north_star_70,
+        traite,
+        type_structure,
+        departement,
+        contribution_rank,
+        nombre_actes as running_nombre_actes
+    from ordered_actes
+    where contribution_rank = 1
+
+    union all
+
+    select
+        ordered_actes.mois,
+        ordered_actes.source,
+        ordered_actes.type_acte,
+        ordered_actes.categorie_acte,
+        ordered_actes.north_star,
+        ordered_actes.north_star_70,
+        ordered_actes.traite,
+        ordered_actes.type_structure,
+        ordered_actes.departement,
+        ordered_actes.contribution_rank,
+        running_totals.running_nombre_actes + ordered_actes.nombre_actes as running_nombre_actes
+    from running_totals
+    inner join ordered_actes
+        on
+            running_totals.mois = ordered_actes.mois
+            and running_totals.source = ordered_actes.source
+            and running_totals.type_acte = ordered_actes.type_acte
+            and running_totals.categorie_acte = ordered_actes.categorie_acte
+            and running_totals.north_star = ordered_actes.north_star
+            and running_totals.north_star_70 = ordered_actes.north_star_70
+            and running_totals.traite = ordered_actes.traite
+            and running_totals.type_structure = ordered_actes.type_structure
+            and running_totals.departement = ordered_actes.departement
+            and running_totals.contribution_rank + 1 = ordered_actes.contribution_rank
+
+),
+
+aggregated as (
+
+    select
+        mois,
+        source,
+        type_acte,
+        categorie_acte,
+        north_star,
+        north_star_70,
+        traite,
+        type_structure,
+        departement,
+        running_nombre_actes as nombre_actes
+    from running_totals
+    where not exists (
+        select 1
+        from running_totals as next_contribution
+        where
+            running_totals.mois = next_contribution.mois
+            and running_totals.source = next_contribution.source
+            and running_totals.type_acte = next_contribution.type_acte
+            and running_totals.categorie_acte = next_contribution.categorie_acte
+            and running_totals.north_star = next_contribution.north_star
+            and running_totals.north_star_70 = next_contribution.north_star_70
+            and running_totals.traite = next_contribution.traite
+            and running_totals.type_structure = next_contribution.type_structure
+            and running_totals.departement = next_contribution.departement
+            and running_totals.contribution_rank + 1 = next_contribution.contribution_rank
+    )
+
+),
+
+rounded as (
+
+    select
+        mois,
+        source,
+        type_acte,
+        categorie_acte,
+        north_star,
+        north_star_70,
+        traite,
+        type_structure,
+        departement,
+        cast(round(nombre_actes) as integer) as nombre_actes
+    from aggregated
+
+)
+
+select *
+from rounded
+where nombre_actes > 0

--- a/dbt/models/intermediate/monrecap/properties.yml
+++ b/dbt/models/intermediate/monrecap/properties.yml
@@ -1,0 +1,89 @@
+version: 2
+
+models:
+  - name: int_monrecap__actes_metier
+    description: >
+      Compte les actes métier Mon Récap par mois. Le modèle reprend la logique du fetcher Python.
+      Il transforme les carnets expédiés en actes de distribution et de remplissage.
+
+      **ATTENTION : ce modèle réplique directement la logique qui existait sur Autometa pour le tableau de bord des actes métier.
+      Il est possible que cette modélisation soit revue. Si tu es en train de t'en servir pour quelque chose, vérifie d'abord
+      avec l'équipe data.**
+    config:
+      tags:
+        - actes-metier
+    columns:
+      - name: mois
+        description: >
+          Mois de l'acte, au format `YYYY-MM`. Le modèle garde les 14 derniers mois complets.
+        tests:
+          - not_null
+      - name: source
+        description: Toujours `monrecap`.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - monrecap
+      - name: type_acte
+        description: Type d'acte Mon Récap.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - Distribution carnet Mon Récap
+                  - Remplissage carnet Mon Récap
+      - name: categorie_acte
+        description: >
+          `Accompagnement` pour la distribution. `Support` pour le remplissage.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - Accompagnement
+                  - Support
+      - name: north_star
+        description: Toujours `false` pour ces actes.
+        tests:
+          - not_null
+      - name: north_star_70
+        description: Toujours `false` pour ces actes.
+        tests:
+          - not_null
+      - name: traite
+        description: Toujours `false` pour ces actes.
+        tests:
+          - not_null
+      - name: type_structure
+        description: >
+          Type de structure normalisé depuis le type de structure de la commande.
+          Vaut `Autre` si le type n'est pas reconnu.
+        tests:
+          - not_null
+      - name: departement
+        description: Code département normalisé. Vaut `Inconnu` si le département est vide ou non reconnu.
+        tests:
+          - not_null
+      - name: nombre_actes
+        description: Nombre d'actes pour ce grain.
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - mois
+              - source
+              - type_acte
+              - north_star
+              - north_star_70
+              - traite
+              - type_structure
+              - departement

--- a/dbt/models/intermediate/properties.yml
+++ b/dbt/models/intermediate/properties.yml
@@ -224,7 +224,7 @@ models:
       avec l'équipe data.**
 
     config:
-      tags: ["matomo-actes-metier"]
+      tags: ["actes-metier"]
 
     columns:
       - name: nombre_actes
@@ -232,4 +232,3 @@ models:
           - dbt_utils.accepted_range:
               arguments:
                 min_value: 0
-

--- a/dbt/models/intermediate/rdvi/properties.yml
+++ b/dbt/models/intermediate/rdvi/properties.yml
@@ -13,7 +13,6 @@ models:
     config:
       tags:
         - actes-metier
-        - rdv-insertion
     columns:
       - name: mois
         tests:

--- a/dbt/models/marts/properties.yml
+++ b/dbt/models/marts/properties.yml
@@ -115,7 +115,7 @@ models:
       avec l'équipe data.**
 
     config:
-      tags: ["matomo-actes-metier"]
+      tags: ["actes-metier"]
 
     tests:
       - dbt_utils.unique_combination_of_columns:

--- a/dbt/models/staging/data_inclusion/_models.yml
+++ b/dbt/models/staging/data_inclusion/_models.yml
@@ -219,3 +219,38 @@ models:
         description: Score de qualité de la fiche structure.
       - name: doublons
         description: Liste des doublons identifiés pour cette structure.
+
+  - name: stg_actes_metier__data_inclusion
+    description: >
+      Vue simple sur la table brute historique des actes métier data inclusion.
+
+    config:
+        tags:
+            - actes-metier
+
+    tests:
+      - dbt_utils.equal_rowcount:
+          arguments:
+            compare_model: source('raw_actes_metier', 'stats_pdi_actes_metiers_data_inclusion')
+
+    columns:
+      - name: mois
+        description: Mois de comptabilisation de l'acte métier.
+      - name: type_acte_raw
+        description: Type d'acte brut dans la table source.
+        tests:
+          - not_null
+      - name: contexte_acte
+        description: Contexte applicatif utilisé pour rattacher les recherches à un type de structure.
+      - name: reseaux_porteurs
+        description: Réseaux porteurs utilisés pour rattacher les mises à jour à un type de structure.
+      - name: raw_departement
+        description: Département brut avant normalisation.
+      - name: nombre_actes_metier
+        description: Nombre d'actes métier fourni par la source.
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true

--- a/dbt/models/staging/data_inclusion/stg_actes_metier__data_inclusion.sql
+++ b/dbt/models/staging/data_inclusion/stg_actes_metier__data_inclusion.sql
@@ -1,0 +1,8 @@
+select
+    mois::date                    as mois,
+    type_acte::text               as type_acte_raw,
+    contexte_acte::text           as contexte_acte,
+    reseaux_porteurs::text        as reseaux_porteurs,
+    departement::text             as raw_departement,
+    nombre_actes_metiers::integer as nombre_actes_metier
+from {{ source('raw_actes_metier', 'stats_pdi_actes_metiers_data_inclusion') }}

--- a/dbt/models/staging/emplois/_properties.yml
+++ b/dbt/models/staging/emplois/_properties.yml
@@ -1,6 +1,27 @@
 version: 2
 
 models:
+  - name: stg_emplois__fiches_de_poste
+    description: >
+      Fiches de poste publiées sur les Emplois de l'Inclusion.
+    config:
+      tags:
+        - actes-metier
+    columns:
+      - name: id
+        description: Identifiant unique de la fiche de poste.
+        tests:
+          - not_null
+          - unique
+      - name: date_creation
+        description: Date de création de la fiche de poste.
+      - name: date_derniere_modification
+        description: Date de dernière modification de la fiche de poste.
+      - name: type_employeur
+        description: Type de l'employeur porteur de la fiche de poste.
+      - name: departement_employeur
+        description: Département de l'employeur porteur de la fiche de poste.
+
   - name: stg_emplois__imer
     description: >
       Intentions de mise en relation (IMER) effectuées sur les

--- a/dbt/models/staging/emplois/stg_emplois__fiches_de_poste.sql
+++ b/dbt/models/staging/emplois/stg_emplois__fiches_de_poste.sql
@@ -1,0 +1,19 @@
+select
+    id,
+    code_rome,
+    nom_rome,
+    recrutement_ouvert,
+    type_contrat,
+    id_employeur,
+    type_employeur,
+    siret_employeur,
+    nom_employeur,
+    mises_a_jour_champs,
+    "département_employeur"      as departement_employeur,
+    "nom_département_employeur"  as nom_departement_employeur,
+    "région_employeur"           as region_employeur,
+    total_candidatures,
+    "date_création"              as date_creation,
+    "date_dernière_modification" as date_derniere_modification,
+    "date_mise_à_jour_metabase"  as date_mise_a_jour_metabase
+from {{ source('emplois', 'fiches_de_poste') }}

--- a/dbt/models/staging/marche/properties.yml
+++ b/dbt/models/staging/marche/properties.yml
@@ -1,0 +1,62 @@
+version: 2
+
+models:
+  - name: stg_marche__tenders
+    description: >
+      Vue simple sur `raw_marche.tenders_tender`, avec les colonnes utiles aux actes métier.
+    config:
+      tags:
+        - marche
+    columns:
+      - name: id
+        tests:
+          - not_null
+          - unique
+
+  - name: stg_marche__users
+    description: >
+      Vue simple sur `raw_marche.users_user`, avec les colonnes utiles aux actes métier.
+    config:
+      tags:
+        - marche
+    columns:
+      - name: id
+        tests:
+          - not_null
+          - unique
+
+  - name: stg_marche__perimeters
+    description: >
+      Vue simple sur `raw_marche.perimeters_perimeter`, avec les colonnes utiles aux actes métier.
+    config:
+      tags:
+        - marche
+    columns:
+      - name: id
+        tests:
+          - not_null
+          - unique
+
+  - name: stg_marche__siae_offers
+    description: >
+      Vue simple sur `raw_marche.siaes_siaeoffer`, avec les colonnes utiles aux actes métier.
+    config:
+      tags:
+        - marche
+    columns:
+      - name: id
+        tests:
+          - not_null
+          - unique
+
+  - name: stg_marche__siaes
+    description: >
+      Vue simple sur `raw_marche.siaes_siae`, avec les colonnes utiles aux actes métier.
+    config:
+      tags:
+        - marche
+    columns:
+      - name: id
+        tests:
+          - not_null
+          - unique

--- a/dbt/models/staging/marche/stg_marche__perimeters.sql
+++ b/dbt/models/staging/marche/stg_marche__perimeters.sql
@@ -1,0 +1,4 @@
+select
+    id,
+    department_code
+from {{ source('raw_marche', 'perimeters_perimeter') }}

--- a/dbt/models/staging/marche/stg_marche__siae_offers.sql
+++ b/dbt/models/staging/marche/stg_marche__siae_offers.sql
@@ -1,0 +1,5 @@
+select
+    id,
+    siae_id,
+    updated_at::timestamp as updated_at
+from {{ source('raw_marche', 'siaes_siaeoffer') }}

--- a/dbt/models/staging/marche/stg_marche__siaes.sql
+++ b/dbt/models/staging/marche/stg_marche__siaes.sql
@@ -1,0 +1,4 @@
+select
+    id,
+    department
+from {{ source('raw_marche', 'siaes_siae') }}

--- a/dbt/models/staging/marche/stg_marche__tenders.sql
+++ b/dbt/models/staging/marche/stg_marche__tenders.sql
@@ -1,0 +1,9 @@
+select
+    id,
+    author_id,
+    location_id,
+    kind,
+    status,
+    siae_count,
+    created_at::timestamp as created_at
+from {{ source('raw_marche', 'tenders_tender') }}

--- a/dbt/models/staging/marche/stg_marche__users.sql
+++ b/dbt/models/staging/marche/stg_marche__users.sql
@@ -1,0 +1,4 @@
+select
+    id,
+    kind
+from {{ source('raw_marche', 'users_user') }}

--- a/dbt/models/staging/matomo/stg_matomo__properties.yml
+++ b/dbt/models/staging/matomo/stg_matomo__properties.yml
@@ -10,7 +10,7 @@ models:
       avec l'équipe data.**
 
     config:
-      tags: ["matomo-actes-metier"]
+      tags: ["actes-metier"]
 
 
     columns:
@@ -30,7 +30,7 @@ models:
       avec l'équipe data.**
 
     config:
-      tags: ["matomo-actes-metier"]
+      tags: ["actes-metier"]
 
 
     columns:

--- a/dbt/models/staging/rdvi/properties.yml
+++ b/dbt/models/staging/rdvi/properties.yml
@@ -9,7 +9,6 @@ models:
 
     config:
       tags:
-        - actes-metier
         - rdv-insertion
     columns:
       - name: id
@@ -45,7 +44,6 @@ models:
 
     config:
       tags:
-        - actes-metier
         - rdv-insertion
     columns:
       - name: id
@@ -74,7 +72,6 @@ models:
 
     config:
       tags:
-        - actes-metier
         - rdv-insertion
     columns:
       - name: id
@@ -129,7 +126,6 @@ models:
 
     config:
       tags:
-        - actes-metier
         - rdv-insertion
     columns:
       - name: invitation_id
@@ -145,7 +141,6 @@ models:
 
     config:
       tags:
-        - actes-metier
         - rdv-insertion
     columns:
       - name: id
@@ -175,7 +170,6 @@ models:
 
     config:
       tags:
-        - actes-metier
         - rdv-insertion
     columns:
       - name: id
@@ -218,7 +212,6 @@ models:
 
     config:
       tags:
-        - actes-metier
         - rdv-insertion
     columns:
       - name: id
@@ -252,7 +245,6 @@ models:
 
     config:
       tags:
-        - actes-metier
         - rdv-insertion
     columns:
       - name: id


### PR DESCRIPTION
**Carte Notion : ** (non nécessaire si `label=hotfix`)
https://app.notion.com/p/gip-inclusion/Finaliser-la-cr-ation-des-mod-les-dbt-pour-les-fetchers-du-tableau-de-bord-des-actes-m-tier-0d45f321b60482c09631017433c785f5?source=copy_link

### Pourquoi ?
 Après les PRs précédentes, celle-ci termine l’ajout des fetchers restants afin de pouvoir reconstruire le mart final qui agrège les modèles intermédiaires.

Je peux squasher les commits si besoin. 

### Checks

- [x] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

