### PR TITLE
Update FAGERH prestation mapping and parse direct beneficiaries

### DIFF
--- a/dbt/models/intermediate/fagerh/int_fagerh__prestations.sql
+++ b/dbt/models/intermediate/fagerh/int_fagerh__prestations.sql
@@ -86,9 +86,10 @@ final as (
         nullif(prestation_json ->> 'sorties', '')::integer                                                            as sorties,
         nullif(prestation_json ->> 'journees', '')::numeric                                                           as journees,
         nullif(prestation_json ->> 'journeesTheoriques', '')::numeric                                                 as journees_theoriques,
-        nullif(prestation_json #>> '{directAvecOrp,row,beneficiaires}', '')::integer                                  as direct_beneficiaires,
-
+        nullif(prestation_json #>> '{directAvecOrp,row,beneficiaires}', '')::integer                                  as direct_avec_orp_beneficiaires,
+        nullif(prestation_json #>> '{directSansOrp,rows,pec,beneficiaires}', '')::integer                             as direct_sans_orp_beneficiaires,
         nullif(prestation_json #>> '{directAvecOrp,row,discontinue_personnes}', '')::integer                          as direct_discontinue_personnes,
+
         nullif(prestation_json #>> '{directAvecOrp,row,presentiel_total}', '')::integer                               as direct_presentiel_total,
         nullif(prestation_json #>> '{directAvecOrp,row,presentiel_complet}', '')::integer                             as direct_presentiel_complet,
         nullif(prestation_json #>> '{directAvecOrp,row,presentiel_partiel}', '')::integer                             as direct_presentiel_partiel,
@@ -96,18 +97,18 @@ final as (
         nullif(prestation_json #>> '{directAvecOrp,row,hybride_complet}', '')::integer                                as direct_hybride_complet,
         nullif(prestation_json #>> '{directAvecOrp,row,hybride_partiel}', '')::integer                                as direct_hybride_partiel,
         nullif(prestation_json #>> '{directAvecOrp,row,distanciel_total}', '')::integer                               as direct_distanciel_total,
-
         nullif(prestation_json #>> '{directAvecOrp,row,distanciel_complet}', '')::integer                             as direct_distanciel_complet,
-        nullif(prestation_json #>> '{directAvecOrp,row,distanciel_partiel}', '')::integer                             as direct_distanciel_partiel,
 
+        nullif(prestation_json #>> '{directAvecOrp,row,distanciel_partiel}', '')::integer                             as direct_distanciel_partiel,
         nullif(prestation_json #>> '{directAvecOrp,row,hors_murs_personnes}', '')::integer                            as direct_hors_murs_personnes,
+
         nullif(prestation_json #>> '{directAvecOrp,row,hors_murs_journees}', '')::numeric                             as direct_hors_murs_journees,
         nullif(prestation_json #>> '{directAvecOrp,row,hebergees_personnes}', '')::integer                            as direct_hebergees_personnes,
-
         nullif(prestation_json #>> '{directAvecOrp,row,hebergees_journees}', '')::numeric                             as direct_hebergees_journees,
-        nullif(prestation_json #>> '{directAvecOrp,row,hebergees_nuitees}', '')::integer                              as direct_hebergees_nuitees,
 
+        nullif(prestation_json #>> '{directAvecOrp,row,hebergees_nuitees}', '')::integer                              as direct_hebergees_nuitees,
         nullif(prestation_json #>> '{sortiesBloc,nb}', '')::integer                                                   as sorties_nb,
+
         nullif(prestation_json #>> '{sortiesBloc,raisons,depart_volontaire}', '')::integer                            as sorties_depart_volontaire,
         nullif(prestation_json #>> '{sortiesBloc,raisons,sante}', '')::integer                                        as sorties_sante,
         nullif(prestation_json #>> '{sortiesBloc,raisons,reorientation}', '')::integer                                as sorties_reorientation,
@@ -116,15 +117,15 @@ final as (
         nullif(prestation_json #>> '{sortiesBloc,raisons,reprise_emploi}', '')::integer                               as sorties_reprise_emploi,
         nullif(prestation_json #>> '{sortiesBloc,raisons,je_ne_sais_pas}', '')::integer                               as sorties_je_ne_sais_pas,
         nullif(prestation_json #>> '{sortiesBloc,raisons,autres_nb}', '')::integer                                    as sorties_autres_nb,
-
         nullif(prestation_json #>> '{suspensionsBloc,nb}', '')::integer                                               as suspensions_nb,
+
         nullif(prestation_json #>> '{suspensionsBloc,raisons,sante_non_liee}', '')::integer                           as suspensions_sante_non_liee,
         nullif(prestation_json #>> '{suspensionsBloc,raisons,evolution_handicap}', '')::integer                       as suspensions_evolution_handicap,
         nullif(prestation_json #>> '{suspensionsBloc,raisons,evolution_sociale}', '')::integer                        as suspensions_evolution_sociale,
         nullif(prestation_json #>> '{suspensionsBloc,raisons,parcours_suspendu}', '')::integer                        as suspensions_parcours_suspendu,
         nullif(prestation_json #>> '{suspensionsBloc,raisons,autres_nb}', '')::integer                                as suspensions_autres_nb,
-
         nullif(prestation_json #>> '{preconisationsBloc,emploi_milieu_ordinaire}', '')::integer                       as preco_emploi_milieu_ordinaire,
+
         nullif(prestation_json #>> '{preconisationsBloc,entreprise_adaptee}', '')::integer                            as preco_entreprise_adaptee,
         nullif(prestation_json #>> '{preconisationsBloc,esat}', '')::integer                                          as preco_esat,
         nullif(prestation_json #>> '{preconisationsBloc,creation_entreprise}', '')::integer                           as preco_creation_entreprise,
@@ -133,17 +134,17 @@ final as (
         nullif(prestation_json #>> '{preconisationsBloc,formation_alternance}', '')::integer                          as preco_formation_alternance,
         nullif(prestation_json #>> '{preconisationsBloc,formation_esrp_dfa}', '')::integer                            as preco_formation_esrp_dfa,
         nullif(prestation_json #>> '{preconisationsBloc,espo_specialisee_ueros}', '')::integer                        as preco_espo_specialisee_ueros,
-
         nullif(prestation_json #>> '{preconisationsBloc,service_accompagnement_social}', '')::integer                 as preco_service_accompagnement_social,
+
         nullif(prestation_json #>> '{preconisationsBloc,vie_sociale}', '')::integer                                   as preco_vie_sociale,
         nullif(prestation_json #>> '{preconisationsBloc,soins}', '')::integer                                         as preco_soins,
         nullif(prestation_json #>> '{preconisationsBloc,emploi_accompagne}', '')::integer                             as preco_emploi_accompagne,
         nullif(prestation_json #>> '{preconisationsBloc,autres}', '')::integer                                        as preco_autres,
-
         nullif(prestation_json #>> '{directAvecOrp,row,emploi_sorties_n_1}', '')::integer                             as emploi_sorties_n_1,
-        nullif(prestation_json #>> '{directAvecOrp,row,emploi_nb_repondants}', '')::integer                           as emploi_nb_repondants,
 
+        nullif(prestation_json #>> '{directAvecOrp,row,emploi_nb_repondants}', '')::integer                           as emploi_nb_repondants,
         nullif(prestation_json #>> '{directAvecOrp,row,emploi_acces_nb}', '')::integer                                as emploi_acces_nb,
+
         nullif(prestation_json #>> '{directAvecOrp,row,emploi_acces_cdi}', '')::integer                               as emploi_acces_cdi,
         nullif(prestation_json #>> '{directAvecOrp,row,emploi_acces_cdd_plus6}', '')::integer                         as emploi_acces_cdd_plus6,
         nullif(prestation_json #>> '{directAvecOrp,row,emploi_acces_cdd_moins6}', '')::integer                        as emploi_acces_cdd_moins6,
@@ -151,14 +152,23 @@ final as (
         nullif(prestation_json #>> '{directAvecOrp,row,emploi_acces_interim}', '')::integer                           as emploi_acces_interim,
         nullif(prestation_json #>> '{directAvecOrp,row,emploi_acces_autre}', '')::integer                             as emploi_acces_autre,
         nullif(prestation_json #>> '{directAvecOrp,row,emploi_acces_encore_nb}', '')::integer                         as emploi_acces_encore_nb,
-
         nullif(prestation_json #>> '{directAvecOrp,row,emploi_sans_acces_formation_qualifiante_nb}', '')::integer     as emploi_sans_acces_formation_qualifiante_nb,
+
         nullif(prestation_json #>> '{directAvecOrp,row,emploi_sans_acces_formation_non_qualifiante_nb}', '')::integer as emploi_sans_acces_formation_non_qualifiante_nb,
         nullif(prestation_json #>> '{directAvecOrp,row,emploi_sans_acces_stage_nb}', '')::integer                     as emploi_sans_acces_stage_nb,
         nullif(prestation_json #>> '{directAvecOrp,row,emploi_sans_acces_benevolat_nb}', '')::integer                 as emploi_sans_acces_benevolat_nb,
         nullif(prestation_json #>> '{directAvecOrp,row,emploi_presence_nb}', '')::integer                             as emploi_presence_nb,
-
         prestation_json                                                                                               as json_prestation_raw,
+
+        case
+            when
+                nullif(prestation_json #>> '{directAvecOrp,row,beneficiaires}', '') is null
+                and nullif(prestation_json #>> '{directSansOrp,rows,pec,beneficiaires}', '') is null
+                then null
+            else
+                coalesce(nullif(prestation_json #>> '{directAvecOrp,row,beneficiaires}', '')::integer, 0)
+                + coalesce(nullif(prestation_json #>> '{directSansOrp,rows,pec,beneficiaires}', '')::integer, 0)
+        end                                                                                                           as direct_beneficiaires,
         prestation_json -> 'visitedBlocks'                                                                            as visited_blocks,
 
         prestation_json -> 'coh' -> 'genre'                                                                           as json_coh_genre,

--- a/dbt/models/intermediate/fagerh/properties.yml
+++ b/dbt/models/intermediate/fagerh/properties.yml
@@ -50,6 +50,20 @@ models:
         data_tests:
           - not_null
 
+      - name: direct_beneficiaires
+        description: >
+          Nombre total de bénéficiaires déclarés dans les blocs des prestations directes.
+          Il additionne les bénéficiaires avec ORP CDAPH et sans ORP CDAPH.
+
+      - name: direct_avec_orp_beneficiaires
+        description: >
+          Nombre de bénéficiaires déclaré dans le bloc des prestations directes avec ORP CDAPH.
+
+      - name: direct_sans_orp_beneficiaires
+        description: >
+          Nombre de bénéficiaires déclaré dans le bloc des prestations directes sans ORP CDAPH.
+          Ce champ est notamment utilisé pour certaines évaluations préliminaires hors ORP.
+
   - name: int_fagerh__prestations_publics
 
     config:

--- a/dbt/models/marts/fagerh/fagerh__activite_prestations.sql
+++ b/dbt/models/marts/fagerh/fagerh__activite_prestations.sql
@@ -39,6 +39,8 @@ final as (
         prestations.journees_theoriques,
 
         prestations.direct_beneficiaires,
+        prestations.direct_avec_orp_beneficiaires,
+        prestations.direct_sans_orp_beneficiaires,
         prestations.direct_hors_murs_personnes,
         prestations.direct_hors_murs_journees,
 

--- a/dbt/models/marts/fagerh/properties.yml
+++ b/dbt/models/marts/fagerh/properties.yml
@@ -99,7 +99,18 @@ models:
         description: Nombre de journées théoriques.
 
       - name: direct_beneficiaires
-        description: Nombre de bénéficiaires déclarés pour la prestation directe.
+        description: >
+          Nombre total de bénéficiaires déclarés dans les blocs des prestations directes.
+          Il additionne les bénéficiaires avec ORP CDAPH et sans ORP CDAPH.
+
+      - name: direct_avec_orp_beneficiaires
+        description: >
+          Nombre de bénéficiaires déclaré dans le bloc des prestations directes avec ORP CDAPH.
+
+      - name: direct_sans_orp_beneficiaires
+        description: >
+          Nombre de bénéficiaires déclaré dans le bloc des prestations directes sans ORP CDAPH.
+          Ce champ est notamment utilisé pour certaines évaluations préliminaires hors ORP.
 
       - name: direct_hors_murs_personnes
         description: Nombre de personnes accompagnées hors les murs.

--- a/dbt/seeds/new_seeds/fagerh/seed_fagerh__prestation_mapping.csv
+++ b/dbt/seeds/new_seeds/fagerh/seed_fagerh__prestation_mapping.csv
@@ -2,13 +2,13 @@ prestation_key_base,prestation_group,prestation_label,orp_status,is_direct,is_re
 directes-orp-cdaph-ueros,Directes,UEROS,Avec ORP CDAPH,true,true
 directes-orp-cdaph-espo,Directes,ESPO,Avec ORP CDAPH,true,true
 directes-orp-cdaph-esrp,Directes,ESRP,Avec ORP CDAPH,true,true
-directes-orp-cdaph-prestation-d-evaluations-et-de,Directes,,,true,false
-directes-orp-cdaph-autre-dispositif-d-evaluation-a,Directes,Autre dispositif d'évaluation avec ORP CDAPH,Avec ORP CDAPH,true,true
-directes-orp-cdaph-autre-dispositif-d-evaluation-s,Directes,Autre dispositif d'évaluation sans ORP CDAPH,Sans ORP CDAPH,true,true
-directes-orp-cdaph-parcours-a-visee-socio-professi,Parcours socio-pro,,Avec ORP CDAPH,true,false
-directes-orp-cdaph-parcours-accompagnement-a-visee,Parcours à visée certifiante,,Avec ORP CDAPH,true,false
-directes-hors-orp-cdaph-evaluations-professionnell,Directes sans ORP,Évaluations professionnelles,Hors ORP CDAPH,true,true
-directes-hors-orp-cdaph-informations-aux-personnes,Directes sans ORP,Informations aux personnes,Hors ORP CDAPH,true,true
+directes-orp-cdaph-prestation-d-evaluations-et-de,Directes,Évaluations préliminaires ,,true,false
+directes-orp-cdaph-autre-dispositif-d-evaluation-a,Directes,Évaluations préliminaires ,Avec ORP CDAPH,true,true
+directes-orp-cdaph-autre-dispositif-d-evaluation-s,Directes,Évaluations préliminaires ,Sans ORP CDAPH,true,true
+directes-orp-cdaph-parcours-a-visee-socio-professi,Parcours socio-pro,Parcours socio-pro,Avec ORP CDAPH,true,false
+directes-orp-cdaph-parcours-accompagnement-a-visee,Parcours à visée certifiante,Parcours à visée certifiante,Avec ORP CDAPH,true,false
+directes-hors-orp-cdaph-evaluations-professionnell,Directes,Évaluations préliminaires ,Hors ORP CDAPH,true,true
+directes-hors-orp-cdaph-informations-aux-personnes,Directes,Évaluations préliminaires ,Hors ORP CDAPH,true,true
 indirectes-informations-partenaires,Indirectes,Informations partenaires,,false,true
 indirectes-informations-organisme-de-formation,Indirectes,Informations organismes formation,,false,true
 indirectes-participations-mdph,Indirectes,Participations MDPH,,false,true


### PR DESCRIPTION
**Carte Notion : ** (non nécessaire si `label=hotfix`)
https://app.notion.com/p/gip-inclusion/FAGERH-Int-grer-les-retours-utilisateurs-3aa5f321b60480dea35bcb9c8e805d0c?source=copy_link

### Pourquoi ?
On a reçu des retours de la FAGERH concernant le tableau de bord. Cette PR vise à en traiter une partie, notamment en améliorant le comptage des accompagnements dans les prestations.

### Checks

- [x] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [ ] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

