### PR TITLE
[Autometa et sécurite] anonymisation du NIR en amont

### DIFF
--- a/dags/common/anonymize_sensitive_columns.py
+++ b/dags/common/anonymize_sensitive_columns.py
@@ -1,0 +1,73 @@
+import hashlib
+import hmac
+import logging
+
+import sqlalchemy
+from airflow.decorators import task
+from airflow.models import Variable
+
+from dags.common import db
+
+
+logger = logging.getLogger(__name__)
+
+COLS_TO_ANONYMIZE = ["hash_nir", "hash_numéro_pass_iae"]
+
+# Each table must be anonymized exactly once per reload (hashing is not idempotent), so a DAG only
+# anonymizes the tables its own pipeline reloads just before running.
+DAILY_TABLES_TO_ANONYMIZE = ["candidats_v0", "candidatures", "pass_agréments"]
+WEEKLY_TABLES_TO_ANONYMIZE = ["fluxIAE_Salarie"]
+
+
+def get_hmac_secret():
+    return Variable.get("MATOMETA_HMAC_SECRET").encode()
+
+
+def _columns_to_anonymize(conn, tables):
+    stmt = sqlalchemy.text(
+        """
+        SELECT table_name, column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name IN :tables AND column_name IN :cols
+        """
+    ).bindparams(
+        sqlalchemy.bindparam("tables", expanding=True),
+        sqlalchemy.bindparam("cols", expanding=True),
+    )
+    return conn.execute(stmt, {"tables": tables, "cols": COLS_TO_ANONYMIZE}).fetchall()
+
+
+def _anonymize_column(conn, secret, table, column):
+    from psycopg2.extras import execute_values
+
+    select = f'SELECT DISTINCT "{column}" FROM "public"."{table}" WHERE "{column}" IS NOT NULL'
+    values = conn.execute(sqlalchemy.text(select)).scalars().all()
+    if not values:
+        return
+
+    mapping = [(v, hmac.new(secret, str(v).encode(), hashlib.sha256).hexdigest()) for v in values]
+
+    conn.execute(sqlalchemy.text("CREATE TEMP TABLE _anonymize_map (old text, new text) ON COMMIT DROP"))
+    with conn.connection.cursor() as cur:
+        execute_values(cur, "INSERT INTO _anonymize_map (old, new) VALUES %s", mapping, page_size=10_000)
+    result = conn.execute(
+        sqlalchemy.text(
+            f'UPDATE "public"."{table}" t SET "{column}" = m.new '
+            f'FROM _anonymize_map m WHERE t."{column}"::text = m.old'
+        )
+    )
+    logger.info("Anonymized %s.%s: %d distinct values, %d rows updated", table, column, len(mapping), result.rowcount)
+
+
+@task
+def anonymize_nir(tables):
+    secret = get_hmac_secret()
+
+    with db.DBConnection(db_url_variable="EMPLOIS_DB_URL_SECRET_local") as emplois_db:
+        with emplois_db.engine.begin() as conn:
+            targets = _columns_to_anonymize(conn, tables)
+
+        logger.info("Anonymizing %d column(s): %s", len(targets), targets)
+        for table, column in targets:
+            with emplois_db.engine.begin() as conn:
+                _anonymize_column(conn, secret, table, column)

--- a/dags/dbt_daily.py
+++ b/dags/dbt_daily.py
@@ -4,6 +4,7 @@ from airflow.models.param import Param
 from airflow.operators import bash
 
 from dags.common import db, dbt, default_dag_args, slack
+from dags.common.anonymize_sensitive_columns import DAILY_TABLES_TO_ANONYMIZE, anonymize_nir
 
 
 dag_args = default_dag_args() | {"default_args": dbt.get_default_args()}
@@ -67,4 +68,13 @@ with airflow.DAG(
         append_env=True,
     )
 
