### PR TITLE
add information about participations, organismes and partenaires to fagerh modeling

### DIFF
--- a/dbt/models/intermediate/fagerh/int_fagerh__prestations.sql
+++ b/dbt/models/intermediate/fagerh/int_fagerh__prestations.sql
@@ -96,10 +96,98 @@ final as (
         nullif(prestation_json ->> 'sortiesAvantTerme', '')::integer                                                  as sorties_avant_terme,
         nullif(prestation_json ->> 'sortiesTerme', '')::integer                                                       as sorties_terme,
         nullif(prestation_json ->> 'sorties', '')::integer                                                            as sorties,
-        nullif(prestation_json ->> 'journees', '')::numeric                                                           as journees,
+        case
+            when
+                nullif(prestation_json ->> 'journees', '') is null
+                and (
+                    prestations_enriched.prestation_key_base != 'directes-hors-orp-cdaph-informations-aux-personnes'
+                    or nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_collectives,journees}', '') is null
+                )
+                and (
+                    prestations_enriched.prestation_key_base != 'indirectes-informations-partenaires'
+                    or nullif(prestation_json #>> '{indirect,rows,part_collectives,journees}', '') is null
+                )
+                and (
+                    prestations_enriched.prestation_key_base != 'indirectes-informations-organisme-de-formation'
+                    or nullif(prestation_json #>> '{indirect,rows,of_collectives,journees}', '') is null
+                )
+                then null
+            else
+                coalesce(nullif(prestation_json ->> 'journees', '')::numeric, 0)
+                + case
+                    when prestations_enriched.prestation_key_base = 'directes-hors-orp-cdaph-informations-aux-personnes'
+                        then coalesce(nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_collectives,journees}', '')::numeric, 0)
+                    else 0
+                end
+                + case
+                    when prestations_enriched.prestation_key_base = 'indirectes-informations-partenaires'
+                        then coalesce(nullif(prestation_json #>> '{indirect,rows,part_collectives,journees}', '')::numeric, 0)
+                    else 0
+                end
+                + case
+                    when prestations_enriched.prestation_key_base = 'indirectes-informations-organisme-de-formation'
+                        then coalesce(nullif(prestation_json #>> '{indirect,rows,of_collectives,journees}', '')::numeric, 0)
+                    else 0
+                end
+        end                                                                                                           as journees,
         nullif(prestation_json ->> 'journeesTheoriques', '')::numeric                                                 as journees_theoriques,
         nullif(prestation_json #>> '{directAvecOrp,row,beneficiaires}', '')::integer                                  as direct_avec_orp_beneficiaires,
         nullif(prestation_json #>> '{directSansOrp,rows,pec,beneficiaires}', '')::integer                             as direct_sans_orp_beneficiaires,
+        nullif(prestation_json #>> '{directSansOrp,rows,pec,beneficiaires}', '')::integer                             as direct_pec_beneficiaires,
+        case
+            when prestations_enriched.prestation_key_base = 'directes-hors-orp-cdaph-informations-aux-personnes'
+                then nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_collectives,journees}', '')::numeric
+        end                                                                                                           as info_personnes_collectives_journees,
+        case
+            when prestations_enriched.prestation_key_base = 'directes-hors-orp-cdaph-informations-aux-personnes'
+                then nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_collectives,boeth}', '')::integer
+        end                                                                                                           as info_personnes_collectives_boeth,
+        case
+            when prestations_enriched.prestation_key_base = 'directes-hors-orp-cdaph-informations-aux-personnes'
+                then nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_collectives,non_boeth}', '')::integer
+        end                                                                                                           as info_personnes_collectives_non_boeth,
+        case
+            when prestations_enriched.prestation_key_base = 'directes-hors-orp-cdaph-informations-aux-personnes'
+                then nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_collectives,sans_statut}', '')::integer
+        end                                                                                                           as info_personnes_collectives_sans_statut,
+        case
+            when prestations_enriched.prestation_key_base != 'directes-hors-orp-cdaph-informations-aux-personnes'
+                then null
+            when
+                nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_collectives,boeth}', '') is null
+                and nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_collectives,non_boeth}', '') is null
+                and nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_collectives,sans_statut}', '') is null
+                then null
+            else
+                coalesce(nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_collectives,boeth}', '')::integer, 0)
+                + coalesce(nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_collectives,non_boeth}', '')::integer, 0)
+                + coalesce(nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_collectives,sans_statut}', '')::integer, 0)
+        end                                                                                                           as info_personnes_collectives_personnes,
+        case
+            when prestations_enriched.prestation_key_base = 'directes-hors-orp-cdaph-informations-aux-personnes'
+                then nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_individuelles,boeth}', '')::integer
+        end                                                                                                           as info_personnes_individuelles_boeth,
+        case
+            when prestations_enriched.prestation_key_base = 'directes-hors-orp-cdaph-informations-aux-personnes'
+                then nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_individuelles,non_boeth}', '')::integer
+        end                                                                                                           as info_personnes_individuelles_non_boeth,
+        case
+            when prestations_enriched.prestation_key_base = 'directes-hors-orp-cdaph-informations-aux-personnes'
+                then nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_individuelles,sans_statut}', '')::integer
+        end                                                                                                           as info_personnes_individuelles_sans_statut,
+        case
+            when prestations_enriched.prestation_key_base != 'directes-hors-orp-cdaph-informations-aux-personnes'
+                then null
+            when
+                nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_individuelles,boeth}', '') is null
+                and nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_individuelles,non_boeth}', '') is null
+                and nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_individuelles,sans_statut}', '') is null
+                then null
+            else
+                coalesce(nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_individuelles,boeth}', '')::integer, 0)
+                + coalesce(nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_individuelles,non_boeth}', '')::integer, 0)
+                + coalesce(nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_individuelles,sans_statut}', '')::integer, 0)
+        end                                                                                                           as info_personnes_individuelles_personnes,
         nullif(prestation_json #>> '{directAvecOrp,row,discontinue_personnes}', '')::integer                          as direct_discontinue_personnes,
 
         nullif(prestation_json #>> '{directAvecOrp,row,presentiel_total}', '')::integer                               as direct_presentiel_total,
@@ -120,6 +208,32 @@ final as (
 
         nullif(prestation_json #>> '{directAvecOrp,row,hebergees_nuitees}', '')::integer                              as direct_hebergees_nuitees,
         nullif(prestation_json #>> '{sortiesBloc,nb}', '')::integer                                                   as sorties_nb,
+
+        case
+            when prestations_enriched.prestation_key_base = 'indirectes-informations-partenaires'
+                then nullif(prestation_json #>> '{indirect,rows,part_collectives,journees}', '')::numeric
+        end                                                                                                           as information_partenaires_collective_journees,
+        case
+            when prestations_enriched.prestation_key_base = 'indirectes-informations-partenaires'
+                then nullif(prestation_json #>> '{indirect,rows,part_collectives,partenaires_total}', '')::integer
+        end                                                                                                           as information_partenaires_collective_nb_partenaires,
+        case
+            when prestations_enriched.prestation_key_base = 'indirectes-informations-partenaires'
+                then nullif(prestation_json #>> '{indirect,rows,part_individuelles,partenaires}', '')::integer
+        end                                                                                                           as information_partenaires_individuelle_nb_partenaires,
+
+        case
+            when prestations_enriched.prestation_key_base = 'indirectes-informations-organisme-de-formation'
+                then nullif(prestation_json #>> '{indirect,rows,of_collectives,journees}', '')::numeric
+        end                                                                                                           as information_organismes_formation_collective_journees,
+        case
+            when prestations_enriched.prestation_key_base = 'indirectes-informations-organisme-de-formation'
+                then nullif(prestation_json #>> '{indirect,rows,of_collectives,partenaires_total}', '')::integer
+        end                                                                                                           as information_organismes_formation_collective_nb_organismes,
+        case
+            when prestations_enriched.prestation_key_base = 'indirectes-informations-organisme-de-formation'
+                then nullif(prestation_json #>> '{indirect,rows,of_individuelles,partenaires}', '')::integer
+        end                                                                                                           as information_organismes_formation_individuelle_nb_organismes,
 
         case
             when prestations_enriched.prestation_key_base = 'indirectes-participations-mdph'
@@ -236,10 +350,32 @@ final as (
             when
                 nullif(prestation_json #>> '{directAvecOrp,row,beneficiaires}', '') is null
                 and nullif(prestation_json #>> '{directSansOrp,rows,pec,beneficiaires}', '') is null
+                and (
+                    prestations_enriched.prestation_key_base != 'directes-hors-orp-cdaph-informations-aux-personnes'
+                    or (
+                        nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_collectives,boeth}', '') is null
+                        and nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_collectives,non_boeth}', '') is null
+                        and nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_collectives,sans_statut}', '') is null
+                        and nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_individuelles,boeth}', '') is null
+                        and nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_individuelles,non_boeth}', '') is null
+                        and nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_individuelles,sans_statut}', '') is null
+                    )
+                )
                 then null
             else
                 coalesce(nullif(prestation_json #>> '{directAvecOrp,row,beneficiaires}', '')::integer, 0)
                 + coalesce(nullif(prestation_json #>> '{directSansOrp,rows,pec,beneficiaires}', '')::integer, 0)
+                + case
+                    when prestations_enriched.prestation_key_base = 'directes-hors-orp-cdaph-informations-aux-personnes'
+                        then
+                            coalesce(nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_collectives,boeth}', '')::integer, 0)
+                            + coalesce(nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_collectives,non_boeth}', '')::integer, 0)
+                            + coalesce(nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_collectives,sans_statut}', '')::integer, 0)
+                            + coalesce(nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_individuelles,boeth}', '')::integer, 0)
+                            + coalesce(nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_individuelles,non_boeth}', '')::integer, 0)
+                            + coalesce(nullif(prestation_json #>> '{directSansOrp,rows,info_personnes_individuelles,sans_statut}', '')::integer, 0)
+                    else 0
+                end
         end                                                                                                           as direct_beneficiaires,
         prestation_json -> 'visitedBlocks'                                                                            as visited_blocks,
 

--- a/dbt/models/intermediate/fagerh/int_fagerh__prestations.sql
+++ b/dbt/models/intermediate/fagerh/int_fagerh__prestations.sql
@@ -121,6 +121,66 @@ final as (
         nullif(prestation_json #>> '{directAvecOrp,row,hebergees_nuitees}', '')::integer                              as direct_hebergees_nuitees,
         nullif(prestation_json #>> '{sortiesBloc,nb}', '')::integer                                                   as sorties_nb,
 
+        case
+            when prestations_enriched.prestation_key_base = 'indirectes-participations-mdph'
+                then nullif(prestation_json #>> '{indirect,rows,epe,origine}', '')::integer
+        end                                                                                                           as mdph_epe_origine_participations,
+        case
+            when prestations_enriched.prestation_key_base = 'indirectes-participations-mdph'
+                then nullif(prestation_json #>> '{indirect,rows,epe,limitrophes}', '')::integer
+        end                                                                                                           as mdph_epe_limitrophes_participations,
+        case
+            when prestations_enriched.prestation_key_base != 'indirectes-participations-mdph'
+                then null
+            when
+                nullif(prestation_json #>> '{indirect,rows,epe,origine}', '') is null
+                and nullif(prestation_json #>> '{indirect,rows,epe,limitrophes}', '') is null
+                then null
+            else
+                coalesce(nullif(prestation_json #>> '{indirect,rows,epe,origine}', '')::integer, 0)
+                + coalesce(nullif(prestation_json #>> '{indirect,rows,epe,limitrophes}', '')::integer, 0)
+        end                                                                                                           as mdph_epe_participations,
+
+        case
+            when prestations_enriched.prestation_key_base = 'indirectes-participations-mdph'
+                then nullif(prestation_json #>> '{indirect,rows,cdaph,origine}', '')::integer
+        end                                                                                                           as mdph_cdaph_origine_participations,
+        case
+            when prestations_enriched.prestation_key_base = 'indirectes-participations-mdph'
+                then nullif(prestation_json #>> '{indirect,rows,cdaph,limitrophes}', '')::integer
+        end                                                                                                           as mdph_cdaph_limitrophes_participations,
+        case
+            when prestations_enriched.prestation_key_base != 'indirectes-participations-mdph'
+                then null
+            when
+                nullif(prestation_json #>> '{indirect,rows,cdaph,origine}', '') is null
+                and nullif(prestation_json #>> '{indirect,rows,cdaph,limitrophes}', '') is null
+                then null
+            else
+                coalesce(nullif(prestation_json #>> '{indirect,rows,cdaph,origine}', '')::integer, 0)
+                + coalesce(nullif(prestation_json #>> '{indirect,rows,cdaph,limitrophes}', '')::integer, 0)
+        end                                                                                                           as mdph_cdaph_participations,
+
+        case
+            when prestations_enriched.prestation_key_base = 'indirectes-participations-mdph'
+                then nullif(prestation_json #>> '{indirect,rows,groupes_travail,origine}', '')::integer
+        end                                                                                                           as mdph_groupes_travail_origine_participations,
+        case
+            when prestations_enriched.prestation_key_base = 'indirectes-participations-mdph'
+                then nullif(prestation_json #>> '{indirect,rows,groupes_travail,limitrophes}', '')::integer
+        end                                                                                                           as mdph_groupes_travail_limitrophes_participations,
+        case
+            when prestations_enriched.prestation_key_base != 'indirectes-participations-mdph'
+                then null
+            when
+                nullif(prestation_json #>> '{indirect,rows,groupes_travail,origine}', '') is null
+                and nullif(prestation_json #>> '{indirect,rows,groupes_travail,limitrophes}', '') is null
+                then null
+            else
+                coalesce(nullif(prestation_json #>> '{indirect,rows,groupes_travail,origine}', '')::integer, 0)
+                + coalesce(nullif(prestation_json #>> '{indirect,rows,groupes_travail,limitrophes}', '')::integer, 0)
+        end                                                                                                           as mdph_groupes_travail_participations,
+
         nullif(prestation_json #>> '{sortiesBloc,raisons,depart_volontaire}', '')::integer                            as sorties_depart_volontaire,
         nullif(prestation_json #>> '{sortiesBloc,raisons,sante}', '')::integer                                        as sorties_sante,
         nullif(prestation_json #>> '{sortiesBloc,raisons,reorientation}', '')::integer                                as sorties_reorientation,

--- a/dbt/models/intermediate/fagerh/properties.yml
+++ b/dbt/models/intermediate/fagerh/properties.yml
@@ -5,6 +5,37 @@ models:
     config:
       tags: ["fagerh"]
     description: Une ligne par réponse et par prestation renseignée dans le JSON des prestations. Le modèle extrait les principaux indicateurs d'activité et ajoute une classification métier de la prestation à partir de la seed `seed_fagerh__prestation_mapping`.
+    tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: >
+              mdph_epe_participations is not distinct from
+              case
+                when mdph_epe_origine_participations is null and mdph_epe_limitrophes_participations is null then null
+                else coalesce(mdph_epe_origine_participations, 0) + coalesce(mdph_epe_limitrophes_participations, 0)
+              end
+          config:
+            severity: warn
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: >
+              mdph_cdaph_participations is not distinct from
+              case
+                when mdph_cdaph_origine_participations is null and mdph_cdaph_limitrophes_participations is null then null
+                else coalesce(mdph_cdaph_origine_participations, 0) + coalesce(mdph_cdaph_limitrophes_participations, 0)
+              end
+          config:
+            severity: warn
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: >
+              mdph_groupes_travail_participations is not distinct from
+              case
+                when mdph_groupes_travail_origine_participations is null and mdph_groupes_travail_limitrophes_participations is null then null
+                else coalesce(mdph_groupes_travail_origine_participations, 0) + coalesce(mdph_groupes_travail_limitrophes_participations, 0)
+              end
+          config:
+            severity: warn
     columns:
       - name: uuid
         description: Identifiant unique de la réponse du questionnaire.
@@ -78,6 +109,60 @@ models:
         description: >
           Nombre de bénéficiaires déclaré dans le bloc des prestations directes sans ORP CDAPH.
           Ce champ est notamment utilisé pour certaines évaluations préliminaires hors ORP.
+
+      - name: mdph_epe_origine_participations
+        description: >
+          Nombre de participations aux EPE avec la MDPH du territoire de l'établissement.
+          Ce champ vient de `indirect.rows.epe.origine` dans le JSON de la prestation.
+          Il est renseigné seulement pour la prestation `indirectes-participations-mdph`.
+
+      - name: mdph_epe_limitrophes_participations
+        description: >
+          Nombre de participations aux EPE avec des MDPH des territoires voisins.
+          Ce champ vient de `indirect.rows.epe.limitrophes` dans le JSON de la prestation.
+          Il est renseigné seulement pour la prestation `indirectes-participations-mdph`.
+
+      - name: mdph_epe_participations
+        description: >
+          Total des participations aux EPE.
+          Il additionne `mdph_epe_origine_participations` et `mdph_epe_limitrophes_participations`.
+          C'est un compteur de participations, pas un compteur de personnes ni de journées.
+
+      - name: mdph_cdaph_origine_participations
+        description: >
+          Nombre de participations aux CDAPH avec la MDPH du territoire de l'établissement.
+          Ce champ vient de `indirect.rows.cdaph.origine` dans le JSON de la prestation.
+          Il est renseigné seulement pour la prestation `indirectes-participations-mdph`.
+
+      - name: mdph_cdaph_limitrophes_participations
+        description: >
+          Nombre de participations aux CDAPH avec des MDPH des territoires voisins.
+          Ce champ vient de `indirect.rows.cdaph.limitrophes` dans le JSON de la prestation.
+          Il est renseigné seulement pour la prestation `indirectes-participations-mdph`.
+
+      - name: mdph_cdaph_participations
+        description: >
+          Total des participations aux CDAPH.
+          Il additionne `mdph_cdaph_origine_participations` et `mdph_cdaph_limitrophes_participations`.
+          C'est un compteur de participations, pas un compteur de personnes ni de journées.
+
+      - name: mdph_groupes_travail_origine_participations
+        description: >
+          Nombre de participations aux groupes de travail de la MDPH du territoire de l'établissement.
+          Ce champ vient de `indirect.rows.groupes_travail.origine` dans le JSON de la prestation.
+          Il est renseigné seulement pour la prestation `indirectes-participations-mdph`.
+
+      - name: mdph_groupes_travail_limitrophes_participations
+        description: >
+          Nombre de participations aux groupes de travail avec des MDPH des territoires voisins.
+          Ce champ vient de `indirect.rows.groupes_travail.limitrophes` dans le JSON de la prestation.
+          Il est renseigné seulement pour la prestation `indirectes-participations-mdph`.
+
+      - name: mdph_groupes_travail_participations
+        description: >
+          Total des participations aux groupes de travail de la MDPH.
+          Il additionne `mdph_groupes_travail_origine_participations` et `mdph_groupes_travail_limitrophes_participations`.
+          C'est un compteur de participations, pas un compteur de personnes ni de journées.
 
   - name: int_fagerh__prestations_details_names
 

--- a/dbt/models/intermediate/fagerh/properties.yml
+++ b/dbt/models/intermediate/fagerh/properties.yml
@@ -36,6 +36,48 @@ models:
               end
           config:
             severity: warn
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: >
+              info_personnes_collectives_personnes is not distinct from
+              case
+                when info_personnes_collectives_boeth is null and info_personnes_collectives_non_boeth is null and info_personnes_collectives_sans_statut is null then null
+                else coalesce(info_personnes_collectives_boeth, 0) + coalesce(info_personnes_collectives_non_boeth, 0) + coalesce(info_personnes_collectives_sans_statut, 0)
+              end
+          config:
+            severity: warn
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: >
+              info_personnes_individuelles_personnes is not distinct from
+              case
+                when info_personnes_individuelles_boeth is null and info_personnes_individuelles_non_boeth is null and info_personnes_individuelles_sans_statut is null then null
+                else coalesce(info_personnes_individuelles_boeth, 0) + coalesce(info_personnes_individuelles_non_boeth, 0) + coalesce(info_personnes_individuelles_sans_statut, 0)
+              end
+          config:
+            severity: warn
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: >
+              (
+                information_partenaires_collective_journees is null
+                and information_partenaires_collective_nb_partenaires is null
+                and information_partenaires_individuelle_nb_partenaires is null
+              )
+              or prestation_key_base = 'indirectes-informations-partenaires'
+          config:
+            severity: warn
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: >
+              (
+                information_organismes_formation_collective_journees is null
+                and information_organismes_formation_collective_nb_organismes is null
+                and information_organismes_formation_individuelle_nb_organismes is null
+              )
+              or prestation_key_base = 'indirectes-informations-organisme-de-formation'
+          config:
+            severity: warn
     columns:
       - name: uuid
         description: Identifiant unique de la réponse du questionnaire.
@@ -99,7 +141,8 @@ models:
       - name: direct_beneficiaires
         description: >
           Nombre total de bénéficiaires déclarés dans les blocs des prestations directes.
-          Il additionne les bénéficiaires avec ORP CDAPH et sans ORP CDAPH.
+          Il additionne les bénéficiaires avec ORP CDAPH, les bénéficiaires PEC sans ORP CDAPH,
+          et les personnes reçues en information collective ou individuelle quand elles sont dans le JSON.
 
       - name: direct_avec_orp_beneficiaires
         description: >
@@ -109,6 +152,80 @@ models:
         description: >
           Nombre de bénéficiaires déclaré dans le bloc des prestations directes sans ORP CDAPH.
           Ce champ est notamment utilisé pour certaines évaluations préliminaires hors ORP.
+
+      - name: direct_pec_beneficiaires
+        description: >
+          Nombre de bénéficiaires du bloc PEC sans ORP CDAPH.
+          Ce champ sert de détail technique pour les évaluations préliminaires.
+
+      - name: info_personnes_collectives_journees
+        description: >
+          Nombre de journées passées en informations collectives à destination des personnes.
+          Ce champ vient de `directSansOrp.rows.info_personnes_collectives.journees`.
+
+      - name: info_personnes_collectives_boeth
+        description: >
+          Nombre de personnes BOETH reçues en informations collectives à destination des personnes.
+
+      - name: info_personnes_collectives_non_boeth
+        description: >
+          Nombre de personnes non BOETH reçues en informations collectives à destination des personnes.
+
+      - name: info_personnes_collectives_sans_statut
+        description: >
+          Nombre de personnes sans statut déclaré reçues en informations collectives à destination des personnes.
+
+      - name: info_personnes_collectives_personnes
+        description: >
+          Total des personnes reçues en informations collectives à destination des personnes.
+          Il additionne BOETH, non BOETH et sans statut.
+
+      - name: info_personnes_individuelles_boeth
+        description: >
+          Nombre de personnes BOETH reçues en rencontres individuelles d'information.
+
+      - name: info_personnes_individuelles_non_boeth
+        description: >
+          Nombre de personnes non BOETH reçues en rencontres individuelles d'information.
+
+      - name: info_personnes_individuelles_sans_statut
+        description: >
+          Nombre de personnes sans statut déclaré reçues en rencontres individuelles d'information.
+
+      - name: info_personnes_individuelles_personnes
+        description: >
+          Total des personnes reçues en rencontres individuelles d'information.
+          Il additionne BOETH, non BOETH et sans statut.
+
+      - name: information_partenaires_collective_journees
+        description: >
+          Nombre de journées passées en information collective à destination des partenaires.
+          Ce champ est renseigné seulement pour la prestation `indirectes-informations-partenaires`.
+
+      - name: information_partenaires_collective_nb_partenaires
+        description: >
+          Nombre de partenaires concernés par l'information collective à destination des partenaires.
+          Ce champ est renseigné seulement pour la prestation `indirectes-informations-partenaires`.
+
+      - name: information_partenaires_individuelle_nb_partenaires
+        description: >
+          Nombre de partenaires concernés par l'information individuelle à destination des partenaires.
+          Ce champ est renseigné seulement pour la prestation `indirectes-informations-partenaires`.
+
+      - name: information_organismes_formation_collective_journees
+        description: >
+          Nombre de journées passées en information collective à destination des organismes de formation.
+          Ce champ est renseigné seulement pour la prestation `indirectes-informations-organisme-de-formation`.
+
+      - name: information_organismes_formation_collective_nb_organismes
+        description: >
+          Nombre d'organismes de formation concernés par l'information collective.
+          Ce champ est renseigné seulement pour la prestation `indirectes-informations-organisme-de-formation`.
+
+      - name: information_organismes_formation_individuelle_nb_organismes
+        description: >
+          Nombre d'organismes de formation concernés par l'information individuelle.
+          Ce champ est renseigné seulement pour la prestation `indirectes-informations-organisme-de-formation`.
 
       - name: mdph_epe_origine_participations
         description: >

--- a/dbt/models/marts/fagerh/fagerh__activite_prestations.sql
+++ b/dbt/models/marts/fagerh/fagerh__activite_prestations.sql
@@ -52,6 +52,16 @@ final as (
         prestations.direct_hebergees_personnes,
         prestations.direct_hebergees_nuitees,
 
+        prestations.mdph_epe_origine_participations,
+        prestations.mdph_epe_limitrophes_participations,
+        prestations.mdph_epe_participations,
+        prestations.mdph_cdaph_origine_participations,
+        prestations.mdph_cdaph_limitrophes_participations,
+        prestations.mdph_cdaph_participations,
+        prestations.mdph_groupes_travail_origine_participations,
+        prestations.mdph_groupes_travail_limitrophes_participations,
+        prestations.mdph_groupes_travail_participations,
+
         prestations.suspensions_nb,
 
         prestations.direct_presentiel_total,

--- a/dbt/models/marts/fagerh/fagerh__activite_prestations.sql
+++ b/dbt/models/marts/fagerh/fagerh__activite_prestations.sql
@@ -46,11 +46,22 @@ final as (
         prestations.direct_beneficiaires,
         prestations.direct_avec_orp_beneficiaires,
         prestations.direct_sans_orp_beneficiaires,
+        prestations.direct_pec_beneficiaires,
+        prestations.info_personnes_collectives_journees,
+        prestations.info_personnes_collectives_personnes,
+        prestations.info_personnes_individuelles_personnes,
         prestations.direct_hors_murs_personnes,
         prestations.direct_hors_murs_journees,
 
         prestations.direct_hebergees_personnes,
         prestations.direct_hebergees_nuitees,
+
+        prestations.information_partenaires_collective_journees,
+        prestations.information_partenaires_collective_nb_partenaires,
+        prestations.information_partenaires_individuelle_nb_partenaires,
+        prestations.information_organismes_formation_collective_journees,
+        prestations.information_organismes_formation_collective_nb_organismes,
+        prestations.information_organismes_formation_individuelle_nb_organismes,
 
         prestations.mdph_epe_origine_participations,
         prestations.mdph_epe_limitrophes_participations,

--- a/dbt/models/marts/fagerh/properties.yml
+++ b/dbt/models/marts/fagerh/properties.yml
@@ -33,6 +33,22 @@ models:
       Pour les indicateurs MDPH demandés, ne pas utiliser `journees` : les nombres sont stockés dans les colonnes dédiées
       `mdph_epe_participations`, `mdph_cdaph_participations` et `mdph_groupes_travail_participations`.
 
+      Pour les évaluations préliminaires, on veut garder le libellé commun `Évaluations préliminaires` dans les graphiques.
+      Il faut quand même lire les indicateurs avec leurs unités:
+      * `direct_beneficiaires` compte les personnes reçues ou concernées.
+      * `journees` compte seulement les journées réellement déclarées, par exemple les informations collectives.
+      * `sorties` ne doit pas être inventé: si la colonne est vide ou à 0, il n'y a pas de sorties à afficher.
+      Les colonnes `direct_pec_beneficiaires`, `info_personnes_collectives_*` et `info_personnes_individuelles_*`
+      servent à expliquer le détail du total.
+
+      Pour l'information collective à destination des partenaires, utiliser
+      `information_partenaires_collective_nb_partenaires` pour le nombre de partenaires concernés et
+      `information_partenaires_collective_journees` pour le nombre de journées.
+      Pour l'information collective à destination des organismes de formation, utiliser
+      `information_organismes_formation_collective_nb_organismes` et
+      `information_organismes_formation_collective_journees`.
+      Ces colonnes ne sont pas des personnes reçues.
+
       Il ne contient pas le détail des publics ou des métiers.
 
     tests:
@@ -141,7 +157,11 @@ models:
         description: Nombre de sorties définitives au terme de la prestation.
 
       - name: journees
-        description: Nombre de journées réalisées.
+        description: >
+          Nombre de journées réalisées.
+          Pour les évaluations préliminaires et certaines prestations indirectes, cette colonne inclut aussi les journées
+          collectives déclarées dans les sous-blocs du formulaire.
+          Elle ne transforme jamais des heures en journées.
 
       - name: journees_theoriques
         description: Nombre de journées théoriques.
@@ -149,7 +169,9 @@ models:
       - name: direct_beneficiaires
         description: >
           Nombre total de bénéficiaires déclarés dans les blocs des prestations directes.
-          Il additionne les bénéficiaires avec ORP CDAPH et sans ORP CDAPH.
+          Pour les évaluations préliminaires, cette colonne peut aussi inclure les personnes reçues en information collective
+          ou en rencontre individuelle d'information.
+          Elle ne doit pas être mélangée avec `nb_files_active`.
 
       - name: direct_avec_orp_beneficiaires
         description: >
@@ -159,6 +181,26 @@ models:
         description: >
           Nombre de bénéficiaires déclaré dans le bloc des prestations directes sans ORP CDAPH.
           Ce champ est notamment utilisé pour certaines évaluations préliminaires hors ORP.
+
+      - name: direct_pec_beneficiaires
+        description: >
+          Nombre de bénéficiaires du bloc PEC sans ORP CDAPH.
+          Dans le dashboard, ce champ sert surtout à expliquer une partie de `direct_beneficiaires` pour les évaluations préliminaires.
+
+      - name: info_personnes_collectives_journees
+        description: >
+          Nombre de journées passées en informations collectives à destination des personnes.
+          Cette valeur entre aussi dans `journees`.
+
+      - name: info_personnes_collectives_personnes
+        description: >
+          Nombre de personnes reçues en informations collectives à destination des personnes.
+          Cette valeur entre aussi dans `direct_beneficiaires`.
+
+      - name: info_personnes_individuelles_personnes
+        description: >
+          Nombre de personnes reçues en rencontres individuelles d'information.
+          Cette valeur entre aussi dans `direct_beneficiaires`.
 
       - name: direct_hors_murs_personnes
         description: Nombre de personnes accompagnées hors les murs.
@@ -171,6 +213,38 @@ models:
 
       - name: direct_hebergees_nuitees
         description: Nombre total de nuitées déclarées pour les personnes hébergées.
+
+      - name: information_partenaires_collective_journees
+        description: >
+          Nombre de journées passées en information collective à destination des partenaires.
+          Pour répondre à la demande métier, sommer cette colonne sur les lignes `Informations partenaires`.
+
+      - name: information_partenaires_collective_nb_partenaires
+        description: >
+          Nombre de partenaires concernés par l'information collective à destination des partenaires.
+          C'est le compteur à utiliser pour "nombre de partenaires concernés".
+          Ce n'est pas un nombre de personnes reçues.
+
+      - name: information_partenaires_individuelle_nb_partenaires
+        description: >
+          Nombre de partenaires concernés par l'information individuelle à destination des partenaires.
+          Ce compteur est séparé des informations collectives.
+
+      - name: information_organismes_formation_collective_journees
+        description: >
+          Nombre de journées passées en information collective à destination des organismes de formation.
+          Pour répondre à la demande métier, sommer cette colonne sur les lignes `Informations organismes formation`.
+
+      - name: information_organismes_formation_collective_nb_organismes
+        description: >
+          Nombre d'organismes de formation concernés par l'information collective.
+          C'est le compteur à utiliser pour "nombre d'organismes de formation concernés".
+          Ce n'est pas un nombre de personnes reçues.
+
+      - name: information_organismes_formation_individuelle_nb_organismes
+        description: >
+          Nombre d'organismes de formation concernés par l'information individuelle.
+          Ce compteur est séparé des informations collectives.
 
       - name: mdph_epe_origine_participations
         description: >

--- a/dbt/models/marts/fagerh/properties.yml
+++ b/dbt/models/marts/fagerh/properties.yml
@@ -25,6 +25,14 @@ models:
       `sum(emploi_presence_nb) / sum(emploi_nb_repondants)`.
       Il ne faut pas moyenner les colonnes `taux_acces_emploi` ou `taux_presence_emploi` ligne par ligne.
 
+      Pour analyser les participations MDPH en BI, filtrer si besoin `prestation_label = 'Participations MDPH'`, puis sommer
+      les colonnes `mdph_*_participations`.
+
+      Attention : ces colonnes comptent des participations, pas des personnes et pas des journées. Il ne faut pas les additionner
+      avec `nb_files_active`, `direct_beneficiaires`, `journees` ou les autres indicateurs d'activité des prestations directes.
+      Pour les indicateurs MDPH demandés, ne pas utiliser `journees` : les nombres sont stockés dans les colonnes dédiées
+      `mdph_epe_participations`, `mdph_cdaph_participations` et `mdph_groupes_travail_participations`.
+
       Il ne contient pas le détail des publics ou des métiers.
 
     tests:
@@ -163,6 +171,63 @@ models:
 
       - name: direct_hebergees_nuitees
         description: Nombre total de nuitées déclarées pour les personnes hébergées.
+
+      - name: mdph_epe_origine_participations
+        description: >
+          Nombre de participations aux EPE avec la MDPH du territoire de l'établissement.
+          Cette colonne est renseignée seulement sur les lignes `Participations MDPH`.
+          Elle ne compte pas des personnes reçues et elle ne doit pas être mélangée avec `journees` ou `nb_files_active`.
+
+      - name: mdph_epe_limitrophes_participations
+        description: >
+          Nombre de participations aux EPE avec des MDPH des territoires voisins.
+          Cette colonne est renseignée seulement sur les lignes `Participations MDPH`.
+          Elle ne compte pas des personnes reçues et elle ne doit pas être mélangée avec `journees` ou `nb_files_active`.
+
+      - name: mdph_epe_participations
+        description: >
+          Nombre de participations aux EPE de la MDPH.
+          Cette colonne est renseignée seulement sur les lignes `Participations MDPH`.
+          Elle additionne les participations avec la MDPH du territoire et les MDPH des territoires voisins.
+          C'est un compteur de participations, pas un compteur de personnes ni de journées.
+
+      - name: mdph_cdaph_origine_participations
+        description: >
+          Nombre de participations aux CDAPH avec la MDPH du territoire de l'établissement.
+          Cette colonne est renseignée seulement sur les lignes `Participations MDPH`.
+          Elle ne compte pas des personnes reçues et elle ne doit pas être mélangée avec `journees` ou `nb_files_active`.
+
+      - name: mdph_cdaph_limitrophes_participations
+        description: >
+          Nombre de participations aux CDAPH avec des MDPH des territoires voisins.
+          Cette colonne est renseignée seulement sur les lignes `Participations MDPH`.
+          Elle ne compte pas des personnes reçues et elle ne doit pas être mélangée avec `journees` ou `nb_files_active`.
+
+      - name: mdph_cdaph_participations
+        description: >
+          Nombre de participations aux CDAPH.
+          Cette colonne est renseignée seulement sur les lignes `Participations MDPH`.
+          Elle additionne les participations avec la MDPH du territoire et les MDPH des territoires voisins.
+          C'est un compteur de participations, pas un compteur de personnes ni de journées.
+
+      - name: mdph_groupes_travail_origine_participations
+        description: >
+          Nombre de participations aux groupes de travail de la MDPH du territoire de l'établissement.
+          Cette colonne est renseignée seulement sur les lignes `Participations MDPH`.
+          Elle ne compte pas des personnes reçues et elle ne doit pas être mélangée avec `journees` ou `nb_files_active`.
+
+      - name: mdph_groupes_travail_limitrophes_participations
+        description: >
+          Nombre de participations aux groupes de travail avec des MDPH des territoires voisins.
+          Cette colonne est renseignée seulement sur les lignes `Participations MDPH`.
+          Elle ne compte pas des personnes reçues et elle ne doit pas être mélangée avec `journees` ou `nb_files_active`.
+
+      - name: mdph_groupes_travail_participations
+        description: >
+          Nombre de participations aux groupes de travail de la MDPH.
+          Cette colonne est renseignée seulement sur les lignes `Participations MDPH`.
+          Elle additionne les participations avec la MDPH du territoire et les MDPH des territoires voisins.
+          C'est un compteur de participations, pas un compteur de personnes ni de journées.
 
       - name: suspensions_nb
         description: Nombre de personnes ayant connu une suspension de parcours.


### PR DESCRIPTION
**Carte Notion : ** (non nécessaire si `label=hotfix`)
[2&:9aQ%KANAR4Ys](https://app.notion.com/p/gip-inclusion/FAGERH-Int-grer-les-retours-utilisateurs-3aa5f321b60480dea35bcb9c8e805d0c)

### Pourquoi ?
Je continue à intégrer les retours utilisateurs. Ils sont toujours liés à l’activité, donc toujours dans le même modèle `fagerh__activite_prestations`.


### Checks

- [x] J'ai rajouté la carte notion associée à la PR (hors `hotfix`)
- [x] J'ai lancé le modèle ou seed sur un dump local (si pertinent)
- [x] J'ai ajouté des tests à mon code Python, ou des assertions DBT sur le modèle SQL
- [x] J'ai documenté ce modèle voire certains de ses champs (usage métier, tableau de bord, etc)

