### PR TITLE
add models for parsing employment rate for fagerh survey

### DIFF
--- a/dags/fagerh_ingestion_questionnaire.py
+++ b/dags/fagerh_ingestion_questionnaire.py
@@ -70,6 +70,13 @@ with DAG(
         append_env=True,
     )
 
+    dbt_seed = bash.BashOperator(
+        task_id="dbt_seed",
+        bash_command="dbt seed",
+        env=env_vars,
+        append_env=True,
+    )
+
     dbt_build = bash.BashOperator(
         task_id="dbt_build",
         bash_command='dbt build --select "+tag:fagerh"',
@@ -79,4 +86,4 @@ with DAG(
 
     loaded = load_raw_csv_to_db()
 
-    loaded >> dbt_debug >> dbt_deps >> dbt_build
+    loaded >> dbt_debug >> dbt_deps >> dbt_seed >> dbt_build

--- a/dags/fagerh_ingestion_questionnaire.py
+++ b/dags/fagerh_ingestion_questionnaire.py
@@ -70,13 +70,6 @@ with DAG(
         append_env=True,
     )
 
-    dbt_seed = bash.BashOperator(
-        task_id="dbt_seed",
-        bash_command="dbt seed",
-        env=env_vars,
-        append_env=True,
-    )
-
     dbt_build = bash.BashOperator(
         task_id="dbt_build",
         bash_command='dbt build --select "+tag:fagerh"',
@@ -86,4 +79,4 @@ with DAG(
 
     loaded = load_raw_csv_to_db()
 
-    loaded >> dbt_debug >> dbt_deps >> dbt_seed >> dbt_build
+    loaded >> dbt_debug >> dbt_deps >> dbt_build

--- a/dbt/models/intermediate/fagerh/int_fagerh__prestations.sql
+++ b/dbt/models/intermediate/fagerh/int_fagerh__prestations.sql
@@ -12,6 +12,13 @@ prestation_mapping as (
 
 ),
 
+prestations_details_names as (
+
+    select *
+    from {{ ref('int_fagerh__prestations_details_names') }}
+
+),
+
 prestations as (
 
     select
@@ -66,16 +73,21 @@ prestations_enriched as (
 final as (
 
     select
-        uuid,
-        answer_id,
-        prestation_key,
-        prestation_key_base,
+        prestations_enriched.uuid,
+        prestations_enriched.answer_id,
+        prestations_enriched.prestation_key,
+        prestations_enriched.prestation_key_base,
 
-        prestation_group,
-        prestation_label,
-        orp_status,
-        is_reliable_prestation_mapping,
-        is_unmapped_prestation,
+        prestations_enriched.prestation_group,
+        prestations_enriched.prestation_label,
+        prestations_enriched.orp_status,
+        prestations_enriched.is_reliable_prestation_mapping,
+        prestations_enriched.is_unmapped_prestation,
+        prestations_details_names.conditional_name                                                                    as prestation_name_detail,
+        prestations_details_names.prestation_category_fine,
+        prestations_details_names.formation_name,
+        prestations_details_names.is_technical_step,
+        prestations_details_names.is_emploi_relevant,
 
         (prestation_json ->> 'done')::boolean                                                                         as prestation_done,
         nullif(prestation_json ->> 'fileActive', '')::integer                                                         as nb_files_active,
@@ -191,6 +203,11 @@ final as (
         nullif(prestation_json #>> '{preconisationsBloc,autres_precision}', '')                                       as preco_autres_precision
 
     from prestations_enriched
+
+    left join prestations_details_names
+        on
+            prestations_enriched.uuid = prestations_details_names.uuid
+            and prestations_enriched.prestation_key = prestations_details_names.conditional_id
 
 )
 

--- a/dbt/models/intermediate/fagerh/int_fagerh__prestations_details_names.sql
+++ b/dbt/models/intermediate/fagerh/int_fagerh__prestations_details_names.sql
@@ -1,0 +1,86 @@
+with source as (
+
+    select *
+    from {{ ref('stg_fagerh__reponses') }}
+
+),
+
+conditional_defs as (
+
+    select
+        source.uuid,
+        conditional_def.value ->> 'id'   as conditional_id,
+        conditional_def.value ->> 'name' as conditional_name
+
+    from source
+
+    cross join lateral jsonb_array_elements(
+        case
+            when
+                jsonb_typeof(
+                    coalesce(nullif(source.prestations_details_json, ''), '{}')::jsonb
+                    #> '{__wizard_v3_state,runtime,conditionalDefs}'
+                ) = 'array'
+                then
+                    coalesce(nullif(source.prestations_details_json, ''), '{}')::jsonb
+                    #> '{__wizard_v3_state,runtime,conditionalDefs}'
+            else '[]'::jsonb
+        end
+    ) as conditional_def (value)
+
+),
+
+classified as (
+
+    select
+        uuid,
+        conditional_id,
+        conditional_name,
+
+        case
+            when conditional_name like '%Préparer à accéder à une formation / remise à niveau savoirs de base%'
+                then 'parcours_preparatoire'
+            when conditional_name like '%Formation certifiante ou diplômante - Formation:%'
+                then 'formation_certifiante'
+            when conditional_name like '%Formation accompagnée certifiante%'
+                then 'formation_accompagnee_certifiante_dfa'
+            when conditional_name like '%Formation professionnalisante (ne débouchant pas sur un diplôme)%'
+                then 'formation_professionnalisante_non_certifiante'
+            when conditional_name like '%Formation accompagnée professionnalisante%'
+                then 'formation_accompagnee_professionnalisante_non_certifiante_dfa'
+        end                                                                                     as prestation_category_fine,
+
+        case
+            when conditional_name like '%Formation certifiante ou diplômante - Formation:%'
+                then nullif(
+                    coalesce(
+                        substring(split_part(conditional_name, ' - Formation: ', 2) from '^(.*) \(Niveau .+\)$'),
+                        split_part(conditional_name, ' - Formation: ', 2)
+                    ),
+                    ''
+                )
+        end                                                                                     as formation_name,
+
+        conditional_name like '%Formation certifiante ou diplômante - Sélection des formations' as is_technical_step
+
+    from conditional_defs
+
+),
+
+final as (
+
+    select
+        uuid,
+        conditional_id,
+        conditional_name,
+        prestation_category_fine,
+        formation_name,
+        is_technical_step,
+        prestation_category_fine is not null and is_technical_step is false as is_emploi_relevant
+
+    from classified
+
+)
+
+select *
+from final

--- a/dbt/models/intermediate/fagerh/properties.yml
+++ b/dbt/models/intermediate/fagerh/properties.yml
@@ -45,6 +45,21 @@ models:
         data_tests:
           - not_null
 
+      - name: prestation_name_detail
+        description: Libellé détaillé de l'étape conditionnelle dans le wizard FAGERH.
+
+      - name: prestation_category_fine
+        description: Catégorie fine de parcours issue du libellé détaillé de l'étape conditionnelle.
+
+      - name: formation_name
+        description: Nom de la formation lorsque la prestation correspond à une formation certifiante ou diplômante.
+
+      - name: is_technical_step
+        description: Indique si la ligne correspond à une étape technique du formulaire, par exemple la sélection des formations.
+
+      - name: is_emploi_relevant
+        description: Indique si la prestation doit être retenue dans le calcul du taux d'accès à l'emploi par catégorie fine.
+
       - name: prestation_done
         description: Indique si la prestation a été renseignée jusqu'au bout.
         data_tests:
@@ -63,6 +78,64 @@ models:
         description: >
           Nombre de bénéficiaires déclaré dans le bloc des prestations directes sans ORP CDAPH.
           Ce champ est notamment utilisé pour certaines évaluations préliminaires hors ORP.
+
+  - name: int_fagerh__prestations_details_names
+
+    config:
+      tags: ["fagerh"]
+
+    description: >
+      Données de libellés détaillés des prestations, extraites de l'état complet du wizard FAGERH.
+      Le modèle contient une ligne par réponse et par étape conditionnelle déclarée dans `prestations_details_json`.
+      Il permet de relier les prestations à une catégorie fine de parcours et au nom de formation quand il existe.
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - uuid
+            - conditional_id
+
+    columns:
+      - name: uuid
+        description: Identifiant unique de la réponse du questionnaire.
+        data_tests:
+          - not_null
+
+      - name: conditional_id
+        description: Identifiant technique de l'étape conditionnelle. Il correspond à la clé de prestation dans `prestations_json`.
+        data_tests:
+          - not_null
+
+      - name: conditional_name
+        description: Libellé complet de l'étape conditionnelle dans le wizard.
+        data_tests:
+          - not_null
+
+      - name: prestation_category_fine
+        description: Catégorie fine utilisée pour analyser le taux d'accès à l'emploi des parcours à visée certifiante.
+        data_tests:
+          - accepted_values:
+              values:
+                - parcours_preparatoire
+                - formation_certifiante
+                - formation_accompagnee_certifiante_dfa
+                - formation_professionnalisante_non_certifiante
+                - formation_accompagnee_professionnalisante_non_certifiante_dfa
+              config:
+                where: "prestation_category_fine is not null"
+
+      - name: formation_name
+        description: Nom de la formation pour les lignes de formation certifiante ou diplômante.
+
+      - name: is_technical_step
+        description: Indique si la ligne correspond à une étape technique du formulaire.
+        data_tests:
+          - not_null
+
+      - name: is_emploi_relevant
+        description: Indique si la ligne est à retenir pour les analyses de taux d'accès à l'emploi par catégorie fine.
+        data_tests:
+          - not_null
 
   - name: int_fagerh__prestations_publics
 

--- a/dbt/models/marts/fagerh/fagerh__activite_prestations.sql
+++ b/dbt/models/marts/fagerh/fagerh__activite_prestations.sql
@@ -68,6 +68,22 @@ final as (
         prestations.emploi_acces_interim,
         prestations.emploi_acces_autre,
 
+        prestations.preco_emploi_milieu_ordinaire,
+        prestations.preco_entreprise_adaptee,
+        prestations.preco_esat,
+        prestations.preco_creation_entreprise,
+        prestations.preco_maintien_emploi,
+        prestations.preco_formation_droit_commun,
+        prestations.preco_formation_alternance,
+        prestations.preco_formation_esrp_dfa,
+        prestations.preco_espo_specialisee_ueros,
+        prestations.preco_service_accompagnement_social,
+        prestations.preco_vie_sociale,
+        prestations.preco_soins,
+        prestations.preco_emploi_accompagne,
+        prestations.preco_autres,
+        prestations.preco_autres_precision,
+
         coalesce(prestations.emploi_acces_cdi, 0)
         + coalesce(prestations.emploi_acces_cdd_plus6, 0)                                                        as emploi_durable_nb,
 

--- a/dbt/models/marts/fagerh/fagerh__activite_prestations.sql
+++ b/dbt/models/marts/fagerh/fagerh__activite_prestations.sql
@@ -27,6 +27,11 @@ final as (
         prestations.orp_status,
         prestations.is_reliable_prestation_mapping,
         prestations.is_unmapped_prestation,
+        prestations.prestation_name_detail,
+        prestations.prestation_category_fine,
+        prestations.formation_name,
+        prestations.is_technical_step,
+        prestations.is_emploi_relevant,
 
         prestations.nb_files_active,
         prestations.preaccueil_sans_suite,
@@ -51,7 +56,28 @@ final as (
 
         prestations.direct_presentiel_total,
         prestations.direct_hybride_total,
-        prestations.direct_distanciel_total
+        prestations.direct_distanciel_total,
+
+        prestations.emploi_nb_repondants,
+        prestations.emploi_acces_nb,
+        prestations.emploi_presence_nb,
+        prestations.emploi_acces_cdi,
+        prestations.emploi_acces_cdd_plus6,
+        prestations.emploi_acces_cdd_moins6,
+        prestations.emploi_acces_alternance,
+        prestations.emploi_acces_interim,
+        prestations.emploi_acces_autre,
+
+        coalesce(prestations.emploi_acces_cdi, 0)
+        + coalesce(prestations.emploi_acces_cdd_plus6, 0)                                                        as emploi_durable_nb,
+
+        coalesce(prestations.emploi_acces_cdd_moins6, 0)
+        + coalesce(prestations.emploi_acces_alternance, 0)
+        + coalesce(prestations.emploi_acces_interim, 0)
+        + coalesce(prestations.emploi_acces_autre, 0)                                                            as emploi_autre_nb,
+
+        {{ safe_divide('prestations.emploi_acces_nb', 'prestations.emploi_nb_repondants') }}    as taux_acces_emploi,
+        {{ safe_divide('prestations.emploi_presence_nb', 'prestations.emploi_nb_repondants') }} as taux_presence_emploi
 
     from prestations
 

--- a/dbt/models/marts/fagerh/properties.yml
+++ b/dbt/models/marts/fagerh/properties.yml
@@ -14,8 +14,27 @@ models:
       * Il rassemble les informations principales de la prestation, de l'établissement et du département.
       * Il contient aussi les principaux indicateurs d'activité : effectifs actifs, sorties, journées, hébergement, accompagnement hors les murs
       et suspensions.
+      * Il expose les indicateurs emploi et la catégorie fine des parcours utiles au calcul du taux d'accès à l'emploi.
 
-      Il ne contient pas le détail des publics, des préconisations, de l'emploi ou des métiers.
+      Pour calculer les taux d'emploi des formations certifiantes ou professionnalisantes, il faut:
+      * filtrer `is_emploi_relevant = true`.
+      * garder les catégories fines `formation_certifiante`, `formation_accompagnee_certifiante_dfa`,
+      `formation_professionnalisante_non_certifiante` et `formation_accompagnee_professionnalisante_non_certifiante_dfa`.
+      * grouper par la dimension d'analyse souhaitée, par exemple `prestation_category_fine`, `departement` ou `formation_name`.
+      * calculer les taux après agrégation: `sum(emploi_acces_nb) / sum(emploi_nb_repondants)` et
+      `sum(emploi_presence_nb) / sum(emploi_nb_repondants)`.
+      Il ne faut pas moyenner les colonnes `taux_acces_emploi` ou `taux_presence_emploi` ligne par ligne.
+
+      Il ne contient pas le détail des publics, des préconisations ou des métiers.
+
+    tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "emploi_durable_nb + emploi_autre_nb <= emploi_acces_nb"
+          config:
+            severity: warn
+            where: "emploi_acces_nb is not null"
+
     columns:
       - name: uuid
         description: Identifiant unique de la réponse au questionnaire.
@@ -73,6 +92,27 @@ models:
           Cette colonne sert au contrôle qualité.
         data_tests:
           - not_null
+
+      - name: prestation_name_detail
+        description: Libellé détaillé de la prestation dans le wizard FAGERH.
+
+      - name: prestation_category_fine
+        description: >
+          Catégorie fine de parcours issue du libellé détaillé de la prestation.
+          Pour répondre aux demandes sur les formations certifiantes ou professionnalisantes, utiliser les valeurs
+          `formation_certifiante`, `formation_accompagnee_certifiante_dfa`,
+          `formation_professionnalisante_non_certifiante` et `formation_accompagnee_professionnalisante_non_certifiante_dfa`.
+
+      - name: formation_name
+        description: Nom de la formation lorsque la prestation correspond à une formation certifiante ou diplômante.
+
+      - name: is_technical_step
+        description: Indique si la ligne correspond à une étape technique du formulaire.
+
+      - name: is_emploi_relevant
+        description: >
+          Indique si la prestation doit être retenue dans le calcul du taux d'accès à l'emploi par catégorie fine.
+          Les analyses BI sur les taux d'emploi des parcours fins doivent filtrer cette colonne à true.
 
       - name: nb_files_active
         description: >
@@ -135,6 +175,61 @@ models:
 
       - name: direct_distanciel_total
         description: Nombre total de personnes accompagnées en distanciel.
+
+      - name: emploi_nb_repondants
+        description: >
+          Nombre de personnes répondantes au suivi emploi.
+          Ce champ sert de dénominateur aux taux d'emploi. Pour une analyse agrégée, utiliser `sum(emploi_nb_repondants)`.
+
+      - name: emploi_acces_nb
+        description: >
+          Nombre de personnes ayant accédé à l'emploi.
+          Ce champ sert de numérateur au taux d'accès à l'emploi. Pour une analyse agrégée, utiliser `sum(emploi_acces_nb)`.
+
+      - name: emploi_presence_nb
+        description: >
+          Nombre de personnes encore en emploi au moment du suivi.
+          Ce champ sert de numérateur au taux de présence en emploi. Pour une analyse agrégée, utiliser `sum(emploi_presence_nb)`.
+
+      - name: emploi_acces_cdi
+        description: Nombre d'accès à l'emploi en CDI.
+
+      - name: emploi_acces_cdd_plus6
+        description: Nombre d'accès à l'emploi en CDD de plus de 6 mois.
+
+      - name: emploi_acces_cdd_moins6
+        description: Nombre d'accès à l'emploi en CDD de moins de 6 mois.
+
+      - name: emploi_acces_alternance
+        description: Nombre d'accès à l'emploi en alternance.
+
+      - name: emploi_acces_interim
+        description: Nombre d'accès à l'emploi en intérim.
+
+      - name: emploi_acces_autre
+        description: Nombre d'accès à l'emploi dans une autre forme de contrat.
+
+      - name: emploi_durable_nb
+        description: >
+          Nombre d'accès à l'emploi durable, calculé comme CDI plus CDD de plus de 6 mois.
+          Pour une analyse agrégée, utiliser `sum(emploi_durable_nb)`.
+
+      - name: emploi_autre_nb
+        description: >
+          Nombre d'accès à l'emploi hors emploi durable, calculé comme CDD de moins de 6 mois, alternance, intérim et autre.
+          Pour une analyse agrégée, utiliser `sum(emploi_autre_nb)`.
+
+      - name: taux_acces_emploi
+        description: >
+          Taux d'accès à l'emploi de la ligne, calculé comme `emploi_acces_nb / emploi_nb_repondants`.
+          Pour tout résultat agrégé, ne pas moyenner cette colonne: recalculer le taux avec
+          `sum(emploi_acces_nb) / sum(emploi_nb_repondants)`.
+
+      - name: taux_presence_emploi
+        description: >
+          Taux de présence en emploi de la ligne, calculé comme `emploi_presence_nb / emploi_nb_repondants`.
+          Pour tout résultat agrégé, ne pas moyenner cette colonne: recalculer le taux avec
+          `sum(emploi_presence_nb) / sum(emploi_nb_repondants)`.
 
   - name: fagerh__publics_prestations
 

--- a/dbt/models/marts/fagerh/properties.yml
+++ b/dbt/models/marts/fagerh/properties.yml
@@ -25,7 +25,7 @@ models:
       `sum(emploi_presence_nb) / sum(emploi_nb_repondants)`.
       Il ne faut pas moyenner les colonnes `taux_acces_emploi` ou `taux_presence_emploi` ligne par ligne.
 
-      Il ne contient pas le détail des publics, des préconisations ou des métiers.
+      Il ne contient pas le détail des publics ou des métiers.
 
     tests:
       - dbt_utils.expression_is_true:
@@ -208,6 +208,81 @@ models:
 
       - name: emploi_acces_autre
         description: Nombre d'accès à l'emploi dans une autre forme de contrat.
+
+      - name: preco_emploi_milieu_ordinaire
+        description: >
+          Nombre de préconisations vers l'emploi en milieu ordinaire déclarées à l'issue de la prestation.
+          Pour une analyse agrégée, utiliser `sum(preco_emploi_milieu_ordinaire)`.
+
+      - name: preco_entreprise_adaptee
+        description: >
+          Nombre de préconisations vers l'entreprise adaptée déclarées à l'issue de la prestation.
+          Pour une analyse agrégée, utiliser `sum(preco_entreprise_adaptee)`.
+
+      - name: preco_esat
+        description: >
+          Nombre de préconisations vers un ESAT déclarées à l'issue de la prestation.
+          Pour une analyse agrégée, utiliser `sum(preco_esat)`.
+
+      - name: preco_creation_entreprise
+        description: >
+          Nombre de préconisations vers la création d'entreprise déclarées à l'issue de la prestation.
+          Pour une analyse agrégée, utiliser `sum(preco_creation_entreprise)`.
+
+      - name: preco_maintien_emploi
+        description: >
+          Nombre de préconisations vers le maintien en emploi déclarées à l'issue de la prestation.
+          Pour une analyse agrégée, utiliser `sum(preco_maintien_emploi)`.
+
+      - name: preco_formation_droit_commun
+        description: >
+          Nombre de préconisations vers une formation de droit commun déclarées à l'issue de la prestation.
+          Pour une analyse agrégée, utiliser `sum(preco_formation_droit_commun)`.
+
+      - name: preco_formation_alternance
+        description: >
+          Nombre de préconisations vers une formation en alternance déclarées à l'issue de la prestation.
+          Pour une analyse agrégée, utiliser `sum(preco_formation_alternance)`.
+
+      - name: preco_formation_esrp_dfa
+        description: >
+          Nombre de préconisations vers une formation ESRP ou DFA déclarées à l'issue de la prestation.
+          Pour une analyse agrégée, utiliser `sum(preco_formation_esrp_dfa)`.
+
+      - name: preco_espo_specialisee_ueros
+        description: >
+          Nombre de préconisations vers une ESPO spécialisée ou une UEROS déclarées à l'issue de la prestation.
+          Pour une analyse agrégée, utiliser `sum(preco_espo_specialisee_ueros)`.
+
+      - name: preco_service_accompagnement_social
+        description: >
+          Nombre de préconisations vers un service d'accompagnement social déclarées à l'issue de la prestation.
+          Pour une analyse agrégée, utiliser `sum(preco_service_accompagnement_social)`.
+
+      - name: preco_vie_sociale
+        description: >
+          Nombre de préconisations liées à la vie sociale déclarées à l'issue de la prestation.
+          Pour une analyse agrégée, utiliser `sum(preco_vie_sociale)`.
+
+      - name: preco_soins
+        description: >
+          Nombre de préconisations vers les soins déclarées à l'issue de la prestation.
+          Pour une analyse agrégée, utiliser `sum(preco_soins)`.
+
+      - name: preco_emploi_accompagne
+        description: >
+          Nombre de préconisations vers l'emploi accompagné déclarées à l'issue de la prestation.
+          Pour une analyse agrégée, utiliser `sum(preco_emploi_accompagne)`.
+
+      - name: preco_autres
+        description: >
+          Nombre d'autres préconisations déclarées à l'issue de la prestation.
+          Pour une analyse agrégée, utiliser `sum(preco_autres)`.
+
+      - name: preco_autres_precision
+        description: >
+          Précision textuelle associée aux autres préconisations déclarées à l'issue de la prestation.
+          Ce champ descriptif ne doit pas être agrégé comme une métrique.
 
       - name: emploi_durable_nb
         description: >


### PR DESCRIPTION
**Carte Notion : ** (non nécessaire si `label=hotfix`)
https://app.notion.com/p/gip-inclusion/FAGERH-Int-grer-les-retours-utilisateurs-3aa5f321b60480dea35bcb9c8e805d0c?source=copy_link

### Pourquoi ?

On m’a demandé d’ajouter au dashboard les taux d’accès à l’emploi et de présence en emploi pour les formations certifiantes ou professionnalisantes, accompagnées ou non.

Pour faire ça, j’ai eu besoin de récupérer le détail des prestations depuis `prestations_details_json`, notamment pour identifier le type de formation et le nom de la formation.

 J’ai préféré enrichir `fagerh__activite_prestations` plutôt que créer un nouveau mart, pour garder une seule table de référence côté activité FAGERH et éviter d’avoir deux endroits différents pour calculer ces indicateurs.

### Checks

- [x] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