-    (params_check() >> dbt_debug >> dbt_deps >> dbt_seed >> dbt_run >> dbt_test >> slack.success_notifying_task())
+    (
+        params_check()
+        >> anonymize_nir(DAILY_TABLES_TO_ANONYMIZE)
+        >> dbt_debug
+        >> dbt_deps
+        >> dbt_seed
+        >> dbt_run
+        >> dbt_test
+        >> slack.success_notifying_task()
+    )

--- a/dags/dbt_weekly.py
+++ b/dags/dbt_weekly.py
@@ -4,6 +4,7 @@ from airflow.models.param import Param
 from airflow.operators import bash
 
 from dags.common import db, dbt, default_dag_args, slack
+from dags.common.anonymize_sensitive_columns import WEEKLY_TABLES_TO_ANONYMIZE, anonymize_nir
 
 
 dag_args = default_dag_args() | {"default_args": dbt.get_default_args()}
@@ -61,4 +62,13 @@ with airflow.DAG(
         append_env=True,
     )
 
-    (params_check() >> dbt_debug >> dbt_deps >> dbt_seed >> dbt_run >> dbt_test >> slack.success_notifying_task())
+    (
+        params_check()
+        >> anonymize_nir(WEEKLY_TABLES_TO_ANONYMIZE)
+        >> dbt_debug
+        >> dbt_deps
+        >> dbt_seed
+        >> dbt_run
+        >> dbt_test
+        >> slack.success_notifying_task()
+    )

--- a/dags/populate_matometa_database.py
+++ b/dags/populate_matometa_database.py
@@ -1,11 +1,8 @@
-import hashlib
-import hmac
 import json
 import logging
 
 from airflow import DAG
 from airflow.decorators import task
-from airflow.models import Variable
 
 from dags.common import db, dbt, default_dag_args, slack
 
@@ -52,16 +49,8 @@ TABLES_DORA = [
     "stats_structureview",
 ]
 
-COLS_TO_ANONYMIZE = ["hash_nir", "hash_numéro_pass_iae"]
-
-
-def get_hmac_secret():
-    return Variable.get("MATOMETA_HMAC_SECRET").encode()
-
 
 def sync_tables(table_names, src_schema, dest_schema, from_db=None):
-    secret = get_hmac_secret()
-
     with db.DBConnection(db_url_variable="MATOMETA_DB_URL_SECRET", ssh_conn_id="matometa_scalingo_ssh") as dst_db:
         for table in table_names:
             query = f'SELECT * FROM "{src_schema}"."{table}";'
@@ -74,15 +63,6 @@ def sync_tables(table_names, src_schema, dest_schema, from_db=None):
                 for col in chunk.columns:
                     if chunk[col].dtype == object:
                         chunk[col] = chunk[col].map(lambda x: json.dumps(x) if isinstance(x, (dict, list)) else x)
-
-                for col in COLS_TO_ANONYMIZE:
-                    if col in chunk.columns:
-                        chunk[col] = chunk[col].map(
-                            lambda x, s=secret: hmac.new(s, str(x).encode(), hashlib.sha256).hexdigest()
-                            if x is not None
-                            else None
-                        )
-                        logger.info("Anonymized column %s in table %s.", col, table)
 
                 dst_db.to_sql(chunk, table=table, schema=dest_schema, if_exists="replace" if i == 0 else "append")
                 logger.info("Exported %d rows to %s.%s", len(chunk), dest_schema, table)


### PR DESCRIPTION
**Carte Notion : ** (non nécessaire si `label=hotfix`)

### Pourquoi ?

Afin de pouvoir merge [cette PR](https://github.com/gip-inclusion/autometa/pull/168) correctement il faut changer la sycnhro de la doc AM + anonymiser les données en amont côté pilotage.

J'ai donc décidé d'anonymiser les fichiers sources d'où proviennent les colonnes clés. Cela se fait dans les deux scripts quui gèrent ces colonnes, dbt_daily et dbt_weekly.

Il faut que cela soit présent dans les deux scripts, car ces deux DAGS font des jointures entre les données de l'ASP et des emplois, donc c'est mieux si tout colle :smile: 

### Checks

- [ ] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [ ] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [ ] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

